### PR TITLE
Highlight site news in /allnew and home page

### DIFF
--- a/www/newitems.php
+++ b/www/newitems.php
@@ -35,6 +35,23 @@ function getNewItems($db, $limit)
     // start with an empty list
     $items = array();
 
+    // query site news
+    $result = mysql_query(
+        "select
+           itemid as sitenewsid, title, ldesc as `desc`,
+           posted as d,
+           date_format(posted, '%M %e, %Y') as fmtdate
+         from
+           sitenews
+         order by
+           d desc
+         $limit", $db);
+    $sitenewscnt = mysql_num_rows($result);
+    for ($i = 0 ; $i < $sitenewscnt ; $i++) {
+        $row = mysql_fetch_array($result, MYSQL_ASSOC);
+        $items[] = array('S', $row['d'], $row);
+    }
+
     // query the recent games
     $result = mysql_query(
         "select id, title, author, `desc`, created as d,
@@ -403,6 +420,12 @@ function showNewItemList($db, $items, $first, $last, $showFlagged, $allowHiddenB
             echo "</div>";
 			if (ENABLE_IMAGES)
 				echo "</td>";
+        }
+        else if ($pick == 'S')
+        {
+            // it's site news
+            echo "<div class=\"site-news\">IFDB <a href='/news'>site news</a> <span class=notes><i>{$row['fmtdate']}</i></span>"
+                . "<br><div class=indented><b>{$row['title']}</b>: {$row['desc']}</div>";
         }
         else if ($pick == 'L')
         {

--- a/www/newitems.php
+++ b/www/newitems.php
@@ -433,7 +433,7 @@ function showNewItemList($db, $items, $first, $last, $showFlagged, $allowHiddenB
         {
             // it's site news
             echo "<div class=\"site-news\">IFDB <a href='/news'>site news</a> <span class=notes><i>{$row['fmtdate']}</i></span>"
-                . "<br><div class=indented><b>{$row['title']}</b>: {$row['desc']}</div>";
+                . "<br><div class=indented><b>{$row['title']}</b>: {$row['desc']}</div></div>";
         }
         else if ($pick == 'L')
         {


### PR DESCRIPTION
In this PR, site news now appears on the IFDB home page and on the `/allnew` page.

Additionally, if the latest ("freshest") site news is less than one week old, we sort it to the top of the list.

To test this, I logged in as admin, created site news, and then posted a review. The site news sorted to the top of the list, even though the review came second.

To double check, I went into the DB and ran this query:

```sql
update sitenews set posted='2021-03-05' where itemid=77;
```

Where `77` was the itemid of my new site news item. I could see that the site news from days ago appeared above the review from today. Then I set the sitenews date back to `2021-01-17`. The site news returned to its natural sort position in the list.

![image](https://user-images.githubusercontent.com/96150/110415526-e308c180-8046-11eb-8803-851d3f9ba634.png)
