### PR TITLE
Fix failure to detect closed tags in fixDesc

### DIFF
--- a/www/util.php
+++ b/www/util.php
@@ -1234,7 +1234,7 @@ function fixDesc($desc, $specials = 0)
                         // open tag.
                         if (in_array($tagName, $tagStack)) {
                             // close tags until we match up with the open
-                            while ($tagSp > 0) {
+                            while ($tagSp >= 0) {
                                 // pop the current tag
                                 $curTag = $tagStack[$tagSp--];
 


### PR DESCRIPTION
The function `fixDesc` is used when truncating reviews in order to embed them in other pages.
For example, the main page has review snippets in the "New on IFDB" section.

The function tries to detect opening and closing of HTML tags, and if any are open at the point of truncation, it adds closing tags.

Due to a bug, it fails to properly detect closing tags, and ends up with this behavior:
```
$ php -a
php > include_once "www/util.php";
php > echo fixDesc("hello <I>world</I> bla bla");
hello <I>world</I> bla bla</i>
```
The expected output is `hello <I>world</I> bla bla`.

This dangling `</i>` is currently causing a small markup error on the main page, with a review that uses italics.

The code tracks opened tags in the `$tagStack` array, and uses `$tagSp` to indicate the index of the head of the stack.
When the scanner encounters a closing tag, it tries to match it with an opening tag and remove it from the stack. But the condition in the loop `while ($tagSp > 0)` is wrong, and ignores cases when the stack has a single item.