### PR TITLE
newitems - removing unnecessary br that affects allnew page

### DIFF
--- a/www/newitems.php
+++ b/www/newitems.php
@@ -43,7 +43,6 @@ function getNewItems($db, $limit)
          from games
          order by created desc
          $limit", $db);
-    echo mysql_error($db)."<br>";
     $gamecnt = mysql_num_rows($result);
     for ($i = 0 ; $i < $gamecnt ; $i++) {
         $row = mysql_fetch_array($result, MYSQL_ASSOC);


### PR DESCRIPTION
Leftovers from debugging MySQL errors printed `<br>` tag and affected `allnew` page.

Original issue : [The allnew page has unicode issues ](https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/7)

