### PR TITLE
Bury games

### DIFF
--- a/sql/patch-schema.sql
+++ b/sql/patch-schema.sql
@@ -15,6 +15,10 @@ ALTER TABLE `clubs`
   ADD COLUMN `pswsalt` varchar(32) COLLATE latin1_german2_ci DEFAULT NULL
 ;
 
+ALTER TABLE `games`
+  ADD COLUMN `flags` int(11) COLLATE latin1_german2_ci NOT NULL DEFAULT '0'
+;
+
 DROP TABLE IF EXISTS `userfilters`;
 /*!40101 SET @saved_cs_client     = @@character_set_client */;
 /*!40101 SET character_set_client = utf8 */;

--- a/www/adminops
+++ b/www/adminops
@@ -33,6 +33,58 @@ if (!$adminPriv) {
     exit();
 }
 
+if (isset($_REQUEST['burygame'])) {
+    $tuid = isset($_REQUEST['id']) ? htmlspecialcharx($_REQUEST['id']) : false;
+    if ($tuid === false) {
+        pageHeader("Bury game");
+        ?>
+        <h1>Bury game</h1>
+        <form>TUID: <input type=hidden name=burygame value=''><input name=id><button>Submit</button></form>
+        <?php
+    } else {
+        $qid = mysql_real_escape_string($tuid, $db);
+        $result = mysql_query("select title, flags from games where id = '$qid'", $db);
+        if (!$result) {
+            error_log(mysql_error($db));
+            echo "There was an error finding this game.";
+        } else if (!mysql_num_rows($result)) {
+            pageHeader("Bury game");
+            echo "Couldn't find a game with ID " . $tuid;
+        } else {
+            list($title, $flags) = mysql_fetch_row($result);
+            $flagset = "";
+            if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+                $shouldHide = $_POST['hide'] === 'on';
+                $newflags = $flags;
+                if ($_POST['hide'] === 'on') {
+                    $newflags |= FLAG_SHOULD_HIDE;
+                } else {
+                    $newflags &= ~FLAG_SHOULD_HIDE;
+                }
+                $result = mysql_query(
+                    "update games
+                    set flags = '$newflags'
+                    where id = '$qid'", $db);
+                if (!$result) {
+                    error_log($mysql_error($db));
+                    echo "There was an error setting the flag.";
+                }
+                $flags = $newflags;
+                $flagset = $shouldHide ? "<p>Buried.</p>" : "<p>Unburied.</p>";
+            }
+            pageHeader("Bury game: " . htmlspecialcharx($title));
+            echo "<h1>Bury game: " . htmlspecialcharx($title) . "</h1>";
+            echo "<p><a href='/viewgame?id=$tuid'>$tuid</a></p>";
+            echo $flagset;
+            $shouldHide = $flags & FLAG_SHOULD_HIDE;
+            $checked = $shouldHide ? "checked" : "";
+            echo "<form method=post>Bury: <input type=checkbox name=hide $checked> <button>Submit</button></form>";
+        }
+    }
+    pageFooter();
+    exit();
+}
+
 if (isset($_REQUEST['showimage'])) {
     list($imgdata, $fmt) = fetch_image($_REQUEST['showimage'], true);
     if (is_null($imgdata))
@@ -2131,6 +2183,7 @@ function cleanutf8($str)
 <a href="adminops?cleanpix">Delete orphaned images</a><br>
 <a href="adminops?users&sortby=new">User list</a><br>
 <a href="adminops?finduser">User search</a><br>
+<a href="adminops?burygame">Bury game</a><br>
 <a href="adminops?userSelfComments">User self-comments</a><br>
 <a href="adminops?reaper=30">Persistent session reaper</a><br>
 <a href="adminops?fixsortkeys">

--- a/www/allnew
+++ b/www/allnew
@@ -14,6 +14,8 @@ $pg = isset($_REQUEST['pg']) ? $_REQUEST['pg'] : "";
 if ($pg < 1)
     $pg = 1;
 
+$showFlagged = isset($_GET['showFlagged']) && $_GET['showFlagged'];
+
 // calculate where that puts us in the results
 $firstOnPage = ($pg - 1) * PER_PAGE;
 $lastOnPage = $firstOnPage + PER_PAGE - 1;
@@ -24,7 +26,7 @@ $tot = count($items);
 
 // set up the page controls
 $pageCtl = "<span class=details>"
-           . makePageControl("allnew?", $pg, $pg + ($tot > PER_PAGE ? 1 : 0),
+           . makePageControl("allnew?" . ($showFlagged ? "showFlagged=1&" : ""), $pg, $pg + ($tot > PER_PAGE ? 1 : 0),
                              $firstOnPage, $lastOnPage, -1,
                              false, false, false)
            . "</span>";
@@ -38,7 +40,7 @@ echo "<h1>New on IFDB</h1>";
 echo "$pageCtl<p><hr class=dots><p>";
 
 // show the new items
-showNewItems($db, $firstOnPage, $lastOnPage, $items);
+showNewItems($db, $firstOnPage, $lastOnPage, $items, $showFlagged);
 
 // show the page controls again at the bottom
 echo "<p><hr class=dots><p>$pageCtl<br>";

--- a/www/editlist
+++ b/www/editlist
@@ -293,7 +293,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_REQUEST['preview'])) {
     // our common select list
     $sel = "select games.id, games.title, games.author,
               (games.coverart is not null) as hasart,
-              date_format(games.published, '%Y') as pubyear";
+              date_format(games.published, '%Y') as pubyear, flags";
 
     // run through the new items and resolve each title/TUID
     for ($i = 0, $numfound = 0, $resolved = false ;
@@ -530,7 +530,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST' && isset($_REQUEST['preview'])) {
                $now = date("M j, Y");
                showRecList($db, $qlistid, $userid, $username, $userloc,
                            $listTitle, $listDesc, $now, $listItems,
-                           "_blank", false);
+                           "_blank", false, true);
            ?>
 
            <p><hr class=dots><p>

--- a/www/gameinfo.php
+++ b/www/gameinfo.php
@@ -36,7 +36,7 @@ function getGameInfo($db, $id, $curuser, $requestVersion, &$errMsg, &$errCode)
             concat(date_format(moddate, '%e %M %Y at %l:%i'),
                lower(date_format(moddate, '%p'))) as moddate,
             date_format(moddate, '%d-%b-%Y %H:%i') as moddate2,
-            pagevsn
+            pagevsn, flags
         from games
         where id = '$qid'", $db);
     if (mysql_num_rows($result) == 0) {
@@ -237,6 +237,7 @@ function getGameInfo($db, $id, $curuser, $requestVersion, &$errMsg, &$errCode)
     $links = $rec["links"];
     $extReviews = $rec["extreviews"];
     $xrefs = $rec["xrefs"];
+    $flags = $rec["flags"];
 
     // make sure that the special name and code are set for the external
     // reviews - historical reviews won't have these elements set
@@ -446,7 +447,7 @@ function getGameInfo($db, $id, $curuser, $requestVersion, &$errMsg, &$errCode)
                  $editedbyid, $editedbyname, $moddate, $moddate2, $pagevsn,
                  $historyView,
                  $dlnotes, $extReviews, $extRevDisplayRank,
-                 $ratingHisto, $xrefs, $inrefs);
+                 $ratingHisto, $xrefs, $inrefs, $flags);
 }
 
 // ----------------------------------------------------------------------------

