### PR TITLE
Hide private emails in the adminops user list

### DIFF
--- a/www/adminops
+++ b/www/adminops
@@ -770,6 +770,8 @@ else if (isset($_REQUEST['users'])) {
              $created, $login) =  mysql_fetch_row($result);
         $name = htmlspecialcharx($name);
         $email = htmlspecialcharx($email);
+		$email = spoilerWarning($email, "Click to see email");
+		$email .=spoilerWarningScript();
         $pubmail = htmlspecialcharx($pubmail);
         $stat = isset($statMap[$statCode]) ? $statMap[$statCode] : "";
         $proStat = isset($proStatMap[$proStat]) ? $proStatMap[$proStat] : "";

--- a/www/adminops
+++ b/www/adminops
@@ -770,8 +770,8 @@ else if (isset($_REQUEST['users'])) {
              $created, $login) =  mysql_fetch_row($result);
         $name = htmlspecialcharx($name);
         $email = htmlspecialcharx($email);
-		$email = spoilerWarning($email, "Click to see email");
-		$email .=spoilerWarningScript();
+        $email = spoilerWarning($email, "Click to see email");
+        $email .=spoilerWarningScript();
         $pubmail = htmlspecialcharx($pubmail);
         $stat = isset($statMap[$statCode]) ? $statMap[$statCode] : "";
         $proStat = isset($proStatMap[$proStat]) ? $proStatMap[$proStat] : "";


### PR DESCRIPTION
Related to https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/46 and https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/265

In the user list on the adminops page, hide user's private email addresses behind a spoiler button. (The background color of the spoiler button doesn't exactly go with this table, with its alternating color rows, but I don't know what to do about that.)