### PR TITLE
Change domain name

### DIFF
--- a/prepare_dev_environment.sh
+++ b/prepare_dev_environment.sh
@@ -9,7 +9,8 @@ unzip -o $FILENAME
 
 rm -rf initdb
 mkdir initdb
-cat create_db.sql ifdb-archive.sql > initdb/00-init.sql
+cp create_db.sql initdb/00-init.sql
+perl -pe 's!https?://ifdb.tads.org!https://ifdb.org!g' < ifdb-archive.sql >> initdb/00-init.sql
 cp patch-schema.sql initdb/01-patch-schema.sql
 cp create-admin.sql initdb/02-create-admin.sql
 

--- a/prepare_full_dev_environment.sh
+++ b/prepare_full_dev_environment.sh
@@ -5,8 +5,8 @@ IFDB_FULL_EXPORT=$1
 rm -rf initdb
 mkdir initdb
 echo "create database if not exists ifdb; use ifdb;\n" > initdb/init.sql
-# remove bogus definers to fix views
-grep -v 'DEFINER=' $IFDB_FULL_EXPORT/ifdb.sql >> initdb/init.sql
+# remove bogus definers to fix views and rewrite URLs
+grep -v 'DEFINER=' $IFDB_FULL_EXPORT/ifdb.sql | perl -pe 's!https?://ifdb.tads.org!https://ifdb.org!g' >> initdb/init.sql
 echo "create database if not exists ifdb_images0; use ifdb_images0;\n" | cat - $IFDB_FULL_EXPORT/pics1.sql > initdb/pics1.sql
 echo "create database if not exists ifdb_images1; use ifdb_images1;\n" | cat - $IFDB_FULL_EXPORT/pics2.sql > initdb/pics2.sql
 echo "create database if not exists ifdb_images2; use ifdb_images2;\n" | cat - $IFDB_FULL_EXPORT/pics3.sql > initdb/pics3.sql

--- a/www/.htaccess
+++ b/www/.htaccess
@@ -14,9 +14,10 @@ RewriteEngine on
 Options FollowSymLinks
 RewriteBase /
 
-RewriteCond %{SERVER_PORT} 80
-RewriteCond %{SERVER_NAME} ifdb.tads.org
-RewriteRule ^(.*)$ https://ifdb.tads.org/$1 [R,L]
+RewriteCond %{HTTPS} !=on
+RewriteCond %{HTTP_HOST} ^ifdb.org$ [OR]
+RewriteCond %{HTTP_HOST} \.ifdb.org$
+RewriteRule ^(.*)$ https://%{HTTP_HOST}%{REQUEST_URI} [L,R=301,NE]
 
 RewriteRule ^$ home [L]
 RewriteRule ^index$ home [L]

--- a/www/.htaccess
+++ b/www/.htaccess
@@ -1,5 +1,6 @@
 ErrorDocument 403 /error403
 ErrorDocument 404 /error404
+ErrorDocument 503 /error503
 
 <FilesMatch "^[^.]+$">
   ForceType application/x-httpd-php
@@ -13,6 +14,10 @@ ErrorDocument 404 /error404
 RewriteEngine on
 Options FollowSymLinks
 RewriteBase /
+
+#Uncomment to enable maintenance mode
+#RewriteCond %{REQUEST_URI} "!/error503"
+#RewriteRule .* - [R=503,L]
 
 RewriteCond %{HTTPS} !=on
 RewriteCond %{HTTP_HOST} ^ifdb.org$ [OR]

