### PR TITLE
Wrap Baf's guide reviews in <p> tags so they wrap properly

### DIFF
--- a/www/viewgame
+++ b/www/viewgame
@@ -2017,7 +2017,7 @@ if (count($inrefs) != 0 && !$historyView) {
                         $txt .= "/game/$bafsid";
                     $txt .= "\" title=\"Go to Baf's Guide to the IF Archive\">"
                             . "$specialname</a></h3>"
-                            . "<div class=smallhead>$stars<br></div>";
+                            . "<div class=smallhead>$stars<br></div><p>";
 
                 } else if ($code == 'external') {
 


### PR DESCRIPTION
This limits the width of Baf's guide reviews to `60ch`.

https://ifdb.org/viewgame?id=op0uw1gn1tjqmjt7

![image](https://user-images.githubusercontent.com/96150/111899518-494bf780-89ea-11eb-8101-2bcf1e524d94.png)
