### PR TITLE
Fix RSS dates

### DIFF
--- a/www/commentlog
+++ b/www/commentlog
@@ -291,7 +291,7 @@ for ($i = 0 ; $i < count($comments) ; $i++) {
         // set up the XML data
         list($desc, $len, $trunc) = summarizeHtml($ctxt, 210);
         $desc = fixDesc($desc, FixDescSpoiler | FixDescRSS);
-        $pubDate = date("D, j M Y H:i:s e", strtotime($ccreDT));
+        $pubDate = date("D, j M Y H:i:s ", strtotime($ccreDT)) . 'UT';
         $link = get_root_url() . $link;
 
         // if this is the latest item, send its date as the <lastBuildDate>

--- a/www/game-rss.php
+++ b/www/game-rss.php
@@ -55,7 +55,7 @@ function getGameRssItems($db, $id, $feedType, $gameTitle, $links, $extFeed)
             $rid = $r['reviewid'];
             $rlink = htmlspecialcharx(
                 get_root_url() . "viewgame?id=$id&review=$rid");
-            $rdate = date("D, j M Y H:i:s e", strtotime($r['moddate']));
+            $rdate = date("D, j M Y H:i:s ", strtotime($r['moddate'])) . 'UT';
             list($rdesc, $len, $trunc) = summarizeHtml($r['review'], 210);
             $rdesc = htmlspecialcharx(fixDesc($rdesc));
             $rauth = htmlspecialcharx($r['username']);
@@ -118,7 +118,7 @@ function getGameRssItems($db, $id, $feedType, $gameTitle, $links, $extFeed)
 
             // quote/reformat the fields
             $nuser = htmlspecialcharx($nuser);
-            $rssdate = date("D, j M Y H:i:s e", strtotime($ndate));
+            $rssdate = date("D, j M Y H:i:s ", strtotime($ndate)) . 'UT';
             $nlink = htmlspecialcharx(
                 get_root_url() . "viewgame?id=$id&version=$nvsn");
             $deltas = unserialize($deltas);

--- a/www/news.php
+++ b/www/news.php
@@ -128,7 +128,7 @@ function queryNewsRss(&$items, $db, $sourceType, $sourceID, $maxItems,
         // quote/reformat fields
         $nuname = htmlspecialcharx($nuname);
         $nunameOrig = htmlspecialcharx($nunameOrig);
-        $rssdate = date("D, j M Y H:i:s e", strtotime($ncre));
+        $rssdate = date("D, j M Y H:i:s ", strtotime($ncre)) . 'UT';
         list($rbody, $len, $trunc) = summarizeHtml($body, 210);
         $nbody = htmlspecialcharx(fixDesc($nbody));
 

--- a/www/poll
+++ b/www/poll
@@ -977,7 +977,7 @@ engine to match.
             $quickQuote = rss_encode(htmlspecialcharx($quickQuote));
             $notes = rss_encode(htmlspecialcharx($notes));
             $voteDate = rss_encode(
-                date("D, j M Y H:i:s e", strtotime($voteDate)));
+                date("D, j M Y H:i:s ", strtotime($voteDate))) . 'UT';
 
             echo "<item>\r\n"
                 . "<title>$gameTitle"

--- a/www/reviewcommentlog
+++ b/www/reviewcommentlog
@@ -162,7 +162,7 @@ if ($rss) {
         $title = "$cuname comments on $runame's review of $gtitle";
         list($desc, $len, $trunc) = summarizeHtml($ctxt, 210);
         $desc = fixDesc($desc, FixDescSpoiler | FixDescRSS);
-        $pubDate = date("D, j M Y H:i:s e", strtotime($ccreDT));
+        $pubDate = date("D, j M Y H:i:s ", strtotime($ccreDT)) . 'UT';
         $link = get_root_url() . "viewgame?id=$gid&review=$rid";
 
         // if this is the latest item, send its date as the <lastBuildDate>

--- a/www/showuser
+++ b/www/showuser
@@ -184,7 +184,7 @@ if ($rss == 'gamenews')
 
         // decode this row
         list($gameid, $moddate, $gtitle) = $g;
-        $rssdate = date("D, j M Y H:i:s e", strtotime($moddate));
+        $rssdate = date("D, j M Y H:i:s ", strtotime($moddate)) . 'UT';
         $gtitle = htmlspecialcharx($gtitle);
 
         // First, add a news item for the creation of the profile link.

--- a/www/viewcomp
+++ b/www/viewcomp
@@ -263,7 +263,7 @@ if ($rss)
         // decode this history row
         list($hEd, $hEdName, $hMod, $hVsn, $deltas, $hModRaw) = $history[$i];
         $hEdName = htmlspecialcharx($hEdName);
-        $rssdate = date("D, j M Y H:i:s e", strtotime($hModRaw));
+        $rssdate = date("D, j M Y H:i:s ", strtotime($hModRaw)) . 'UT';
         $dn = deltaDesc($deltas);
         $nlink = htmlspecialcharx(
             get_root_url() . "viewcomp?id=$compID&vsn=$hVsn");


### PR DESCRIPTION
IFDB has a bunch of RSS feeds:

* https://ifdb.org/allnew-rss
* https://ifdb.org/news?rss
* Each game has three feeds:
    * https://ifdb.org/viewgame?id=aearuuxv83plclpl&reviews&rss
    * https://ifdb.org/viewgame?id=aearuuxv83plclpl&downloads&rss
    * https://ifdb.org/viewgame?id=aearuuxv83plclpl&news&rss
* Each user has a couple of feeds:
    * Authored games: https://ifdb.org/showuser?id=xrln6pdkzzbje6r3&rss=gamenews
    * Public Inbox: https://ifdb.org/commentlog?user=oyrrw74upu8n2dds&mode=inbox&rss
* Each competition has a news feed: https://ifdb.org/viewcomp?id=sn15z5e6mxgba5ee&rss
* Each poll has a news feed: https://ifdb.org/poll?id=9qfut6yy8yudnbat&rss

Most of these feeds don't validate according to https://validator.w3.org/feed/check.cgi due to an incorrect time zone. The timezones are all `UTC` but RFC822 requires the timezone `UT` instead. (RSS readers can typically muddle their way through this anyway.)

This PR converts them all to use `UT`.