### PR TITLE
Fix broken Baf's Guide link on search page

### DIFF
--- a/www/search
+++ b/www/search
@@ -1023,7 +1023,10 @@ else if ($searchType == "member") {
           at least one story file or application download link. 
 
        <p><b>bafs:<i>id</i></b> searches for the game with the given
-          <a href="http://www.wurb.com/if">Baf's Guide</a> ID.
+	      Baf's Guide ID.
+       (<?php
+          echo helpWinLink("help-bafs", "What's a Baf's Guide ID?");
+       ?>)
 
        <p><b>ifid:<i>xxx</i></b> searches for a game with the given IFID.
        (<?php


### PR DESCRIPTION
Remove broken Baf's Guide link on the search page. Instead, link to an explanation of "Baf's Guide ID," similar to the way "IFID" is handled on that page.

Fixes iftechfoundation/ifdb-suggestion-tracker#228