### PR TITLE
Make the header stick to the top of the screen

### DIFF
--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -150,6 +150,12 @@ h3 {
     margin-bottom: 0px;
 }
 
+header {
+    position: -webkit-sticky;
+    position: sticky;
+    top: 0;
+}
+
 /*
 The "topbar" division is the area where we display the main IFDB
 banner identifying the site.  The color setting is chosen so that the

--- a/www/pagetpl.php
+++ b/www/pagetpl.php
@@ -109,43 +109,45 @@ function pageHeader($title, $focusCtl = false, $extraOnLoad = false,
 
     // add the top bar for a regular window
 ?>
-<div class="topbar">
-   <div class="topbar-right">
-      <a class="topbar" href="/"><!--
-         <img src="/ifdb-topbar.jpg" border=0> --></a>
-   </div>
-</div>
+<header>
+    <div class="topbar">
+    <div class="topbar-right">
+        <a class="topbar" href="/"><!--
+            <img src="/ifdb-topbar.jpg" border=0> --></a>
+    </div>
+    </div>
 
-<div class="topctl">
-   <form method="get" action="/search" name="search">
-      <table width="100%" border=0 cellspacing=0 cellpadding=0>
-         <tr valign=baseline>
-            <td align=left>
-               <?php echo $homearrow ?>
-               <a id="topbar-home" href="/">Home</a>
-               | <?php echo $profarrow ?><a id="topbar-profile" href="/showuser">Profile</a>
-               - <?php echo $editprofarrow ?><a id="topbar-edit" href="/editprofile">Edit</a>
-               | <?php echo $yourarrow ?><a id="topbar-personal" href="/personal"><b>Your Page</b></a>
-               | <?php echo $commentarrow ?><a id="topbar-inbox" href="/commentlog?mode=inbox">
-                  Your Inbox</a>
-            </td>
-            <td align=right>
-               <a id="topbar-browse" href="/search?browse">Browse</a> |
-               <a id="topbar-search" href="/search">Search</a> Games
-               <input id="topbar-searchbar" type="text" size=30 name="searchbar" value="">
-               <button class="go-button" id="topbar-search-go-button"
-                   style="margin:0 0 0 0;padding:0 0 0 0;"></button>
-               &nbsp; | &nbsp; <?php
-if (isset($_SESSION['logged_in']) && $_SESSION['logged_in'])
-    echo "<a id=\"topbar-logout\" href=\"/logout\">Log Out</a>";
-else
-    echo "<a id=\"topbar-login\" href=\"/login\">Log In</a>";
-               ?>
-            </td>
-         </tr>
-      </table>
-   </form>
-</div>
+    <div class="topctl">
+    <form method="get" action="/search" name="search">
+        <table width="100%" border=0 cellspacing=0 cellpadding=0>
+            <tr valign=baseline>
+                <td align=left>
+                <?php echo $homearrow ?>
+                <a id="topbar-home" href="/">Home</a>
+                | <?php echo $profarrow ?><a id="topbar-profile" href="/showuser">Profile</a>
+                - <?php echo $editprofarrow ?><a id="topbar-edit" href="/editprofile">Edit</a>
+                | <?php echo $yourarrow ?><a id="topbar-personal" href="/personal"><b>Your Page</b></a>
+                | <?php echo $commentarrow ?><a id="topbar-inbox" href="/commentlog?mode=inbox">
+                    Your Inbox</a>
+                </td>
+                <td align=right>
+                <a id="topbar-browse" href="/search?browse">Browse</a> |
+                <a id="topbar-search" href="/search">Search</a> Games
+                <input id="topbar-searchbar" type="text" size=30 name="searchbar" value="">
+                <button class="go-button" id="topbar-search-go-button"
+                    style="margin:0 0 0 0;padding:0 0 0 0;"></button>
+                &nbsp; | &nbsp; <?php
+    if (isset($_SESSION['logged_in']) && $_SESSION['logged_in'])
+        echo "<a id=\"topbar-logout\" href=\"/logout\">Log Out</a>";
+    else
+        echo "<a id=\"topbar-login\" href=\"/login\">Log In</a>";
+                ?>
+                </td>
+            </tr>
+        </table>
+    </form>
+    </div>
+</header>
 
 <div class="main">
 <?php


### PR DESCRIPTION
I'm… not sure if I like this. It seems especially wasteful on iOS, where there's a one-tap shortcut to scroll up to the top of the screen, and where the header bar is currently particularly useless, due to https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/216 and https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/217.

(Click for full-size images)

<img src="https://user-images.githubusercontent.com/96150/111948359-43165380-8a9c-11eb-820a-abafbffd5739.png" height=400> <img src="https://user-images.githubusercontent.com/96150/111948424-5e815e80-8a9c-11eb-8a19-7bcc9a97dbf9.png" height=400>

