### PR TITLE
Allow Android devices to use mobile styles

### DIFF
--- a/www/pagetpl.php
+++ b/www/pagetpl.php
@@ -38,13 +38,8 @@ function basePageHeader($title, $focusCtl, $extraOnLoad, $extraHead,
        // add the checkbox javascript if requested
        if ($ckbox)
            ckboxSetup();
-
-       // add iPod/iPhone parameters if applicable
-       if (is_ipod_or_iphone())
-           echo "<meta name=\"viewport\" content=\"width=device-width\">"
-               . "<meta name=\"viewport\" content=\"initial-scale=1.0\">";
-
    ?>
+   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 </head>
 <body<?php
 

--- a/www/util.php
+++ b/www/util.php
@@ -199,16 +199,16 @@ function browser_os_detect()
 }
 
 // --------------------------------------------------------------------------
-// are we on an iPod or iPhone?
+// are we on an iPhone or Android device?
 //
-function is_ipod_or_iphone()
+function is_mobile()
 {
     // get the browser ID string
     $b = $_SERVER['HTTP_USER_AGENT'];
 
     // check for the relevant strings
     return preg_match(
-        "/^Mozilla\/[0-9.]+ \((iPhone|iPod|iPhone Simulator);/",
+        "/^Mozilla\/[0-9.]+ \((iPhone;|iPod;|iPhone Simulator;|Linux; Android)/",
         $b, $match, 0, 0);
 }
 
@@ -419,7 +419,7 @@ function echoStylesheetLink()
 
     // failing that, check to see if we're on an iPod or iPhone - if so,
     // use the special default style sheet for those devices
-    if (!$ssid && is_ipod_or_iphone()) {
+    if (!$ssid && is_mobile()) {
         // the iPod/iPhone style sheet has ID=6 - it's really an ordinary
         // style sheet, created by Craig Smith (craig@ni.com), but it's
         // distinguished as the default style sheet for these devices


### PR DESCRIPTION
I realized today that IFDB does have _very_ basic support for mobile layout, but it was only/explicitly for iPhones and iPods, but not for Android phones.

In this PR, I enable the mobile styles for Android, also.

In util.php, mobile devices are configured to use a user-generated CSS file https://ifdb.org/css?id=6

These mobile styles are better than nothing, but there are a lot of problems with this stylesheet.

1. it's full of invalid CSS comments (`//` is not a comment in CSS, though it does effectively work like one)
2. It hides the "play on-line" button, even though modern iplayif games are typically at least kinda sorta mobile compatible (it hides the `dla-button` download advisor, too, but that may be reasonable)
3. It hides the left side of the top controls, so there's no link to Home, Profile, or Inbox
4. It hides the right side pane of the home page, so there's no way to access any of that stuff
5. It hides the fmtnotes fine print on downloadable files ("For all systems. To play, you'll need a glulx interpreter - visit Brass Lantern for download links."
6. It hides the "rightbar" of games, giving you no way to rate, review, wishlist, or mark played
7. It hides _everything_ called a "rightbar", regardless of whether that makes sense
8. It hides the footer. (Why??)

Despite all of this, it's surprisingly usable, and it's only about 100 lines long. This suggests to me that we could probably import the "good parts" of this stylesheet into the default `ifdb.css` stylesheet and not regret it too much.