### PR TITLE
Fix home page "IFDB Recommends"

### DIFF
--- a/www/home
+++ b/www/home
@@ -394,7 +394,7 @@ if ($loggedIn) {
             "create temporary table rating_space as
              select
                r2.userid as userid,
-               sum((r1.rating - r2.rating)*(r1.rating - r2.rating))
+               sum(power(cast(r1.rating as signed) - cast(r2.rating as signed), 2))
                  / count(r2.gameid) as dist,
                count(r2.gameid) as cnt
              from

--- a/www/home
+++ b/www/home
@@ -526,6 +526,8 @@ if ($loggedIn) {
                        and not (games.flags & " . FLAG_SHOULD_HIDE . ")
                      group by
                        games.id
+                     having
+                       count(reviews.rating) >= 5
                      order by
                        avgrating desc
                      limit


### PR DESCRIPTION
Fixes https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/192

This query was failing with this error:

    ERROR 1690 (22003): BIGINT UNSIGNED value is out of range in '`ifdb`.`r1`.`rating` - `ifdb`.`r2`.`rating`'

r2.rating could be bigger than r1.rating, which would result in overflow. Casting the ratings to signed integers fixes this.

https://stackoverflow.com/questions/11698613/bigint-unsigned-value-is-out-of-range-my-sql
http://dev.mysql.com/doc/refman/5.5/en/out-of-range-and-overflow.html

In addition, I fixed an issue where it was only recommending games with high average rating i.e. games with one or two 5-star reviews. The recommendations seem plausible to me now.