### PR TITLE
Delete "previously" from helpful vote notification

### DIFF
--- a/www/reviews.php
+++ b/www/reviews.php
@@ -153,7 +153,7 @@ function displayReviewVote(reviewID, vote)
 	    } 
 	    else {	    
         	document.getElementById("voteStat_" + reviewID).innerHTML =
-       	  	   "<br>(You previously voted "
+       	  	   "<br>(You voted "
 	   	  	   + (vote == 'Y' ? "Yes" : "No")
 	   	  	   + ")";
 	    	document.getElementById("voteRemove_" + reviewID).innerHTML = "<a href=\"needjs\" "


### PR DESCRIPTION
Immediately after voting a review helpful, the user would see the message "You previously voted Yes," which was causing confusion.

Delete the word "previously."

Closes https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/75

Closes https://github.com/iftechfoundation/ifdb/issues/54