### PR TITLE
Fix unmatched HTML tags

### DIFF
--- a/www/pagetpl.php
+++ b/www/pagetpl.php
@@ -160,7 +160,7 @@ function pageFooter()
 <a class="nav" id="footer-tos" href="/tos">Terms of Service</a> |
 <a class="nav" id="footer-privacy" href="/privacy">Privacy</a> |
 <a class="nav" id="footer-copyright" href="/copyright">Copyrights &amp; Trademarks</a>
-</a></div>
+</div>
 
 </div>
 </body>


### PR DESCRIPTION
* In the main page, the `<div style="width:100%;">` at the top was never closed.
* In the "IFDB Recommends" section, a `<div>` was opened without being closed.
* In the "New on IFDB" and "In the Database" sections, a `</div>` was closed without being opened. I removed the closing tags.
* In the footer, there was an extra `</a>`.