### PR TITLE
Ban users without deleting them

### DIFF
--- a/www/adminops
+++ b/www/adminops
@@ -750,6 +750,8 @@ else if (isset($_REQUEST['users'])) {
 
 		$oldSandbox = $sandbox;
 		$newSandbox = $_REQUEST['sandbox'];
+        // banned/closed users shouldn't show up
+        if ($stat == 'B' || $stat == 'X') $newSandbox = 1;
 		if (isset($sandboxMap[$newSandbox]))
 			$sandbox = $newSandbox;
 
@@ -774,10 +776,6 @@ else if (isset($_REQUEST['users'])) {
                `privileges` = '$privcode',
                sandbox = '$sandbox'
              where id = '$quid'", $db);
-
-        // close or ban the account, if desired
-        if ($result && ($stat == 'B' || $stat == 'X'))
-            $result = close_user_acct($db, $uid, $stat, $progress);
 
         // delete the old format privileges, and insert the new ones
         if ($result) {


### PR DESCRIPTION
When banning a user, sandbox them, don't delete them. (This allows us to reverse a ban if we decide to do so.)

Fixes https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/22