### PR TITLE
Remove broken Baf's Guide link on Edit Game page

### DIFF
--- a/www/editgame-util.php
+++ b/www/editgame-util.php
@@ -131,9 +131,7 @@ $fields = array(
           . helpWinLink("help-forgiveness", "Details"),
           array("Merciful", "Polite", "Tough", "Nasty", "Cruel"), TypeString),
     array("<i>Baf's Guide</i> ID", "bafsid", 10,
-          "Integer identifier assigned by
-           <a target=\"_blank\" href=\"http://www.wurb.com/if\">Baf's
-             Guide</a> - "
+          "Integer identifier assigned by Baf's Guide - "
           . helpWinLink("help-bafs", "How do I find this?"),
           null, TypeInt),
     array("Web site", "website", 60,


### PR DESCRIPTION
The "Baf's Guide ID" section of the Edit Game page has a broken link to Baf's Guide. Eventually I think we will hide or delete the Baf's ID field, but in the meantime, we can at least remove the broken link.

Relates to https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/205