--- a/www/home
+++ b/www/home
@@ -523,6 +523,7 @@ if ($loggedIn) {
                        and uw.userid is null
                        and not (reviews.RFlags & " . RFLAG_OMIT_AVG . ")
                        and ifnull(now() >= reviews.embargodate, 1)
+                       and not (games.flags & " . FLAG_SHOULD_HIDE . ")
                      group by
                        games.id
                      order by
@@ -595,6 +596,7 @@ if ($loggedIn) {
                        and uw.userid is null
                        and r1.rating >= 4
                        and ifnull(now() >= r1.embargodate, 1)
+                       and not (games.flags & " . FLAG_SHOULD_HIDE . ")
                      group by
                        r1.gameid
                      order by
@@ -658,6 +660,7 @@ if (count($recs) == 0) {
            games.id = reviews.gameid
            and ifnull(now() >= reviews.embargodate, 1)
            and not (reviews.RFlags & " . RFLAG_OMIT_AVG . ")
+           and not (games.flags & " . FLAG_SHOULD_HIDE . ")
            $exclWhere
          group by
            games.id

--- a/www/home
+++ b/www/home
@@ -126,7 +126,7 @@ else {
     $limit = 5;
     
     // get the latest games, reviews, and lists, and show a mix
-    if (showNewItems($db, 0, 5, false))
+    if (showNewItems($db, 0, 5, false, false, false))
         echo "<p><span class=details><a href=\"allnew\">"
             . "See the full list...</a></span>";
 }

--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -347,6 +347,11 @@ div.new-club {
     margin-bottom: 1.25em;
 }
 
+.restricted {
+    background: #F0F0F0;
+    padding: 1em;
+}
+
 /*
 The "title" division is used to display the title of a game in
 a review.

--- a/www/playlist
+++ b/www/playlist
@@ -153,6 +153,7 @@ if ($errMsg) {
            count(r3.rating) as numratings,
            games.sort_title as sort_title,
            games.sort_author as sort_author,
+           games.flags,
            r2.rating as urating
            $listCols
          from
@@ -217,6 +218,7 @@ if ($errMsg) {
             $author = htmlspecialcharx($rec['author']);
             list($desc, $desclen, $desctrun) = summarizeHtml($rec['desc'], 210);
             $desc = fixDesc($desc);
+            $shouldHide = $rec['flags'] & FLAG_SHOULD_HIDE;
             $rating = $rec['rating'];
             $urating = $rec['urating'];
             $numratings = $rec['numratings'];
@@ -251,7 +253,7 @@ if ($errMsg) {
                 echo "<span class=details>On your play list</span><br>";
             }
 
-            if ($rating) {
+            if ($rating && !$shouldHide) {
                 echo "<span class=details>Average member rating: "
                     . showStars($rating) . " ($numratings rating"
                     . ($numratings == 1 ? "" : "s") . ")</span><br>";

--- a/www/random
+++ b/www/random
@@ -112,6 +112,7 @@ $sql = "select
           $tableList
         where
           $where
+          and not (games.flags & " . FLAG_SHOULD_HIDE . ")
         $groupBy
         $having
         order by rand()

--- a/www/search
+++ b/www/search
@@ -1380,6 +1380,24 @@ else if ($term || $browse)
             echo $pageCtl;
         echo "</div>";
 
+        $showFlagged = isset($_GET['showFlagged']) && $_GET['showFlagged'];
+        if (!$showFlagged && $searchType == "game") {
+            for ($i = 0 ; $i < count($rows) ; $i++) {
+                $row = $rows[$i];
+                $flags = $row['flags'];
+                if ($flags & FLAG_SHOULD_HIDE) {
+                    $currentUrl = $_SERVER['REQUEST_URI'];
+                    if (strpos($currentUrl, '?') === false) {
+                        $currentUrl .= "?";
+                    }
+                    $showAllLink = htmlspecialchars( $currentUrl, ENT_QUOTES, 'UTF-8' ) . "&showFlagged=1";
+                    echo "<p><div class=restricted>Some results were hidden. "
+                        . "<a href=\"$showAllLink\">See all results</a></div></p>";
+                    break;
+                }
+            }
+        }
+
         for ($i = 0 ; $i < count($rows) ; $i++) {
             // retrieve the row
             $row = $rows[$i];
@@ -1390,6 +1408,10 @@ else if ($term || $browse)
             case "game":
                 // get the row data, formatted for display
                 $id = $row['id'];
+                $flags = $row['flags'];
+                if (!$showFlagged && ($flags & FLAG_SHOULD_HIDE)) {
+                    continue;
+                }
                 $title = output_encode(htmlspecialcharx($row['title']));
                 $author = output_encode(htmlspecialcharx($row['author']));
                 $stars = showStars($row['avgrating']);

--- a/www/search
+++ b/www/search
@@ -1095,6 +1095,7 @@ if ($xml) {
     $grouptag = $grouptags[$searchType];
     echo "<$grouptag>";
 
+    $showFlagged = isset($_GET['showFlagged']) && $_GET['showFlagged'];
     // send the results
     for ($i = 0 ; $i < count($rows) ; $i++)
     {
@@ -1103,6 +1104,10 @@ if ($xml) {
         {
         case "game":
             $id = $row['id'];
+            $flags = $row['flags'];
+            if (!$showFlagged && ($flags & FLAG_SHOULD_HIDE)) {
+                continue;
+            }
             $title = htmlspecialcharx($row['title']);
             $author = htmlspecialcharx($row['author']);
             $published = $row['published'];

--- a/www/search
+++ b/www/search
@@ -1414,12 +1414,13 @@ else if ($term || $browse)
                 // get the row data, formatted for display
                 $id = $row['id'];
                 $flags = $row['flags'];
-                if (!$showFlagged && ($flags & FLAG_SHOULD_HIDE)) {
+                $shouldHide = $flags & FLAG_SHOULD_HIDE;
+                if (!$showFlagged && $shouldHide) {
                     continue;
                 }
                 $title = output_encode(htmlspecialcharx($row['title']));
                 $author = output_encode(htmlspecialcharx($row['author']));
-                $stars = showStars($row['avgrating']);
+                $stars = $shouldHide ? "" : showStars($row['avgrating']);
                 $year = output_encode(htmlspecialcharx($row['pubyear']));
                 $art = $row['hasart'];
                 $rcnt = $row['ratingcnt'];
@@ -1466,19 +1467,21 @@ else if ($term || $browse)
                 }
 
                 $ratingExtra = "";
-                if (isset($specialsUsed['ratingdev:']) && $rcnt != 0) {
-                    $ratingExtra = "$rcnt rating"
-                                   . ($rcnt == 1 ? "" : "s")
-                                   . ", &sigma;=$rdev";
+                if (!$shouldHide) {
+                    if (isset($specialsUsed['ratingdev:']) && $rcnt != 0) {
+                        $ratingExtra = "$rcnt rating"
+                                    . ($rcnt == 1 ? "" : "s")
+                                    . ", &sigma;=$rdev";
+                    }
+                    else if ((isset($specialsUsed['#ratings:'])
+                            || preg_match("/^ratingcnt[ ,]/", $orderBy))
+                            && $rcnt != 0) {
+                        $ratingExtra = "$rcnt rating"
+                                    . ($rcnt == 1 ? "" : "s");
+                    }
+                    if ($ratingExtra != "")
+                        $ratingExtra = "<span class=details>($ratingExtra)</span>";
                 }
-                else if ((isset($specialsUsed['#ratings:'])
-                          || preg_match("/^ratingcnt[ ,]/", $orderBy))
-                         && $rcnt != 0) {
-                    $ratingExtra = "$rcnt rating"
-                                   . ($rcnt == 1 ? "" : "s");
-                }
-                if ($ratingExtra != "")
-                    $ratingExtra = "<span class=details>($ratingExtra)</span>";
 
                 // show the item
                 echo "<p>";

--- a/www/search
+++ b/www/search
@@ -1105,7 +1105,8 @@ if ($xml) {
         case "game":
             $id = $row['id'];
             $flags = $row['flags'];
-            if (!$showFlagged && ($flags & FLAG_SHOULD_HIDE)) {
+            $shouldHide = $flags & FLAG_SHOULD_HIDE;
+            if (!$showFlagged && $shouldHide) {
                 continue;
             }
             $title = htmlspecialcharx($row['title']);
@@ -1133,9 +1134,11 @@ if ($xml) {
                 .   "<title>$title</title>"
                 .   "<link>$link</link>"
                 .   "<author>$author</author>"
-                .   "<averageRating>$rating</averageRating>"
-                .   "<numRatings>$ratingCnt</numRatings>"
-                .   "<starRating>$stars</starRating>"
+                .   ($shouldHide ? "" : (
+                        "<averageRating>$rating</averageRating>"
+                    .   "<numRatings>$ratingCnt</numRatings>"
+                    .   "<starRating>$stars</starRating>"
+                ))
                 .   "<hasCoverArt>$art</hasCoverArt>"
                 .   "<devsys>$devsys</devsys>"
                 .   "<published>"

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -255,7 +255,8 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
                          as ratingdev,
                        games.sort_title as sort_title,
                        games.sort_author as sort_author,
-                       ifnull(games.published, '9999-12-31') as sort_pub";
+                       ifnull(games.published, '9999-12-31') as sort_pub,
+                       games.flags";
         $tableList = "games
                       left outer join reviews
                         on reviews.gameid = games.id

--- a/www/showuser
+++ b/www/showuser
@@ -492,7 +492,8 @@ function pingMultiUserSession(sid, gameid, title, author, started)
            games.`desc` as `desc`,
            (coverart is not null) as hasart,
 		   grv.avgRating as rating,
-           grv.numRatingsInAvg as ratingCnt
+           grv.numRatingsInAvg as ratingCnt,
+           flags
          from
            games
            join gameprofilelinks
@@ -516,8 +517,14 @@ function pingMultiUserSession(sid, gameid, title, author, started)
             $art = $rec['hasart'];
             $descInfo = summarizeHtml($rec['desc'], 200);
             $desc = fixDesc($descInfo[0]);
-            $stars = showStars($rec['rating']);
-            $ratingCnt = $rec['ratingCnt'];
+            $shouldHide = $rec['flags'] & FLAG_SHOULD_HIDE;
+            if ($shouldHide) {
+                $stars = "";
+                $ratingCnt = 0;
+            } else {
+                $stars = showStars($rec['rating']);
+                $ratingCnt = $rec['ratingCnt'];
+            }
             $year = $rec['year'];
 
             if ($ratingCnt != 0)

--- a/www/util.php
+++ b/www/util.php
@@ -55,6 +55,10 @@ define("RFLAG_OMIT_AVG",     0x0002);
 define("GAMELINK_IS_GAME",  0x0001);
 define("GAMELINK_PENDING",  0x0002);
 
+// --------------------------------------------------------------------------
+// GAMES table FLAGS column bit values
+//
+define("FLAG_SHOULD_HIDE", 0x0001);
 
 // --------------------------------------------------------------------------
 // shoot the recommendation cache

--- a/www/viewgame
+++ b/www/viewgame
@@ -335,7 +335,7 @@ function showMemberReviewsHeader($rowcnt, $ratingsView, $showHisto)
     }
 
     // show the statistics
-    if ($ratingCntAvg > 0) {
+    if ($showHisto && $ratingCntAvg > 0) {
         echo "<span class=details>Average Rating: "
             . showStars($ratingAvg)
             . "</span><br>";
@@ -449,8 +449,10 @@ if (!$errMsg) {
          $editedbyid, $editedbyname, $moddate, $moddate2, $pagevsn,
          $historyView,
          $dlnotes, $extReviews, $extRevDisplayRank,
-         $ratingHisto, $xrefs, $inrefs) =
+         $ratingHisto, $xrefs, $inrefs, $flags) =
              getGameInfo($db, $id, $curuser, $reqVersion, $errMsg, $errCode);
+
+    $should_hide = ($flags & FLAG_SHOULD_HIDE);
 
     // encode some items for output
     $title = output_encode($title);
@@ -1406,6 +1408,11 @@ echo "updatePlaylistCount($playlistCnt); updateWishlistCount($wishlistCnt);"
 <table cellspacing=0 cellpadding=0 border=0>
    <tr valign=top>
       <td>
+        <?php
+            if ($should_hide) {
+                ?><div class=restricted>Links to this page and its ratings have been restricted, due to violations of our Code of Conduct.</div><?php
+            }
+        ?>
          <p>
          <table cellspacing=0 cellpadding=0 border=0>
             <tr valign=top>
@@ -1729,7 +1736,7 @@ if ($ratingCntTot == 0) {
         . "$ratingCntTot member rating" . ($ratingCntTot != 1 ? "s" : "")
         . "</a><br>";
 } else {
-    if ($ratingAvg != 0) {
+    if (!$should_hide && $ratingAvg != 0) {
         echo showStars($ratingAvg)
             . " (based on <a href=\"viewgame?id=$id&ratings\" "
             . "title=\"View all ratings and reviews for this game\">"
@@ -2657,7 +2664,8 @@ dispTags();
             $showcnt = $rowcnt;
 
             // show the Member Reviews section header
-            showMemberReviewsHeader($rowcnt, false, true);
+            $showHisto = !$should_hide;
+            showMemberReviewsHeader($rowcnt, false, $showHisto);
 
             // if we have too many for this front page, limit it
             if ($rowcnt > $reviewsOnHomePage) {
@@ -3157,8 +3165,10 @@ dispTags();
         echo "<br><span class=notes><a href=\"viewgame?id=$id\">Return to the
             game's main page</a></span><br>";
 
+        $showHisto = !$should_hide;
+        
         // start the section
-        showMemberReviewsHeader($realtotcnt, $ratingsView, true);
+        showMemberReviewsHeader($realtotcnt, $ratingsView, $showHisto);
 
         // show the reviews/ratings only if we have any
         if ($totcnt != 0) {

--- a/www/viewgame
+++ b/www/viewgame
@@ -1641,6 +1641,7 @@ if (!isEmpty($seriesname)) {
                and games.id = r2.gameid
                and ifnull(now() >= r1.embargodate, 1)
                and ifnull(now() >= r2.embargodate, 1)
+               and not (games.flags & " . FLAG_SHOULD_HIDE . ")
                $andOtherUser
             group by r2.gameid
             order by rand()
@@ -1694,6 +1695,7 @@ if (!isEmpty($seriesname)) {
                $joinOtherUser
              where
                c.fromgame = '$qid'
+               and not (g.flags & " . FLAG_SHOULD_HIDE . ")
                $andOtherUser
              group by
                c.fromgame, c.togame

--- a/www/viewgame
+++ b/www/viewgame
@@ -816,7 +816,7 @@ echo helpWinLink("help-ifid", "IFID");
         $reviewView = true;
 
         // note whether we're including ratings that don't have reviews
-        $ratingsView = isset($_REQUEST['ratings']);
+        $ratingsView = isset($_REQUEST['ratings']) && !$should_hide;
 
         // get the page we're showing, defaulting to 1 if it's non-positive
         $reviewPage = get_req_data('pg');

--- a/www/viewgame
+++ b/www/viewgame
@@ -704,8 +704,12 @@ if (isset($_REQUEST['ifiction']))
 }
 
 // start the page
+$extraHead = "<script src=\"xmlreq.js\"></script>";
+if ($should_hide) {
+    $extraHead .= "<meta name=\"robots\" content=\"noindex\">";
+}
 pageHeader("$title - Details", false, false,
-           "<script src=\"xmlreq.js\"></script>", true);
+           $extraHead, true);
 initReviewVote();
 
 // check for a game specified by IFID and not found

--- a/www/viewgame
+++ b/www/viewgame
@@ -1321,6 +1321,7 @@ if (!document.all)
       </tr>
    </table>
 
+<?php if (!$should_hide) { ?>
    <p>
    <table class=gamerightbar>
       <tr>
@@ -1384,7 +1385,7 @@ echo "updatePlaylistCount($playlistCnt); updateWishlistCount($wishlistCnt);"
 ?>
 //-->
 </script>
-
+<?php } ?>
    <p>
    <table class=gamerightbar>
       <tr>

--- a/www/viewgame
+++ b/www/viewgame
@@ -1417,7 +1417,7 @@ echo "updatePlaylistCount($playlistCnt); updateWishlistCount($wishlistCnt);"
       <td>
         <?php
             if ($should_hide) {
-                ?><div class=restricted>Links to this page and its ratings have been restricted, due to violations of our Code of Conduct.</div><?php
+                ?><div class=restricted>Links to this page and its ratings have been restricted, due to violations of our <a href="/code-of-conduct">Code of Conduct</a>.</div><?php
             }
         ?>
          <p>

--- a/www/viewgame
+++ b/www/viewgame
@@ -688,11 +688,13 @@ if (isset($_REQUEST['ifiction']))
         xmlField("url", get_root_url() . "viewgame?id=$id&coverart");
         echo "</coverart>";
     }
-    xmlField("averageRating", $ratingAvg);
-    list($stars) = roundStars($ratingAvg);
-    xmlField("starRating", $stars);
-    xmlField("ratingCountAvg", $ratingCntAvg);
-    xmlField("ratingCountTot", $ratingCntTot);
+    if (!$should_hide) {
+        xmlField("averageRating", $ratingAvg);
+        list($stars) = roundStars($ratingAvg);
+        xmlField("starRating", $stars);
+        xmlField("ratingCountAvg", $ratingCntAvg);
+        xmlField("ratingCountTot", $ratingCntTot);
+    }
     echo "</ifdb>";
     
     // main end tags

--- a/www/viewlist
+++ b/www/viewlist
@@ -41,7 +41,7 @@ if (mysql_num_rows($result) == 0) {
         "select gameid as tuid, title, author,
              date_format(published, '%Y') as pubyear,
              (coverart is not null) as hasart,
-             comments, displayorder
+             comments, displayorder, flags
          from
              reclistitems, games
          where
@@ -69,9 +69,11 @@ if ($errMsg) {
     echo "<span class=errmsg>$errMsg</span><br>";
 } else {
 
+    $showFlagged = isset($_GET['showFlagged']) && $_GET['showFlagged'];
+
     // show the list
     showRecList($db, $qlistid, $ownerID, $ownerName, $ownerLoc,
-                $title, $desc, $moddate, $items, "", true);
+                $title, $desc, $moddate, $items, "", true, $showFlagged);
 
     // show some options
     echo "<p><hr class=dots><p>";


### PR DESCRIPTION
This pull request allows moderators to "bury" a game. It's intended to be used when the game is brigaded.

The feature is available on the `/adminops` page, with a new "Bury game" link. You can bury and unbury a game there.

Burying a game has the following effects:

On the game page for buried games:
* There’s a banner at the top. “Links to this page and its ratings have been restricted, due to violations of our Code of Conduct.”
* We hide rating counts, averages, and histograms. Written reviews remain, but it's no longer possible to see how many ratings a game has received.
* The “Playlists and wishlists” section is missing on buried games.
* Buried games have a Google `noindex` instruction, requesting that Google hide this page in search results. (Most search engines support this request.)

In searches, recommended lists, and the `/allnew` page:
* Results would not appear in search results by default, but would show a banner. "Some results were hidden. <ins>See all results</ins>"
* If you click the "See all results" link, all results appear, but with no star rating or ratings count
* On recommended lists, which are numbered, the game's number would be skipped, making it clearer that something is missing.

Buried games would be invisibly hidden in these places:
* Home page "New on IFDB" and "IFDB Recommends"
* `/random` "10 random games" would just not show buried games

**This PR is huge; I recommend reading it commit-by-commit.**