### PR TITLE
Update editprofile page to say "Settings"

### DIFF
--- a/www/editprofile
+++ b/www/editprofile
@@ -619,14 +619,14 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST'
 }
 
 // start the page
-pageHeader("Update Profile", "editprofile.email", false,
+pageHeader("Update Settings", "editprofile.email", false,
            "<script src='xmlreq.js'></script");
 imageUploadScripts();
 captchaSupportScripts($captchaKey);
 
 ?>
 
-<h1>Update Profile</h1>
+<h1>Update Settings</h1>
 
 <?php
     if ($errFlagged)
@@ -639,7 +639,7 @@ captchaSupportScripts($captchaKey);
 
     if ($changed)
         echo "<p><span class=success><b>
-           Your profile has been updated.</b></span>";
+           Your settings have been updated.</b></span>";
 
     if ($emailChanged && !$errFlagged)
         echo "<p><font color=red><b>Your email address has been updated,


### PR DESCRIPTION
Update editprofile page to say "Settings" in a few places instead of "Profile," to be consistent with the name of the link in the navigation bar.

I do not know what the "editprofile.email" part of the following code does, so I left that as is:
 `pageHeader("Update Settings", "editprofile.email", false,`

Related to https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/254