### PR TITLE
Force browsers to revalidate CSS and JS cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,5 +4,5 @@ RUN docker-php-ext-install mysqli
 RUN apt-get update -y && apt-get install -y zlib1g-dev libpng-dev libjpeg-dev
 RUN docker-php-ext-configure gd --with-jpeg
 RUN docker-php-ext-install gd
-RUN a2enmod rewrite
+RUN a2enmod rewrite headers
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"

--- a/www/.htaccess
+++ b/www/.htaccess
@@ -11,6 +11,10 @@ ErrorDocument 503 /error503
   Deny from All
 </FilesMatch>
 
+<FilesMatch "\.(css|js)$">
+  Header set Cache-Control "no-cache"
+</FilesMatch>
+
 RewriteEngine on
 Options FollowSymLinks
 RewriteBase /


### PR DESCRIPTION
Fixes https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/251

This is deployed to dev.ifdb.org. If you view https://dev.ifdb.org/ifdb.css in Chrome dev tools you can see it now has a `Cache-Control: no-cache` header.