### PR TITLE
Fix minor mobile bugs

### DIFF
--- a/www/home
+++ b/www/home
@@ -128,7 +128,7 @@ else {
     // get the latest games, reviews, and lists, and show a mix
     if (showNewItems($db, 0, 5, false, false, false))
         echo "<p><span class=details><a href=\"allnew\">"
-            . "See the full list...</a></span>";
+            . "See the full list...</a></span></p>";
 }
 
 //         </div>
@@ -140,8 +140,7 @@ else {
       ?>
 
       </div>
-      <table>
-         <tr valign=top>
+      <div class=twocol>
 
 
 <?php
@@ -244,8 +243,8 @@ $colClass = "firstcol";
 // 
 $rows = $pollRows;
 if (count($rows) > 0) {
-    echo "<td width=\"$colWidth\">"
-        . "<p><table class=\"halfcol\" cellpadding=0 cellspacing=0>"
+    echo "<div width=\"$colWidth\">"
+        . "<table class=\"halfcol\" cellpadding=0 cellspacing=0>"
         . "<tr><td class='$colClass'><div class=\"headline\">Vote!</div>"
         . "<div style=\"margin-bottom: 1ex;\">"
         . "Help other IFDB members find the games they're looking for "
@@ -279,7 +278,7 @@ if (count($rows) > 0) {
 
 //  ------------------------ end poll sampler box ---------------------------
 ?>
-            </td>
+            </div>
 
 
             <?php
@@ -287,7 +286,7 @@ if (count($rows) > 0) {
             ?>
 
 
-            <td width="<?php echo $colWidth ?>">
+            <div width="<?php echo $colWidth ?>">
                <table class="halfcol" cellpadding=0 cellspacing=0>
                   <tr>
                      <td class="<?php echo $colClass; $colClass=""; ?>">
@@ -337,14 +336,13 @@ if (!detectMetaInstaller())
                      </td>
                   </tr>
                </table>
-            </td>
+            </div>
 
             <?php
 // ----------------------- End New To IF? Box ---------------------------
             ?>
-
-         </tr>         
-      </table>
+         
+      </div>
       <?php
 // ------------------------- end bottom row extra stuff table ----------------
       ?>

--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -979,15 +979,13 @@ div.headline {
     font-weight: normal;
     color: #000080;
     margin: 2em 0 1em 0;
-    position: relative;
+    display: flex;
+    justify-content: space-between;
 }
 div.headline1 {
     margin-top: 0;
 }
 span.headlineRss {
-    position: absolute;
-    right: 4px;
-    top: 2px;
     text-align: right;
     vertical-align: middle;
     font:  70% Verdana, Arial, Helvetica, Sans-Serif;

--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -994,15 +994,21 @@ span.headlineRss {
     font-weight: normal;
 }
 
-table.halfcol tr td {
-    border-left: 1em solid transparent;
-}
-table.halfcol tr td.firstcol {
-    border-left: none;
-}
-table.halfcol div.headline {
-}
+@media (min-width: 100ch) {
+    .twocol {
+        display: flex;
+    }
+    .twocol > div {
+        flex-basis: 50%;
+    }
+    table.halfcol tr td {
+        border-left: 1em solid transparent;
+    }
+    table.halfcol tr td.firstcol {
+        border-left: none;
+    }
 
+}
 /*
 The "rightbar" table style is used for the little information
 boxes at the right of the home page and some other pages.


### PR DESCRIPTION
1. The home page prefers to put the "Vote!" and "New to IF?" sections side-by-side, but that's not a good fit on mobile. On narrow screens, we now convert these to blocks in a single column.

![image](https://user-images.githubusercontent.com/96150/111280929-a0705780-85f9-11eb-9239-a9654794235c.png)

2. When viewing the site in Desktop mode, the RSS links would overlap the text. They were using absolute positioning; now we use flexbox instead.

![image](https://user-images.githubusercontent.com/96150/111281061-c4339d80-85f9-11eb-8246-b793c7878e70.png)