--- a/www/adminops
+++ b/www/adminops
@@ -672,7 +672,7 @@ else if (isset($_REQUEST['users'])) {
     $name = htmlspecialcharx($name);
     $remarks = htmlspecialcharx($remarks);
 
-    $acturl = "http://ifdb.tads.org/userconfirm?a=$actcode";
+    $acturl = get_root_url() . "userconfirm?a=$actcode";
 
     $statMap = array("A" => "Active", "D" => "Pending Activation",
                      "B" => "Banned", "X" => "Closed",

--- a/www/akismet.php
+++ b/www/akismet.php
@@ -4,7 +4,7 @@ include_once "Akismet.class.php";
 
 function akNew()
 {
-    return new Akismet("http://ifdb.tads.org", localAkismetKey());
+    return new Akismet(get_root_url(), localAkismetKey());
 }
 
 function akSpamError($objname)

--- a/www/allnew-rss
+++ b/www/allnew-rss
@@ -28,7 +28,7 @@ echo "<?xml version=\"1.0\"?>\r\n";
 <rss version="2.0">
    <channel>
       <title>New on IFDB</title>
-      <link>http://ifdb.tads.org/</link>
+      <link><?php echo get_root_url(); ?></link>
       <description>The latest reviews and listings on IFDB, the
          Interactive Fiction DataBase.</description>
       <language>en-us</language>

--- a/www/api/putific
+++ b/www/api/putific
@@ -41,7 +41,7 @@ listing with excellent fidelity.
 <h2>Basic protocol</h2>
 
 <p>The putific API is exposed as an HTTP POST request to a particular
-URL on the IFDB Web site.  The URL is <tt>http://ifdb.tads.org/putific</tt>.
+URL on the IFDB Web site.  The URL is <tt>http://ifdb.org/putific</tt>.
 
 <p>All parameters are passed as POST data with the HTTP request.  As
 typical for HTTP, there's no session state or context; the entire

--- a/www/api/putific
+++ b/www/api/putific
@@ -328,7 +328,7 @@ request via the <b>links</b> parameter.  The XML content is formatted
 as follows:
 
 <p><pre>
-   &lt;downloads xmlns="http://ifdb.tads.org/api/xmlns"&gt;
+   &lt;downloads xmlns="http://ifdb.org/api/xmlns"&gt;
       &lt;links&gt;
         link 1
         link 2
@@ -587,7 +587,7 @@ result.  The response has this tag structure for a successful
 transaction:
 
 <p><pre>
-   &lt;putific xmlns="http://ifdb.tads.org/api/xmlns"&gt;
+   &lt;putific xmlns="http://ifdb.org/api/xmlns"&gt;
       &lt;ok/&gt;
       &lt;ACTION-NAME/&gt;
       &lt;tuid&gt;TUID (IFDB's internal ID) of the listing&lt;/tuid&gt;

--- a/www/api/search
+++ b/www/api/search
@@ -76,7 +76,7 @@ soon as they're available in the UI.
 
 <p><pre>
    &lt;?xml version="1.0" encoding="UTF-8" ?&gt; 
-   &lt;searchReply xmlns="http://ifdb.tads.org/api/xmlns"&gt;
+   &lt;searchReply xmlns="http://ifdb.org/api/xmlns"&gt;
       <i>reply-data</i>
    &lt;/searchReply&gt;
 </pre>

--- a/www/api/search
+++ b/www/api/search
@@ -18,7 +18,7 @@ Parameters are encoded into a URL query string, and the URL is sent to
 IFDB as an http GET request.  The server replies with an XML content
 body that contains the search results.
 
-<p>The root of the URL is <tt>http://ifdb.tads.org/search?xml</tt>.
+<p>The root of the URL is <tt>https://ifdb.org/search?xml</tt>.
 
 <p>The search term and object type are added to the root URL as query
 parameters, using standard URL encoding.  That is, each parameter is
@@ -67,7 +67,7 @@ soon as they're available in the UI.
 
 <p>To search for a game listing for <tt>Deep Space Drifter</tt>:
 
-<p><pre>http://ifdb.tads.org/search?xml&amp;game&amp;searchfor=Deep+Space+Drifter
+<p><pre>https://ifdb.org/search?xml&amp;game&amp;searchfor=Deep+Space+Drifter
 </pre>
 
 <h2>Reply</h2>

--- a/www/api/viewgame
+++ b/www/api/viewgame
@@ -206,7 +206,7 @@ ratingCountAvg value.
 <p>The returned iFiction record also includes the colophon element,
 which identifies how the record was generated.  For the purposes of
 the colophon, the API identifies itself with the generator name
-"ifdb.tads.org/viewgame".
+"ifdb.org/viewgame".
 
 <?php
 

--- a/www/api/viewgame
+++ b/www/api/viewgame
@@ -53,13 +53,13 @@ iFiction elements, plus some custom IFDB-specific extensions.
 <p>To retrieve data by TUID, use this URL:
 
 <p><pre>
-  http://ifdb.tads.org/viewgame?ifiction&amp;id=<i>TUID</i>
+  https://ifdb.org/viewgame?ifiction&amp;id=<i>TUID</i>
 </pre>
 
 <p>To retrieve data by IFID, use this URL:
 
 <p><pre>
-  http://ifdb.tads.org/viewgame?ifiction&amp;ifid=<i>IFID</i>
+  https://ifdb.org/viewgame?ifiction&amp;ifid=<i>IFID</i>
 </pre>
 
 

--- a/www/api/viewgame
+++ b/www/api/viewgame
@@ -94,7 +94,7 @@ of the respective records.
 <p>On error, the reply has this structure:
 
 <p><pre>
-   &lt;viewgame xmlns="http://ifdb.tads.org/api/xmlns"&gt;
+   &lt;viewgame xmlns="http://ifdb.org/api/xmlns"&gt;
      &lt;errorCode&gt;<i>code</i>&lt;/errorCode&gt;
      &lt;errorMessage&gt;<i>Error message text</i>&lt;/errorMessage&gt;
    &lt;/viewgame&gt;
@@ -152,7 +152,7 @@ appears at the same XML nesting level as &lt;identification&gt;,
 &lt;story&gt; element).  The structure is as follows:
 
 <p><pre>
-   &lt;ifdb xmlns="http://ifdb.tads.org/api/xmlns"&gt;
+   &lt;ifdb xmlns="http://ifdb.org/api/xmlns"&gt;
      &lt;tuid&gt;<i>TUID</i>&lt;/tuid&gt;
      &lt;link&gt;<i>URL to game page</i>&lt;/link&gt;
      &lt;coverart&gt;

--- a/www/club
+++ b/www/club
@@ -89,7 +89,7 @@ if (isset($_REQUEST['news-rss']))
 
     // send the items
     sendRSS("$name - Club News",
-            "http://ifdb.tads.org/club?id=$qid",
+            get_root_url() . "club?id=$qid",
             "IFDB news postings for the club $name",
             $items, false);
 

--- a/www/comment.php
+++ b/www/comment.php
@@ -404,7 +404,7 @@ if ($errMsg) {
 
             // send email
             if (!$errMsg && !mail(
-                "ifdbadmin@ifdb.tads.org",
+                "ifdbadmin@ifdb.org",
                 "IFDB comment spam flag",
 
                 "<b>Possible spam comment posted</b><br><br>User: "
@@ -430,7 +430,7 @@ if ($errMsg) {
                 
                 . "<br><br>",
                 
-                "From: IFDB <noreply@ifdb.tads.org>\r\n"
+                "From: IFDB <noreply@ifdb.org>\r\n"
                 . "Content-type: Text/HTML\r\n"))
             {
                 $errMsg = "$spamErr RVE1928)";

--- a/www/comment.php
+++ b/www/comment.php
@@ -375,7 +375,7 @@ if ($errMsg) {
         $ak->setCommentAuthor($userAccountName);
         $ak->setCommentAuthorEmail($userAccountEmail);
         $ak->setCommentAuthorURL(
-            "http://ifdb.tads.org/showuser?id=$curuser");
+            get_root_url() . "showuser?id=$curuser");
         $ak->setCommentContent($commentText);
 
         // notify ifdbadmin if it looks like spam
@@ -396,7 +396,7 @@ if ($errMsg) {
                     $errMsg = "$spamErr RVN1927)";
 
                 // generate the admin url ase
-                $adminUrl = "http://ifdb.tads.org/userconfirm"
+                $adminUrl = get_root_url() . "userconfirm"
                             . "?nonce=$nonce"
                             . "&userid=$curuser"
                             . "&reviewProfile=";
@@ -408,9 +408,9 @@ if ($errMsg) {
                 "IFDB comment spam flag",
 
                 "<b>Possible spam comment posted</b><br><br>User: "
-                . "<a href=\"http://ifdb.tads.org/showuser?id=$curuser\">"
+                . "<a href=\"" . get_root_url() . "showuser?id=$curuser\">"
                 . htmlspecialchars($userAccountName) . "</a> - "
-                . "<a href=\"http://ifdb.tads.org/commentlog?user=$curuser\">"
+                . "<a href=\"" . get_root_url() . "commentlog?user=$curuser\">"
                 . "user comment log</a>"
                 . "<br>Email: "
                 . htmlspecialchars($userAccountEmail)

--- a/www/commentlog
+++ b/www/commentlog
@@ -148,7 +148,7 @@ if ($rss) {
     ?><rss version="2.0">
        <channel>
           <title><?php echo $username ?>'s Comment Updates</title>
-          <link>http://ifdb.tads.org/</link>
+          <link><?php echo get_root_url(); ?> </link>
           <description>A history of IFDB comments for
              <?php echo $username ?>.</description>
           <language>en-us</language>
@@ -292,7 +292,7 @@ for ($i = 0 ; $i < count($comments) ; $i++) {
         list($desc, $len, $trunc) = summarizeHtml($ctxt, 210);
         $desc = fixDesc($desc, FixDescSpoiler | FixDescRSS);
         $pubDate = date("D, j M Y H:i:s e", strtotime($ccreDT));
-        $link = "http://ifdb.tads.org/$link";
+        $link = get_root_url() . $link;
 
         // if this is the latest item, send its date as the <lastBuildDate>
         if ($i == 0)

--- a/www/contact
+++ b/www/contact
@@ -17,7 +17,7 @@ captchaSupportScripts($capkey);
 
 <p>If you have any comments or questions about this site, you can
 reach us by email at <?php
-   echo captchaMaskEmail("ifdbadmin@ifdb.tads.org",
+   echo captchaMaskEmail("ifdbadmin@ifdb.org",
                          "[<a><i>click to reveal</i></a>]") ?>.
 Please read the advice below about reporting specific kinds of
 problems.

--- a/www/cron-pending.php
+++ b/www/cron-pending.php
@@ -53,7 +53,7 @@ for ($i = 0 ; $i < $rowcnt ; $i++)
     }
 
     // if it's an IFDB 'pending' URL, ignore it
-    if (preg_match("/^http:\/\/ifdb.tads.org\/ifarchive-pending\?/i", $url))
+    if (preg_match("/^https:\/\/ifdb.org\/ifarchive-pending\?/i", $url))
     {
         $output[] = "ifarchive-pending URL: gameID=$gameID, "
                     . "game title=$gameTitle, link title=$linkTitle,"

--- a/www/dladviser
+++ b/www/dladviser
@@ -71,7 +71,7 @@ function sendXml($contents)
     header("Content-Type: text/xml");
     
     echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-        . "<autoinstall xmlns=\"http://ifdb.tads.org/xmlns/autoinstall\">\n";
+        . "<autoinstall xmlns=\"http://ifdb.org/xmlns/autoinstall\">\n";
 
     sendXmlContents($contents);
 

--- a/www/editgame
+++ b/www/editgame
@@ -1387,7 +1387,7 @@ function submitUpload(id, fname, fmtid, osid, compression, pri)
         if (idx = fname.lastIndexOf("\\"))
             fname = fname.substr(idx+1);
     }
-    var url = 'http://ifdb.tads.org/ifarchive-pending?ifdbid=' + id;
+    var url = get_root_url() . 'ifarchive-pending?ifdbid=' + id;
 
     gfInsRow("linkModel", v.length,
              [fname + ' (' + url + ')',

--- a/www/editgame
+++ b/www/editgame
@@ -1387,7 +1387,7 @@ function submitUpload(id, fname, fmtid, osid, compression, pri)
         if (idx = fname.lastIndexOf("\\"))
             fname = fname.substr(idx+1);
     }
-    var url = get_root_url() . 'ifarchive-pending?ifdbid=' + id;
+    var url = '<?php echo get_root_url() ?>ifarchive-pending?ifdbid=' + id;
 
     gfInsRow("linkModel", v.length,
              [fname + ' (' + url + ')',

--- a/www/editprofile
+++ b/www/editprofile
@@ -444,10 +444,10 @@ function saveChanges()
             $ak->setCommentAuthor($dname);
             $ak->setCommentAuthorEmail($email);
             $ak->setCommentAuthorURL(
-                "http://ifdb.tads.org/showuser?id=$usernum");
+                get_root_url() . "showuser?id=$usernum");
             $ak->setCommentContent($profile);
             $ak->setPermalink(
-                "http://ifdb.tads.org/showuser?id=$usernum");
+                get_root_url() . "showuser?id=$usernum");
 
             $akIsSpam = $ak->isCommentSpam();
             if ($akIsSpam)
@@ -474,7 +474,7 @@ function saveChanges()
             // Send email to the IFDB admin on any profile change.  Even
             // if the profile doesn't require review, we want to take a
             // look anyway just to be sure.
-            $adminUrl = "http://ifdb.tads.org/userconfirm"
+            $adminUrl = get_root_url() . "userconfirm"
                         . "?nonce=$nonce"
                         . "&userid=$usernum"
                         . "&reviewProfile=";
@@ -484,9 +484,9 @@ function saveChanges()
                       "<b>*** Review required ***</b>" :
                       "(No review required - advisory only)")
                    . "<p>Profile page: "
-                   . "<a href=\"http://ifdb.tads.org/showuser"
+                   . "<a href=\"". get_root_url() . "showuser"
                    . "?id=$usernum&unlock=$nonce\">"
-                   .     "http://ifdb.tads.org/showuser?id=$usernum</a>"
+                   .     get_root_url() . "showuser?id=$usernum</a>"
                    . "<br>User email: " . htmlspecialcharx($email)
                    . "<br>Screen name: " . htmlspecialcharx($dname)
                    . "<br>Location: " . htmlspecialcharx($loc)
@@ -556,7 +556,7 @@ complete the re-activation process.</b>
             $actcode = sha1(md5_rand($usernum) . md5_rand($email));
 
             // build the activation link
-            $actlink = "http://ifdb.tads.org/userconfirm?a=$actcode";
+            $actlink = get_root_url() . "userconfirm?a=$actcode";
 
             // build the message body
             $msg = "Welcome to IFDB!\n\n

--- a/www/editprofile
+++ b/www/editprofile
@@ -511,10 +511,10 @@ function saveChanges()
 
                    . "<br><br>";
 
-            $hdrs = "From: IFDB <noreply@ifdb.tads.org>\r\n"
+            $hdrs = "From: IFDB <noreply@ifdb.org>\r\n"
                     . "Content-type: Text/HTML\r\n";
 
-            mail("ifdbadmin@ifdb.tads.org",
+            mail("ifdbadmin@ifdb.org",
                  "IFDB profile change", $msg, $hdrs);
         }
 
@@ -571,7 +571,7 @@ complete the re-activation process.</b>
                 not reply to this email - replies to this address are not monitored.\n\n";
 
             // build the headers
-            $hdrs = "From: IFDB <noreply@ifdb.tads.org>\r\n"
+            $hdrs = "From: IFDB <noreply@ifdb.org>\r\n"
                     . "Content-type: Text/HTML\r\n";
 
             // send the message

--- a/www/editprofile
+++ b/www/editprofile
@@ -567,7 +567,7 @@ complete the re-activation process.</b>
                 clicking on it, copy and paste the entire link into your Web\n
                 browser's Address bar.\n\n
                 <p>Thank you for registering your new user account.  If you need to\n
-                contact us, please see the Contact page at ifdb.tads.org.  Please do\n
+                contact us, please see the Contact page at ifdb.org.  Please do\n
                 not reply to this email - replies to this address are not monitored.\n\n";
 
             // build the headers

--- a/www/error403
+++ b/www/error403
@@ -28,7 +28,7 @@ so that we can fix the broken link - see our <a href='/contact.htm'>
 contact information</a>.
 
 <li>You might be able to find the information you're looking for by
-following links from our home page, <a href='/'>ifdb.tads.org</a>.
+following links from our home page, <a href='/'>ifdb.org</a>.
 
 </ul>
 

--- a/www/error404
+++ b/www/error404
@@ -24,7 +24,7 @@ IFDB itself, see our <a href='/contact'>contact information</a>.)
 browser's address bar, check to make sure you entered it correctly.
 
 <li>You might be able to find the information you're looking for via
-our home page, <a href='/'>ifdb.tads.org</a>.
+our home page, <a href='/'>ifdb.org</a>.
 
 </ul>
 

--- a/www/error503
+++ b/www/error503
@@ -1,0 +1,18 @@
+<?php
+include "pagetpl.php";
+
+@session_start();
+
+header("HTTP/1.1 503 Service Unavailable");
+pageHeader("503 - Service Unavailable");
+?>
+<h1>Service Unavailable</h1>
+
+<p><span class=details>HTTP Error 503</span>
+
+<p>The server is temporarily unable due to maintenance downtime or capacity problems. Please try again later.
+
+
+<?php
+pageFooter();
+?>

--- a/www/game-rss.php
+++ b/www/game-rss.php
@@ -54,7 +54,7 @@ function getGameRssItems($db, $id, $feedType, $gameTitle, $links, $extFeed)
             $rtitle = htmlspecialcharx($r['summary']);
             $rid = $r['reviewid'];
             $rlink = htmlspecialcharx(
-                "http://ifdb.tads.org/viewgame?id=$id&review=$rid");
+                get_root_url() . "viewgame?id=$id&review=$rid");
             $rdate = date("D, j M Y H:i:s e", strtotime($r['moddate']));
             list($rdesc, $len, $trunc) = summarizeHtml($r['review'], 210);
             $rdesc = htmlspecialcharx(fixDesc($rdesc));
@@ -120,7 +120,7 @@ function getGameRssItems($db, $id, $feedType, $gameTitle, $links, $extFeed)
             $nuser = htmlspecialcharx($nuser);
             $rssdate = date("D, j M Y H:i:s e", strtotime($ndate));
             $nlink = htmlspecialcharx(
-                "http://ifdb.tads.org/viewgame?id=$id&version=$nvsn");
+                get_root_url() . "viewgame?id=$id&version=$nvsn");
             $deltas = unserialize($deltas);
 
             // build the item XML, according to what kind of update they want

--- a/www/ifarchive-commit
+++ b/www/ifarchive-commit
@@ -10,7 +10,7 @@ $db = dbConnect();
 
 $id = mysql_real_escape_string(get_req_data("ifdbid"), $db);
 $newPath = mysql_real_escape_string(get_req_data("path"), $db);
-$oldUrl = "http://ifdb.tads.org/ifarchive-pending?ifdbid=$id";
+$oldUrl = "https://ifdb.org/ifarchive-pending?ifdbid=$id";
 $apiKey = get_req_data("key");
 
 // remove any leading '/' in the path

--- a/www/lostpass
+++ b/www/lostpass
@@ -171,7 +171,7 @@ function handlePost()
     
 
     // build the headers
-    $hdrs = "From: IFDB <noreply@ifdb.tads.org>\r\n";
+    $hdrs = "From: IFDB <noreply@ifdb.org>\r\n";
     $hdrs .= "Content-type: Text/HTML\r\n";
 
     // send it

--- a/www/lostpass
+++ b/www/lostpass
@@ -155,7 +155,7 @@ function handlePost()
         where id = '$usernum'", $db);
 
     // assemble the message body
-    $href = "http://ifdb.tads.org/resetpsw?a=$actcode";
+    $href = get_root_url() . "resetpsw?a=$actcode";
 
     $msg = "This message is in response to your request to reset your forgotten\n";
     $msg .= "IFDB password. If you didn't make this request, you can simply\n";

--- a/www/newitems.php
+++ b/www/newitems.php
@@ -650,7 +650,7 @@ function showNewItemsRSS($db, $showcnt)
                      . " of {$r['title']}";
             list($summary, $len, $trunc) = summarizeHtml($r['review'], 140);
             $desc = fixDesc($summary);
-            $link = "http://ifdb.tads.org/viewgame?id={$r['gameid']}"
+            $link = get_root_url() . "viewgame?id={$r['gameid']}"
                     . "&review={$r['reviewid']}";
             $pubDate = $r['d'];
         }
@@ -660,7 +660,7 @@ function showNewItemsRSS($db, $showcnt)
             $title = "A Recommended List by {$l['username']}: {$l['title']}";
             list($desc, $len, $trunc) = summarizeHtml($l['desc'], 210);
             $desc = fixDesc($desc);
-            $link = "http://ifdb.tads.org/viewlist?id={$l['id']}";
+            $link = get_root_url() . "viewlist?id={$l['id']}";
             $pubDate = $l['d'];
         }
         else if ($pick == 'P')
@@ -669,7 +669,7 @@ function showNewItemsRSS($db, $showcnt)
             $title = "A poll by {$p['username']}: {$p['title']}";
             list($desc, $len, $trunc) = summarizeHtml($p['desc'], 210);
             $desc = fixDesc($desc);
-            $link = "http://ifdb.tads.org/poll?id={$p['pollid']}";
+            $link = get_root_url() . "poll?id={$p['pollid']}";
             $pubDate = $p['d'];
         }
         else if ($pick == 'N')
@@ -679,7 +679,7 @@ function showNewItemsRSS($db, $showcnt)
             list($desc, $len, $trunc) = summarizeHtml($n['body'], 210);
             $desc = fixDesc($desc);
             $desc = "Reported by {$n['origUserName']}: $desc";
-            $link = "http://ifdb.tads.org/newslog?newsid={$n['newsID']}";
+            $link = get_root_url() . "newslog?newsid={$n['newsID']}";
             $pubDate = $n['d'];
         }
         else if ($pick == 'C')
@@ -688,7 +688,7 @@ function showNewItemsRSS($db, $showcnt)
             $title = "A new competition page: {$c['title']}";
             list($desc, $len, $trunc) = summarizeHtml($c['desc'], 210);
             $desc = fixDesc($desc);
-            $link = "http://ifdb.tads.org/viewcomp?id={$c['compid']}";
+            $link = get_root_url() . "viewcomp?id={$c['compid']}";
             $pubDate = $c['d'];
         }
         else if ($pick == 'U')
@@ -697,7 +697,7 @@ function showNewItemsRSS($db, $showcnt)
             $title = "A new club page: {$c['name']}";
             list($desc, $len, $trunc) = summarizeHtml($c['desc'], 210);
             $desc = fixDesc($desc);
-            $link = "http://ifdb.tads.org/club?id={$c['clubid']}";
+            $link = get_root_url() . "club?id={$c['clubid']}";
             $pubDate = $c['d'];
         }
         else if ($pick == 'G')
