### PR TITLE
Remove broken Baf's guide links

### DIFF
--- a/www/viewgame
+++ b/www/viewgame
@@ -3117,12 +3117,6 @@ dispTags();
                 . "\", null);\n";
         }
 
-        // generate the Baf's Guide link if we have one
-        if ($bafsid) {
-            echo "addLinkItem(\"Baf's Guide\", \"http://www.wurb.com/if\", "
-                . "\"/game/" . $bafsid . "\");\n";
-        }
-
         // generate a run-time check for an IF Wiki link, if we have an IFID
         if (count($ifids) > 0) {
             $jifid = str_replace("\"", "&#34;", $ifids[0]);

--- a/www/viewgame
+++ b/www/viewgame
@@ -2093,7 +2093,7 @@ if (count($inrefs) != 0 && !$historyView) {
 
                     // Baf's Guide
                     $showBody = true;
-                    $txt .= "<h3><a href=\"http://www.wurb.com/if";
+                    $txt .= "<h3><a href=\"https://web.archive.org/web/20110100000000/https://www.wurb.com/if";
                     if (!isEmpty($bafsid))
                         $txt .= "/game/$bafsid";
                     $txt .= "\" title=\"Go to Baf's Guide to the IF Archive\">"


### PR DESCRIPTION
Remove the "[Game Title] at Baf's Guide" links from the bottom of the page. Fixes https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/206