### PR TITLE
Ensure reviews and descriptions aren't too wide

### DIFF
--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -164,6 +164,8 @@ div.topbar {
     width: 100%;
     background: url("/ifdb-topbar.jpg") #c0c0c0 no-repeat;
     height: 55px;
+    max-width: 100ch;
+    margin: 0 auto;
 }
 a.topbar {
     height: 55px;
@@ -181,10 +183,11 @@ div.topctl {
     font:  100%/140% Verdana, Arial, Helvetica, Sans-Serif;
     width: 100%;
     padding: 0 0 0 0;
-    margin: 0 0 1em 0;
+    margin: 0 auto 1em auto;
     font-size: 95%;
     background: #e8e8e8;
     border-bottom: thin dotted #d0d0d0;
+    max-width: calc(100ch / 0.95);
 }
 div.topctl table {
     margin: 0 0 0 0;
@@ -2126,7 +2129,6 @@ span.sfl-save-autodesc {
         background: url("/dark-images/ifdb-smalltopbar-midnight.jpg") #000030 no-repeat;
     }
     div.topctl {
-        font: 11pt/15pt Verdana, Arial, Helvetica, Sans-Serif;
         background: #202040;
         border-bottom: thin dotted #303060;
     }

--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -181,7 +181,7 @@ div.topctl {
     font:  100%/140% Verdana, Arial, Helvetica, Sans-Serif;
     width: 100%;
     padding: 0 0 0 0;
-    margin: 0 0 2em 0;
+    margin: 0 0 1em 0;
     font-size: 95%;
     background: #e8e8e8;
     border-bottom: thin dotted #d0d0d0;
@@ -214,7 +214,9 @@ order to make the main contents more readable, we add some actual
 margins here.
 */
 div.main {
-    margin: 1em 1em 1em 1em;
+    max-width: 100ch;
+    padding: 1em 1em 1em 1em;
+    margin: 0 auto;
 }
 
 /*
@@ -853,6 +855,10 @@ spacing on any side.
 */
 p.nosp {
     margin: 0 0 0 0;
+}
+
+p {
+    max-width: 60ch;
 }
 
 /*

--- a/www/reviews.php
+++ b/www/reviews.php
@@ -387,7 +387,7 @@ function showReview($db, $gameid, $rec, $specialNames, $optionFlags = 0)
     }
 
     // show the review body
-    echo "$review<br>";
+    echo "<p>$review</p>";
 
     // set up the comment controls, if applicable
     $commentCtls = $barCommentCtl = "";

--- a/www/viewgame
+++ b/www/viewgame
@@ -1782,7 +1782,7 @@ if ($embargoCnt > 0)
     if (!isEmpty($desc) && ($detailView || $historyView)) {
 ?>
          <h3>About the Story</h3>
-         <?php echo $desc ?>
+         <p><?php echo $desc ?></p>
 <?php
     }
 
@@ -2331,7 +2331,7 @@ if (count($inrefs) != 0 && !$historyView) {
 
         ?>
 
-        <span id="tagPre" class=details></span>
+        <p><span id="tagPre" class=details></span>
         <span class=details style="margin-left: 1ex;">
            - <a href="showtags?limit=50">View the most common tags</a>
            (<?php echo helpWinLink("help-tags", "What's a tag?")
@@ -2339,7 +2339,7 @@ if (count($inrefs) != 0 && !$historyView) {
 //           onclick="javascript:helpWin('help-tags');return false;"
 //           >What's a tag?</a>
            ?>)
-        </span>
+        </span></p>
         <div class=indented>
            <table id="tagTable" border=0 class=tags>
            </table>


### PR DESCRIPTION
On my MacBook Pro, I set my resolution pretty high in settings; IFDB displays very long lines by default. I find it hard to skim paragraphs that wide.

In this PR, I limit `<p>` tags to `60ch` wide and the main/topbar/topctl `<div>`s to `100ch`. It leaves some awkward whitespace, but the text flows a lot better IMO.

![image](https://user-images.githubusercontent.com/96150/111293597-ac164b00-8606-11eb-8715-5fd1ac306c2e.png)

![image](https://user-images.githubusercontent.com/96150/111677913-f2250780-87dc-11eb-9c20-80c85aaea1fe.png)



