### PR TITLE
Log out banned users, polling DB frequently

### DIFF
--- a/www/login-check.php
+++ b/www/login-check.php
@@ -43,8 +43,13 @@ function provisionally_logged_in()
 function logged_in($smallPage = false)
 {
     // if we have the session flag indicating we're logged in, we're good
-    if (isset($_SESSION['logged_in']) && $_SESSION['logged_in'] == true)
+    if (isset($_SESSION['logged_in']) && $_SESSION['logged_in'] == true) {
+        if (check_banned($_SESSION['logged_in_as'])) {
+            redirect_to_login_page();
+            return false;
+        }
         return true;
+    }
 
     // look for a persistent session
     $userid = checkPersistentLogin();

--- a/www/login-persist.php
+++ b/www/login-persist.php
@@ -7,8 +7,11 @@ function checkPersistentLogin()
 {
     // if we're already logged in, there's no need to check for a persistent
     // session
-    if (isset($_SESSION['logged_in']) && $_SESSION['logged_in'] == true)
-        return $_SESSION['logged_in_as'];
+    if (isset($_SESSION['logged_in']) && $_SESSION['logged_in'] == true) {
+        $userid = $_SESSION['logged_in_as'];
+        if (check_banned($userid)) return false;
+        return $userid;
+    }
 
     // check for the session ID
     if (isset($_COOKIE['IFDBSessionID'])) {
@@ -49,6 +52,21 @@ function checkPersistentLogin()
 
     // not logged in
     return false;
+}
+
+
+function check_banned($userid) {
+    $db = dbConnect();
+    $result = mysql_query(
+        "select 1 from users where id = '$userid' and acctstatus = 'B'", $db);
+    $banned = mysql_num_rows($result) > 0;
+    if ($banned) {
+        error_log("user $user_id is banned; logging out");
+        $_SESSION['logged_in'] = false;
+        $_SESSION['logged_in_as'] = null;
+        unset($_SESSION['provisional_logged_in_as']);
+    }
+    return $banned;
 }
 
 ?>


### PR DESCRIPTION
MJR's implementation of `logged_in`/`checkPersistentLogin` would trust the session, but if the user is signed in, the session has no way of knowing whether it's banned, so we have to poll the DB on every request.

Fixes https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/23.