### PR TITLE
Add "Create a Poll" link on the Browse Polls page

### DIFF
--- a/www/search
+++ b/www/search
@@ -1370,6 +1370,14 @@ else if ($term || $browse)
             echo "</div>";
         }
 
+        // if this is a poll search, show the poll tip box
+            if ($searchType == "poll") {
+                echo "<div class=tipbox><h1><a href=\"poll?id=new\">Create a Poll</a></h1>"
+                    . "If you'd like recommendations for a specific kind of IF, you can "
+                    . "<a href=\"poll?id=new\">create a new poll</a>."
+                    . "</div>";
+        }
+		
         // show the sorting controls
         $hids = array("searchfor" => $term);
         if ($browse)


### PR DESCRIPTION
Add a tip box that links to the "Create a Poll" page when you are browsing polls. This is modeled after the tip boxes that show up when you Browse/Search games, so like those, it shows up (1) when you are browsing and (2) when you are searching and there are search results.

It does not show up when you click to search polls, and have not entered any search terms (the search tips page). I'm not sure if we wanted something there as well, and if so, what (this same tip box? A text link within the search tips?).

Relates to https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/227