### PR TITLE
Allow admins to see helpful/unhelpful review votes

### DIFF
--- a/www/adminops
+++ b/www/adminops
@@ -127,6 +127,148 @@ if (isset($_REQUEST['burygame'])) {
     exit();
 }
 
+if (isset($_REQUEST['reviewvotes'])) {
+    if (isset($_REQUEST['reviewid'])) {
+        $reviewid = $_REQUEST['reviewid'];
+        $rid = htmlspecialcharx($_REQUEST['reviewid']);
+        $result = mysql_query("select
+            userid, name, sandbox, vote
+            from reviewvotes
+            join users on userid = users.id
+            where reviewid=" . mysql_real_escape_string($reviewid, $db) . "
+            order by vote, sandbox, name", $db);
+        pageHeader("Review votes");
+        if (!$result) {
+            error_log(mysql_error($db));
+            echo "There was an error finding this review.";
+            pageFooter();
+            exit();
+        }
+        if (mysql_num_rows($result) == 0) {
+            echo "This review has no votes: $rid";;
+            pageFooter();
+            exit();
+        }
+
+        ?>
+        <h1>Review votes</h1>
+        <p>Review votes for review ID <?php echo $rid ?><p>
+        <table><tr><th>User</th><th>Sandbox</th><th>Vote</th></tr>
+        <?php
+        for ($i = 0 ; $i < mysql_num_rows($result) ; $i++) {
+            list($userid, $name, $sandbox, $vote) = mysql_fetch_row($result);
+            echo "<td><a href=\"/adminops?reviewvotes&userid=".htmlspecialcharx($userid)."\">";
+            echo htmlspecialcharx($name);
+            echo "</a></td><td>".htmlspecialcharx($sandbox)."</td>";
+            echo "<td>".htmlspecialcharx($vote)."</td></tr>\n";
+        }
+        echo "</table>\n";
+    } else if (isset($_GET['userid'])) {
+        $userid = $_GET['userid'];
+        $result = mysql_query("select
+            name
+            from users
+            where id='" . mysql_real_escape_string($userid, $db) . "'", $db);
+        pageHeader("Review votes");
+        if (!$result) {
+            error_log(mysql_error($db));
+            echo "There was an error finding this user.";
+            pageFooter();
+            exit();
+        }
+        list($name) = mysql_fetch_row($result);
+
+        $votername = htmlspecialcharx($name);
+        echo "<h1>Review votes: $votername</h1>";
+
+        $result = mysql_query("select
+            reviews.userid as userid,
+            users.name as name,
+            count(reviewid) as count,
+            sum(case when vote = 'Y' then 1 else 0 end) as helpful
+            from reviewvotes
+            join reviews on reviewid = reviews.id
+            join users on reviews.userid = users.id
+            where reviewvotes.userid = '" . mysql_real_escape_string($userid, $db) ."'
+            group by reviews.userid, users.name
+            order by count(reviewid) desc
+        ", $db);
+
+        if (!$result) {
+            error_log(mysql_error($db));
+            echo "There was an error loading this user's review votes.";
+            pageFooter();
+            exit();
+        }
+
+        ?>
+        <h2>Summary</h2>
+        <table>
+        <tr><th>Review Author</th><th>Count</th><th>% Helpful?</th></tr>
+        <?php
+        for ($i = 0 ; $i < mysql_num_rows($result) ; $i++) {
+            list($reviewuserid, $name, $count, $helpful) = mysql_fetch_row($result);
+            echo "<tr><td><a href=\"showuser?id=$reviewuserid\">".htmlspecialcharx($name)."</td>";
+            echo "<td>$count</td><td>".(round($helpful / $count * 100))."%</td></tr>\n";
+        }
+        echo "</table><hr>";
+
+        $result = mysql_query("select
+            games.id as gameid,
+            games.title as title,
+            games.author as author,
+            reviews.userid as userid,
+            users.name as username,
+            reviews.id as reviewid,
+            reviews.rating as rating,
+            reviews.summary as summary,
+            reviews.review as review,
+            reviews.moddate as moddate,
+            date_format(reviews.moddate, '%M %e, %Y') as moddatefmt,
+            vote
+            from reviewvotes
+            join reviews on reviewid = reviews.id
+            join games on gameid = games.id
+            join users on reviews.userid = users.id
+            where reviewvotes.userid = '" . mysql_real_escape_string($userid, $db) ."'
+            order by gameid, vote, reviews.moddate
+        ", $db);
+        if (!$result) {
+            error_log(mysql_error($db));
+            echo "There was an error loading this user's review votes.";
+            pageFooter();
+            exit();
+        }
+
+        include "reviews.php";
+        $specialNames = initSpecialNames($db);
+        
+        for ($i = 0 ; $i < mysql_num_rows($result) ; $i++) {
+            $rec = mysql_fetch_array($result, MYSQL_ASSOC);
+
+            // display the game information
+            $gameid = $rec['gameid'];
+            $title = htmlspecialcharx($rec['title']);
+            $author = htmlspecialcharx($rec['author']);
+            echo "<div style=\"margin-bottom:0.5em;\">"
+                . "<a href=\"viewgame?id=$gameid\"><b><i>$title</i></b></a>"
+                . ", by $author</div>";
+
+            echo "<div class=indented>";
+
+            echo "<p>$votername voted this review <b>" . ($rec['vote'] === 'Y' ? "helpful" : "unhelpful")  . "</b></p>";
+            
+            showReview($db, $gameid, $rec, $specialNames, 3 /*SHOWREVIEW_NOVOTECTLS & SHOWREVIEW_NOCOMMENTCTLS*/);
+
+            // end the listing
+            echo "</div>";
+        }
+
+    }
+    pageFooter();
+    exit();
+}
+
 if (isset($_REQUEST['showimage'])) {
     list($imgdata, $fmt) = fetch_image($_REQUEST['showimage'], true);
     if (is_null($imgdata))

--- a/www/allreviews
+++ b/www/allreviews
@@ -20,6 +20,10 @@ include_once "util.php";
 include_once "dbconnect.php";
 $db = dbConnect();
 
+if ($curuser) {
+    $adminPriv = check_admin_privileges($db, $curuser);
+}
+
 include "reviews.php";
 $specialNames = initSpecialNames($db);
 
@@ -265,7 +269,7 @@ if ($errMsg) {
             // display it
             if ($rec['review'] != "") {
                 // we have a full review
-                showReview($db, $gameid, $rec, $specialNames);
+                showReview($db, $gameid, $rec, $specialNames, 0 | ($adminPriv ? SHOWREVIEW_ADMINREVIEWVOTESLINK : 0));
             } else {
                 // we have a rating only
                 echo "$username's Rating: " . showStars($rec['rating'])

--- a/www/reviews.php
+++ b/www/reviews.php
@@ -231,6 +231,7 @@ function popupMenuKey(e, id)
 define("SHOWREVIEW_NOVOTECTLS", 0x0001);
 define("SHOWREVIEW_NOCOMMENTCTLS", 0x0002);
 define("SHOWREVIEW_COMMENTCTLSADDONLY", 0x0004);
+define("SHOWREVIEW_ADMINREVIEWVOTESLINK", 0x0008);
 
 function showReview($db, $gameid, $rec, $specialNames, $optionFlags = 0)
 {
@@ -240,6 +241,7 @@ function showReview($db, $gameid, $rec, $specialNames, $optionFlags = 0)
     $showVoteCtls = !($optionFlags & SHOWREVIEW_NOVOTECTLS);
     $showCommentCtls = !($optionFlags & SHOWREVIEW_NOCOMMENTCTLS);
     $addCommentOnly = ($optionFlags & SHOWREVIEW_COMMENTCTLSADDONLY);
+    $adminReviewVotes = ($optionFlags & SHOWREVIEW_ADMINREVIEWVOTESLINK);
     
     // get the current user, if we're logged in
     checkPersistentLogin();
@@ -319,7 +321,7 @@ function showReview($db, $gameid, $rec, $specialNames, $optionFlags = 0)
         if ($helpful != 0 || $unhelpful != 0) {
             echo "<p><div class=smallhead><span class=details>$helpful of
                   $totalvotes people found the following review helpful:
-                 </span></div>";
+                 ".($adminReviewVotes ? "<a href=\"/adminops?reviewvotes&reviewid=$reviewid\">Admin: Who?</a>" : "")."</span></div>";
         }
     }
 

--- a/www/viewgame
+++ b/www/viewgame
@@ -2317,7 +2317,7 @@ if (count($inrefs) != 0 && !$historyView) {
             // show the reviews
             for ($i = 0 ; $i < mysql_num_rows($result) ; $i++)
                 showReview($db, $id, mysql_fetch_array($result, MYSQL_ASSOC),
-                           $specialNames);
+                           $specialNames, 0 | ($adminPriv ? SHOWREVIEW_ADMINREVIEWVOTESLINK : 0));
         }
 
         // end the indented division if we started one
@@ -2814,7 +2814,7 @@ dispTags();
                 $reviewRec = mysql_fetch_array($result, MYSQL_ASSOC);
 
                 // show it
-                showReview($db, $id, $reviewRec, $specialNames);
+                showReview($db, $id, $reviewRec, $specialNames, 0 | ($adminPriv ? SHOWREVIEW_ADMINREVIEWVOTESLINK : 0));
             }
 
             // show the link to the full list of reviews, if there are more
@@ -3204,7 +3204,7 @@ dispTags();
             // list the comments below and thus don't need the control
             // to show more of them.
             showReview($db, $id, $reviewRec, $specialNames,
-                       SHOWREVIEW_COMMENTCTLSADDONLY);
+                       SHOWREVIEW_COMMENTCTLSADDONLY | ($adminPriv ? SHOWREVIEW_ADMINREVIEWVOTESLINK : 0));
 
             // end the nested division that the header opens
             echo "</div>";
@@ -3324,7 +3324,7 @@ dispTags();
             // now show the reviews
             for ($i = $firstOnPage ; $i <= $lastOnPage ; $i++) {
                 showReview($db, $id, mysql_fetch_array($result, MYSQL_ASSOC),
-                           $specialNames);
+                           $specialNames, 0 | ($adminPriv ? SHOWREVIEW_ADMINREVIEWVOTESLINK : 0));
             }
 
             // show the page controls again at the bottom of the review list


### PR DESCRIPTION
Fixes https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/48

When logged in as an admin, each review has a link:

![image](https://user-images.githubusercontent.com/96150/111849287-73a69380-88ca-11eb-8b4d-44ef640e6830.png)

You can click that link to go to `/adminops?reviewvotes?reviewid=#####` to see who voted helpful/unhelpful for a given review. If you click on the user's name, you'll go to `/adminops?reviewvotes&userid=#####` to see a summary of that user's helpful/unhelpful votes, followed by a complete list of all of the reviews on which they voted helpful unhelpful.

You'll find that there's a bit of an issue with _testing_ this PR in local dev: the IFDB IFArchive scrubber scrubs the identities of all votes! Therefore, all reviews in local dev will say, "This review has no votes: 59797" even though it clearly _does_ have votes.

So, uh, all testing will have to happen on dev.ifdb.org.