### PR TITLE
Fix broken Baf's link on recommendations help page

### DIFF
--- a/www/help-crossrec
+++ b/www/help-crossrec
@@ -10,7 +10,8 @@ helpPageHeader("Automatic Recommendations");
 <p>The recommendations on the IFDB home page are "algorithmic" -
 they're picked by the computer based on statistics in the database.
 They're <i>not</i> paid ads - they're based purely on ratings from our
-members and review sites like <a href=\"http://www.wurb.com/if"
+members and review sites like 
+<a href="https://web.archive.org/web/20110109233058/http://www.wurb.com/if"
 target="_blank">Baf's Guide</a>.  We're not being paid to promote one
 game over another.
 


### PR DESCRIPTION
(To get to this help page, go to the the "IFDB recommends" section at the bottom of the home page, and click the link to explain the recommendations.)

Replace broken Baf's Guide link with Wayback link.

Fixes https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/230