@@ -706,7 +706,7 @@ function showNewItemsRSS($db, $showcnt)
             $title = "A new listing for {$g['title']} by {$g['author']}";
             list($desc, $len, $trunc) = summarizeHtml($g['desc'], 210);
             $desc = fixDesc($desc);
-            $link = "http://ifdb.tads.org/viewgame?id={$g['id']}";
+            $link = get_root_url() . "viewgame?id={$g['id']}";
             $pubDate = $g['d'];
         }
 

--- a/www/news
+++ b/www/news
@@ -37,7 +37,7 @@ if (isset($_REQUEST['rss'])) {
 <rss version="2.0">
    <channel>
       <title>IFDB Site News</title>
-      <link>http://ifdb.tads.org/news</link>
+      <link><?php echo get_root_url() ?>news</link>
       <description>Updates on the latest new features on IFDB.</description>
       <language>en-us</language>
 <?php
@@ -55,7 +55,7 @@ if (isset($_REQUEST['rss'])) {
         $ldesc = rss_encode($ldesc);
         $pub = date("D, j M Y H:i:s e", strtotime($pub));
 
-        $link = "http://ifdb.tads.org/news?item=$itemid";
+        $link = get_root_url() . "news?item=$itemid";
         $link = rss_encode(htmlspecialcharx($link));
 
         // send the item

--- a/www/news.php
+++ b/www/news.php
@@ -133,7 +133,7 @@ function queryNewsRss(&$items, $db, $sourceType, $sourceID, $maxItems,
         $nbody = htmlspecialcharx(fixDesc($nbody));
 
         $nlink = htmlspecialcharx(
-            "http://ifdb.tads.org/newslog?newsid=$norig");
+            get_root_url() . "newslog?newsid=$norig");
 
         // generate the title
         $nhead = htmlspecialcharx($titleFunc($titleCtx, $nhead));

--- a/www/newuser
+++ b/www/newuser
@@ -505,10 +505,10 @@ function handlePost()
 
            . "<br>";
 
-    $hdrs = "From: IFDB <noreply@ifdb.tads.org>\r\n"
+    $hdrs = "From: IFDB <noreply@ifdb.org>\r\n"
             . "Content-type: Text/HTML\r\n";
 
-    mail("ifdbadmin@ifdb.tads.org",
+    mail("ifdbadmin@ifdb.org",
          "IFDB new user registration", $msg, $hdrs);
 
     // if the account is pending review, we're done, since we've already

--- a/www/newuser
+++ b/www/newuser
@@ -458,14 +458,14 @@ function handlePost()
     }
 
     // generate the admin url base
-    $adminUrl = "https://ifdb.tads.org/userconfirm"
+    $adminUrl = get_root_url() . "userconfirm"
                 . "?nonce=$nonce"
                 . "&userid=$userid"
                 . "&reviewProfile=";
 
     // add the user record
     $result = mysql_query($sql, $db);
-    $proPage = "https://ifdb.tads.org/showuser?id=$userid";
+    $proPage = get_root_url() . "showuser?id=$userid";
 
     // add a login record to record the user's IP address
     mysql_query("insert into logins (uid, ip, `when`)

--- a/www/newuserconf
+++ b/www/newuserconf
@@ -23,8 +23,8 @@ page and try again.
     {
         $_SESSION['sent_activation'] = true;
         $msgbody = "Welcome to IFDB! Please activate your account\nby clicking on the link below.\n";
-        $hdrs = "From: IFDB Admin <noreply@ifdb.tads.org>\r\n";
-        if (mail("ifdbadmin@ifdb.tads.org", "IFDB user activation", $msgbody, $hdrs)) {
+        $hdrs = "From: IFDB Admin <noreply@ifdb.org>\r\n";
+        if (mail("ifdbadmin@ifdb.org", "IFDB user activation", $msgbody, $hdrs)) {
 ?>
 <h1>Registration Confirmed</h1>
 

--- a/www/pagetpl.php
+++ b/www/pagetpl.php
@@ -27,7 +27,7 @@ function basePageHeader($title, $focusCtl, $extraOnLoad, $extraHead,
    <link rel="shortcut icon" href="/favicon.ico">
    <link rel="search" type="application/opensearchdescription+xml"
          title="IFDB Search Plugin"
-         href="http://ifdb.tads.org/plugins/ifdb-opensearchdesc.xml">
+         href="<?php echo get_root_url() ?>plugins/ifdb-opensearchdesc.xml">
    <script src="ifdbutil.js"></script>
    <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
    <meta name="description" content="IFDB is a game catalog and recommendation engine for Interactive Fiction, also known as Text Adventures. IFDB is a collaborative, wiki-style community project.  Members can contribute game listings, reviews, recommendations, and more.">

--- a/www/plugins/WindowsIE/plugin-win-ie
+++ b/www/plugins/WindowsIE/plugin-win-ie
@@ -10,7 +10,7 @@ pageHeader("IFDB Installer - Windows Internet Explorer");
 
 <object
  classid="clsid:67BAF0C9-D511-4925-A796-3F7BB19726EE"
- codebase="http://ifdb.tads.org/plugins/IFDBInstaller-Windows-IE.CAB"
+ codebase="<?php echo get_root_url() ?>plugins/IFDBInstaller-Windows-IE.CAB"
  style="display:none">
 </object>
 

--- a/www/plugins/ifdb-meta-installer.htm
+++ b/www/plugins/ifdb-meta-installer.htm
@@ -115,7 +115,7 @@ Adviser expert:
 
 <ul>
 
-   <li>Create a user account on <a href="http://ifdb.tads.org">IFDB</a>.
+   <li>Create a user account on <a href="https://ifdb.org">IFDB</a>.
    (Use an email address that's recognizably you - we want users to be
    able to trust that the download instructions won't be hijacked to
    point to malware, so we want to keep write access limited to
@@ -125,8 +125,8 @@ Adviser expert:
    OS/format combinations you want to manage, so that I
    can give you write access to the relevant entries.
 
-   <li>Go to the <a href="http://ifdb.tads.org/fileformat">File Format list</a>
-   and/or the <a href="http://ifdb.tads.org/opsys">OS list</a>, depending
+   <li>Go to the <a href="https://ifdb.org/fileformat">File Format list</a>
+   and/or the <a href="https://ifdb.org/opsys">OS list</a>, depending
    on your area of expertise.  Click through to the formats or OSes of
    interest.
 
@@ -168,7 +168,7 @@ Adviser expert:
 <h2>Background</h2>
 
 <p>I've been working on a new IF catalog and recommendation site that
-I'm calling <a href="http://ifdb.tads.org/">IFDB</a> (for Interactive
+I'm calling <a href="https://ifdb.org/">IFDB</a> (for Interactive
 Fiction DataBase).  The main thrust of the site is to try some new
 approaches to community recommendations for IF, but I felt it was
 important for the sake of user experience to provide integrated
@@ -303,7 +303,7 @@ work.
 <h2>Download Adviser Algorithm</h2>
 
 <p>Note: To see an example of the DLA in action, go to <a
-href="http://ifdb.tads.org"> ifdb.tads.org</a>, search for Deep Space
+href="https://ifdb.org">ifdb.org</a>, search for Deep Space
 Drifter (or any other TADS 2 game), click "Show Me How" in the
 Download box, and make sure that you have a Windows OS version
 selected in the OS list.  I haven't loaded instructions for most of
@@ -345,7 +345,7 @@ does include all of the actively used Story File formats, plus native
 Executables and Installers, plus a number of other common formats used
 frequently in the IF Archive (plain text, HTML, PDF, various image
 types, executables, installers...).  The current list is
-<a href="http://ifdb.tads.org/fileformat">here</a>.
+<a href="https://ifdb.org/fileformat">here</a>.
 
    <li>For the Executable and Installer formats, the file information
 is further qualified by the operating system ID <a
@@ -503,7 +503,7 @@ selector dialog - select {fname} to start the game.
 </blockquote>
 
 <p>To see how these entries look once formatted, go to
-<a href="http://ifdb.tads.org">IFDB</a>, search for Deep Space
+<a href="https://ifdb.org">IFDB</a>, search for Deep Space
 Drifter, click through to the game page, click the
 "Show Me How" button near the top right; if necessary,
 select a Windows version from the OS list and click Go.
@@ -603,7 +603,7 @@ more suitable for a particular client.
    sends an HTTP GET to the following URL (this is a fixed URL
    that can simply be hard-coded into the plug-in):
    <p>
-   <pre>  http://ifdb.tads.org/dladviser?id=<i>TUID</i>&amp;os=<i>OSID</i>&amp;xml</pre>
+   <pre>  https://ifdb.org/dladviser?id=<i>TUID</i>&amp;os=<i>OSID</i>&amp;xml</pre>
 
    <p>where <i>TUID</i> is the game identifier passed in from the hosting
    web page, and <i>OSID</i> is an identification code that specifies
@@ -1620,7 +1620,7 @@ information at all.
    <li>The <b>only</b> information that a web page passes to the
 plug-in is an ID string of the game to be installed.  This ID string
 contains no URL information - it's simply a <a
-href="http://ifdb.tads.org/help-tuid">TUID</a>, which is an
+href="https://ifdb.org/help-tuid">TUID</a>, which is an
 alphanumeric serial number identifying the game in the database.  This
 number has no meaning to a web browser or any network software, so
 it's not possible to use a spoofed TUID to misdirect the plug-in to a
@@ -1720,7 +1720,7 @@ malicious hidden in the plug-in itself.
 user's express permission.
 
    <li>If possible, the plug-in should verify that the browser is
-displaying a page within the ifdb.tads.org site.  This should largely
+displaying a page within the ifdb.org site.  This should largely
 eliminate the possibility that a malicious web site could re-purpose the
 plug-in to install a malicious game program - if a non-IFDB site can't
 invoke the plug-in at all, it can't use it to install anything

--- a/www/plugins/ifdb-meta-installer.htm
+++ b/www/plugins/ifdb-meta-installer.htm
@@ -121,7 +121,7 @@ Adviser expert:
    point to malware, so we want to keep write access limited to
    trustworthy individuals.)
 
-   <li>Let ifdbadmin@ifdb.tads.org know about your new account, and the
+   <li>Let ifdbadmin@ifdb.org know about your new account, and the
    OS/format combinations you want to manage, so that I
    can give you write access to the relevant entries.
 

--- a/www/plugins/ifdb-meta-installer.htm
+++ b/www/plugins/ifdb-meta-installer.htm
@@ -684,7 +684,7 @@ OS-specific part, and weight that against the cost of parsing it.
 
 <pre>
   &lt;?xml version="1.0"?&gt;
-  &lt;autoinstall xmlns="http://ifdb.tads.org/autoinstall" version="1"&gt;
+  &lt;autoinstall xmlns="http://ifdb.org/autoinstall" version="1"&gt;
      <i>contents</i>
   &lt;/autoinstall&gt;
 </pre>

--- a/www/plugins/ifdb-opensearchdesc.xml
+++ b/www/plugins/ifdb-opensearchdesc.xml
@@ -4,8 +4,8 @@
    <Description>Search IFDB</Description>
    <InputEncoding>ISO-8859-1</InputEncoding>
    <Image width="16" height="16" type="image/x-icon">data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8%2F9hAAAAB3RJTUUH2AcaAwUFsGbhmgAAAAlwSFlzAAALEgAACxIB0t1%2B%2FAAAAARnQU1BAACxjwv8YQUAAAGuSURBVHjaY9hgofAfCBjIxYyrTDT%2FM0BB6OlrjAwkAsYlhsb%2F0QWjz50h2iDGebo2%2F3FJJl46TNAgxn2V3SgGMDEzM%2Fz7%2BxfOZ%2BXiZLCpycZt0PPzN0GB%2BP%2FPj1%2F%2Fn5y4%2FP%2Fpqav%2Fv756DxZ7d%2FcJWAzEP9A4C2tgM23Omwo26OvrDwwrotoZlke0Mtw%2FdAksdnL6Zoa9zUsZLizby%2FD04hOGXuXo%2FyCM7ACWP384wAxghDD8%2FsMJZv%2F7xwymJY21GXTCnBkurjjM8OjMU6AIRL5DPgVsSMXDOYwsv%2F5CBP%2F%2FZ2L49YcLYsB%2FFjAtbaLGwMHHyfDnLxtcDh2w%2FEZywS%2BoC%2F5CXXBw0kEGFnYWhuc3P8LlQKDlZSc8UFk0vI3ADDYudgbdUEtgLDAxCCmIgcVkTVUY7p98xPDi7leGb395GPre1GLEBuPtw49QAoWRCeiafwg%2BJz87g7SuGKM092awuqdffVEMYenz2IQziqd9QY1%2FkGaQQciGMCazz8VIiXN%2BJKFohNmODkAGAWMBEbqLfkdg%2BBHZRnTbQXwWUOiu%2BO9PMM3DXIHsGpBhACjY%2B%2Fjx%2B8FgAAAAAElFTkSuQmCC</Image>
-   <Url type="text/html" method="GET" template="http://ifdb.tads.org/search">
+   <Url type="text/html" method="GET" template="https://ifdb.org/search">
       <Param name="searchfor" value="{searchTerms}"/>
    </Url>
-   <moz:SearchForm>http://ifdb.tads.org/search</moz:SearchForm>
+   <moz:SearchForm>https://ifdb.org/search</moz:SearchForm>
 </OpenSearchDescription>

--- a/www/poll
+++ b/www/poll
@@ -293,7 +293,7 @@ if (isset($_REQUEST['newPollGo'])) {
         pageHeader("New Poll");
 
         // get the new poll ID, and generate the URL
-        $url = "http://ifdb.tads.org/poll?id=$tuid";
+        $url = get_root_url() . "poll?id=$tuid";
 
         // get my user name
         $result = mysql_query("select name from users where id='$userid'", $db);
@@ -940,7 +940,7 @@ engine to match.
 <rss version="2.0">
    <channel>
       <title><?php echo $title ?>: an IFDB poll by <?php echo $authname ?></title>
-      <link>http://ifdb.tads.org/</link>
+      <link><?php echo get_root_url() ?></link>
       <description>The latest reviews and listings on IFDB, the
          Interactive Fiction DataBase.</description>
       <language>en-us</language>
@@ -963,7 +963,7 @@ engine to match.
                v.votedate desc", $db);
 
         $pollUrl = rss_encode(htmlspecialcharx(
-            "http://ifdb.tads.org/poll?id=$id"));
+            get_root_url() . "poll?id=$id"));
 
         // send the rows
         for ($i = 0, $cnt = mysql_num_rows($result) ; $i < $cnt ; $i++) {

--- a/www/putific
+++ b/www/putific
@@ -664,7 +664,7 @@ if ($saveErrMsg) {
 replyXml("<ok/>"
          . "<$action/>"
          . "<tuid>$newid</tuid>"
-         . "<viewUrl>http://ifdb.tads.org/viewgame?id=$newid</viewUrl>"
-         . "<editUrl>http://ifdb.tads.org/editgame?id=$newid</editUrl>");
+         . "<viewUrl>" . get_root_url() . "viewgame?id=$newid</viewUrl>"
+         . "<editUrl>" . get_root_url() . "editgame?id=$newid</editUrl>");
     
 ?>

--- a/www/putific
+++ b/www/putific
@@ -23,7 +23,7 @@ function replyXml($body)
     header("Pragma: no-cache");
 
     echo "<?xml version=\"1.0\" encoding=\"utf8\"?>"
-        . "<putific xmlns=\"http://ifdb.tads.org/api/xmlns\">"
+        . "<putific xmlns=\"http://ifdb.org/api/xmlns\">"
         . rss_encode($body)
         . "</putific>";
     exit();

--- a/www/reviewcommentlog
+++ b/www/reviewcommentlog
@@ -139,7 +139,7 @@ if ($rss) {
     <rss version="2.0">
        <channel>
           <title><?php echo $username ?>'s Comment Updates</title>
-          <link>http://ifdb.tads.org/</link>
+          <link><?php echo get_root_url() ?></link>
           <description>A history of IFDB review comments for
              <?php echo $username ?>.</description>
           <language>en-us</language>
@@ -163,7 +163,7 @@ if ($rss) {
         list($desc, $len, $trunc) = summarizeHtml($ctxt, 210);
         $desc = fixDesc($desc, FixDescSpoiler | FixDescRSS);
         $pubDate = date("D, j M Y H:i:s e", strtotime($ccreDT));
-        $link = "http://ifdb.tads.org/viewgame?id=$gid&review=$rid";
+        $link = get_root_url() . "viewgame?id=$gid&review=$rid";
 
         // if this is the latest item, send its date as the <lastBuildDate>
         if ($i == 0)

--- a/www/search
+++ b/www/search
@@ -1099,7 +1099,6 @@ if ($xml) {
     for ($i = 0 ; $i < count($rows) ; $i++)
     {
         $row = $rows[$i];
-        $site = "http://ifdb.tads.org";
         switch($searchType)
         {
         case "game":
@@ -1113,13 +1112,13 @@ if ($xml) {
             list($stars) = roundStars($rating);
             $ratingCnt = $row['ratingcnt'];
             $art = ($row['hasart'] ? "yes" : "no");
-            $link = htmlspecialcharx("$site/viewgame?id=$id");
+            $link = htmlspecialcharx(get_root_url() . "viewgame?id=$id");
 
             $coverArtLink = "";
             if ($art == "yes") {
                 $coverArtLink =
                     "<coverArtLink>"
-                    . htmlspecialcharx("$site/viewgame?id=$id&coverart")
+                    . htmlspecialcharx(get_root_url() . "viewgame?id=$id&coverart")
                     . "</coverArtLink>";
             }
 
@@ -1149,7 +1148,7 @@ if ($xml) {
             $userid = $row['userid'];
             $username = htmlspecialcharx($row['username']);
             $items = $row['itemcount'];
-            $link = htmlspecialcharx("$site/viewlist?id=$id");
+            $link = htmlspecialcharx(get_root_url() . "viewlist?id=$id");
 
             echo rss_encode(
                 "<list>"
@@ -1171,7 +1170,7 @@ if ($xml) {
             $username = htmlspecialcharx($row['username']);
             $votecnt = $row['votecnt'];
             $gamecnt = $row['gamecnt'];
-            $link = htmlspecialcharx("$site/poll?id=$id");
+            $link = htmlspecialcharx(get_root_url() . "poll?id=$id");
 
             echo rss_encode(
                 "<poll>"
@@ -1192,7 +1191,7 @@ if ($xml) {
             $desc = fixDesc($row['desc']);
             $gamecnt = $row['gamecnt'];
             $divcnt = $row['divcnt'];
-            $link = htmlspecialcharx("$site/viewcomp?id=$id");
+            $link = htmlspecialcharx(get_root_url() . "viewcomp?id=$id");
 
             echo rss_encode(
                 "<competition>"
@@ -1210,7 +1209,7 @@ if ($xml) {
             $title = htmlspecialcharx($row['name']);
             $desc = fixDesc($row['desc']);
             $membercnt = $row['membercnt'];
-            $link = htmlspecialcharx("$site/club?id=$id");
+            $link = htmlspecialcharx(get_root_url() . "club?id=$id");
 
             echo rss_encode(
                 "<club>"
@@ -1229,13 +1228,13 @@ if ($xml) {
             $pic = ($row['haspic'] ? "yes" : "no");
             $badgeInfo = $badges ? $badges[$id] : false;
             $badge = ($badgeInfo ? $badgeInfo[1] : false);
-            $link = htmlspecialcharx("$site/showuser?id=$id");
+            $link = htmlspecialcharx(get_root_url() . "showuser?id=$id");
 
             $picLink = "";
             if ($pic == "yes") {
                 $picLink =
                     "<pictureLink>"
-                    . htmlspecialcharx("$site/showuser?id=$id&pic")
+                    . htmlspecialcharx(get_root_url() . "showuser?id=$id&pic")
                     . "</pictureLink>";
             }
 

--- a/www/search
+++ b/www/search
@@ -153,7 +153,7 @@ if ($xml && $enum)
     header("Cache-Control: no-store, no-cache, must-revalidate");
 
     echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-        . "<searchEnum xmlns=\"http://ifdb.tads.org/api/xmlns\">"
+        . "<searchEnum xmlns=\"http://ifdb.org/api/xmlns\">"
         . rss_encode($errmsg)
         . "<itemType>$enum</itemType>"
         . "<items>";
@@ -1071,7 +1071,7 @@ if ($xml) {
     header("Cache-Control: no-store, no-cache, must-revalidate");
 
     echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-        . "<searchReply xmlns=\"http://ifdb.tads.org/api/xmlns\">";
+        . "<searchReply xmlns=\"http://ifdb.org/api/xmlns\">";
 
     // check for errors
     if ($errMsg)

--- a/www/showuser
+++ b/www/showuser
@@ -193,7 +193,7 @@ if ($rss == 'gamenews')
                 . "<description><i>$gtitle</i> has been newly "
                 . "linked to this author's profile.</description>"
                 . "<pubDate>$rssdate</pubDate>"
-                . "<guid>http://ifdb.tads.org/viewgame?id=$gameid</guid>"
+                . "<guid>" . get_root_url() . "viewgame?id=$gameid</guid>"
                 . "</item>";
         $items[] = array($moddate, $item);
 
@@ -224,7 +224,7 @@ if ($rss == 'gamenews')
 
     // send the list
     sendRSS("$username's game updates",
-            "http://ifdb.tads.org/showuser?id=$uid",
+            get_root_url() . "showuser?id=$uid",
             "News about games linked to $username's IFDB profile.",
             $items, 50);
 

--- a/www/useractivation.php
+++ b/www/useractivation.php
@@ -16,7 +16,7 @@ function sendActivationEmail($email, $actcode)
         clicking on it, copy and paste the entire link into your Web\n
         browser's Address bar.\n\n
         <p>Thank you for registering your new user account.  If you need to\n
-        contact us, please see the Contact page at ifdb.tads.org.  Please do\n
+        contact us, please see the Contact page at ifdb.org.  Please do\n
         not reply to this email - replies to this address are not monitored.\n\n";
 
     // build the headers

--- a/www/useractivation.php
+++ b/www/useractivation.php
@@ -20,7 +20,7 @@ function sendActivationEmail($email, $actcode)
         not reply to this email - replies to this address are not monitored.\n\n";
 
     // build the headers
-    $hdrs = "From: IFDB <noreply@ifdb.tads.org>\r\n"
+    $hdrs = "From: IFDB <noreply@ifdb.org>\r\n"
             . "Content-type: Text/HTML\r\n";
 
     // send the message

--- a/www/useractivation.php
+++ b/www/useractivation.php
@@ -3,7 +3,7 @@
 function sendActivationEmail($email, $actcode)
 {
     // build the activation link
-    $actlink = "http://ifdb.tads.org/userconfirm?a=$actcode&email="
+    $actlink = get_root_url() . "userconfirm?a=$actcode&email="
                . urlencode($email);
 
     // build the message
@@ -30,15 +30,15 @@ function sendActivationEmail($email, $actcode)
 function genNewUserAdminLinks($verbose, $actcode, $salt)
 {
     $br = ($verbose ? "<p>" : "<br>");
-    return "<a href=\"http://ifdb.tads.org/userconfirm?"
+    return "<a href=\"" . get_root_url() . "userconfirm?"
         . "a=$actcode&s=$salt&c=approve\">"
         . ($verbose ? "<b>Approve</b> - " : "")
         . "Activate account and send email notice</a>"
-        . "$br<a href=\"http://ifdb.tads.org/userconfirm?"
+        . "$br<a href=\"" . get_root_url() . "userconfirm?"
         . "a=$actcode&s=$salt&c=delete\">"
         . ($verbose ? "<b>Reject</b> - " : "")
         . "Delete account and send notice by email</a>"
-        . "$br<a href=\"http://ifdb.tads.org/userconfirm?"
+        . "$br<a href=\"" . get_root_url() . "userconfirm?"
         . "a=$actcode&s=$salt&c=flush\">"
         . ($verbose ? "<b>Flush</b> - " : "")
         . "Delete without notice</a>";

--- a/www/util.php
+++ b/www/util.php
@@ -3069,9 +3069,9 @@ function send_admin_email_if_links($txt, $context, $contextLink)
     if (preg_match("/https?:\/\//i", $txt))
     {
         $userid = $_SESSION['logged_in_as'];
-        $hdrs = "From: IFDB <noreply@ifdb.tads.org>\r\n"
+        $hdrs = "From: IFDB <noreply@ifdb.org>\r\n"
                 . "Content-type: Text/HTML\r\n";
-        mail("ifdbadmin@ifdb.tads.org", "IFDB hyperlink review",
+        mail("ifdbadmin@ifdb.org", "IFDB hyperlink review",
              "User: <a href=\"https://ifdb.tads.org/showuser?id=$userid\">$userid</a><br>\n"
              . "Context: <a href=\"https://ifdb.tads.org/{$contextLink}\">$context</a><br>\n"
              . "Text:<br>\n<br>\n"

--- a/www/util.php
+++ b/www/util.php
@@ -26,7 +26,8 @@ function mysql_insert_id($linkid) { return mysqli_insert_id($linkid); }
 define("MYSQL_ASSOC", MYSQLI_ASSOC);
 define("MYSQL_BOTH",  MYSQLI_BOTH);
 
-define("PRODUCTION_SERVER_NAME", "ifdb.tads.org");
+define("PRODUCTION_SERVER_NAME", "ifdb.org");
+define("STAGING_SERVER_NAME", "dev.ifdb.org");
 
 // --------------------------------------------------------------------------
 //
@@ -3072,8 +3073,8 @@ function send_admin_email_if_links($txt, $context, $contextLink)
         $hdrs = "From: IFDB <noreply@ifdb.org>\r\n"
                 . "Content-type: Text/HTML\r\n";
         mail("ifdbadmin@ifdb.org", "IFDB hyperlink review",
-             "User: <a href=\"https://ifdb.tads.org/showuser?id=$userid\">$userid</a><br>\n"
-             . "Context: <a href=\"https://ifdb.tads.org/{$contextLink}\">$context</a><br>\n"
+             "User: <a href=\"" . get_root_url() . "showuser?id=$userid\">$userid</a><br>\n"
+             . "Context: <a href=\"" . get_root_url() . "{$contextLink}\">$context</a><br>\n"
              . "Text:<br>\n<br>\n"
              . $txt,
              $hdrs);
@@ -3084,8 +3085,22 @@ function isProduction() {
     return $_SERVER['SERVER_NAME'] === PRODUCTION_SERVER_NAME;
 }
 
+function isStaging() {
+    return $_SERVER['SERVER_NAME'] === STAGING_SERVER_NAME;
+}
+
 function isLocalDev() {
-    return !isProduction();
+    return !isProduction() && !isStaging();
+}
+
+function get_root_url() {
+    if (isProduction()) {
+        return "https://ifdb.org/";
+    } else if (isStaging()) {
+        return "https://dev.ifdb.org/";
+    } else {
+        return (isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] === 'on' ? "https" : "http") . "://$_SERVER[HTTP_HOST]/";
+    }
 }
 
 ?>

--- a/www/util.php
+++ b/www/util.php
@@ -26,7 +26,7 @@ function mysql_insert_id($linkid) { return mysqli_insert_id($linkid); }
 define("MYSQL_ASSOC", MYSQLI_ASSOC);
 define("MYSQL_BOTH",  MYSQLI_BOTH);
 
-define("PRODUCTION_SERVER_NAME", "ifdb.org");
+define("PRODUCTION_SERVER_NAME", "ifdb.tads.org");
 define("STAGING_SERVER_NAME", "dev.ifdb.org");
 
 // --------------------------------------------------------------------------

--- a/www/viewcomp
+++ b/www/viewcomp
@@ -266,7 +266,7 @@ if ($rss)
         $rssdate = date("D, j M Y H:i:s e", strtotime($hModRaw));
         $dn = deltaDesc($deltas);
         $nlink = htmlspecialcharx(
-            "http://ifdb.tads.org/viewcomp?id=$compID&vsn=$hVsn");
+            get_root_url() . "viewcomp?id=$compID&vsn=$hVsn");
 
         // generate this item
         $item = "<item>"
@@ -285,7 +285,7 @@ if ($rss)
 
     // send the data
     sendRSS($rec["title"],
-            "http://ifdb.tads.org/viewcomp?id=$compID",
+            get_root_url() . "viewcomp?id=$compID",
             $rec["title"] . " - Competition news &amp; updates from IFDB.",
             $items, 50);
 

--- a/www/viewgame
+++ b/www/viewgame
@@ -586,7 +586,7 @@ if (isset($_REQUEST['ifiction']))
         . "<story>"
         
         . "<colophon>"
-        .    "<generator>ifdb.tads.org/viewgame</generator>"
+        .    "<generator>ifdb.org/viewgame</generator>"
         .   "<generatorversion>1</generatorversion>"
         .   "<originated>" . date("Y-m-d", strtotime($moddate2)) . "</originated>"
         . "</colophon>"

--- a/www/viewgame
+++ b/www/viewgame
@@ -574,7 +574,7 @@ if (isset($_REQUEST['ifiction']))
 
     // if an error occurred, show the error
     if ($errMsg) {
-        echo "<viewgame xmlns=\"http://ifdb.tads.org/api/xmlns\">";
+        echo "<viewgame xmlns=\"http://ifdb.org/api/xmlns\">";
         xmlField("errorCode", $errCode);
         xmlField("errorMessage", $errMsg);
         echo "</viewgame>";
@@ -678,7 +678,7 @@ if (isset($_REQUEST['ifiction']))
     
     echo "</contact>";
 
-    echo "<ifdb xmlns=\"http://ifdb.tads.org/api/xmlns\">";
+    echo "<ifdb xmlns=\"http://ifdb.org/api/xmlns\">";
     xmlField("tuid", $id);
     xmlField("link", "http://ifdb.tads.org/viewgame?id=$id");
     if ($hasart) {

--- a/www/viewgame
+++ b/www/viewgame
@@ -534,17 +534,17 @@ if (isset($_REQUEST['rss'])) {
     // send it
     if ($feedType == GAME_RSS_ALL) {
         sendRSS("$title - IFDB Updates",
-                "http://ifdb.tads.org/viewgame?id=$id",
+                get_root_url() . "viewgame?id=$id",
                 "Updates to <i>$title</i>'s IFDB page",
                 $items, 50);
     } else if ($feedType == GAME_RSS_DLS) {
         sendRSS("$title - File Updates on IFDB",
-                "http://ifdb.tads.org/viewgame?id=$id",
+                get_root_url() . "viewgame?id=$id",
                 "IFDB File Updates for <i>$title</i>",
                 $items, 50);
     } else if ($feedType == GAME_RSS_REVIEWS) {
         sendRSS("$title - IFDB Reviews",
-                "http://ifdb.tads.org/viewgame?id=$id&reviews",
+                get_root_url() . "viewgame?id=$id&reviews",
                 "IFDB Member Reviews of <i>$title</i>",
                 $items, 50);
     }
@@ -680,10 +680,10 @@ if (isset($_REQUEST['ifiction']))
 
     echo "<ifdb xmlns=\"http://ifdb.org/api/xmlns\">";
     xmlField("tuid", $id);
-    xmlField("link", "http://ifdb.tads.org/viewgame?id=$id");
+    xmlField("link", get_root_url() . "viewgame?id=$id");
     if ($hasart) {
         echo "<coverart>";
-        xmlField("url", "http://ifdb.tads.org/viewgame?id=$id&coverart");
+        xmlField("url", get_root_url() . "viewgame?id=$id&coverart");
         echo "</coverart>";
     }
     xmlField("averageRating", $ratingAvg);


### PR DESCRIPTION
Working on #7.

This is a tough one to review, especially since we don't have a test plan. I tried to break it up into several commits.

1. Update email address: We'll always use the same domain for this, ifdb.org. The code should never suggest emailing dev.ifdb.org.
2. HTTPS redirect: I _think_ I set it up correctly so it will redirect from HTTP to HTTPS in staging and production but not in local dev. All I've actually tested is that it doesn't redirect in local dev.
3. xmlns: I'm not entirely sure if I should change these at all. (But it can't be right to just leave these URLs pointing to ifdb.tads.org, right?) I _just_ changed the domain names without switching to `https://` but it's not at all clear to me that this is the right call.
4. This is the big one, but it's also the simplest: I introduce a `get_root_url()` utility in `utils.php` and then use it all over the place instead of a hardcoded string. (It's plausible that some of these _should_ be hard coded strings; more eyes are very welcome here.)
5. Colophon: Here's a weird one. It's about the `viewgame` API. https://ifdb.tads.org/api/viewgame 
    > The viewgame API lets applications retrieve IFDB's listing data for a game in the Treaty of Babel's iFiction XML format.
    
    The "Treaty of Babel" has a `<colophon>` section with a `<generator>` element. I'm hard coding this to `ifdb.org/viewgame`. (Right??)
6. IFArchive pending URLs: These are actually stored in the database, so we don't want them to vary depending on whether you're in local dev/staging/production.
7. OpenSearch descriptor: This is what allows your browser to help you search IFDB straight from the URL bar. I suppose I _could_ generate the OpenSearch descriptor via PHP and use `get_root_url()`, but, meh.
8. Dev images: Lastly, I undid part of my change by setting the production URL back to ifdb.tads.org, because for now that's the only place for local developers to get their images. Once we're deployed to prod for real, we'll change this setting and then developers can get their images from prod. (Or _maybe_ by then we'll have a way of storing/retrieving the images directly from IFArchive.)
9. Data migration: We're running a basic regex on the SQL as we import it to replace all ifdb.tads.org references in the SQL to ifdb.org