### PR TITLE
Hide Editorial Reviews section when it's empty

### DIFF
--- a/www/viewgame
+++ b/www/viewgame
@@ -72,8 +72,8 @@ if ($curuser) {
         list($offsiteMode) = mysql_fetch_row($result);
 
     // if it's not set, default to 'A'
-    if (strlen($offsetMode) != 1 || strpos("ABLN", $offsiteMode) === false)
-        $offsetMode = 'A';
+    if (strlen($offsiteMode) != 1 || strpos("ABLN", $offsiteMode) === false)
+        $offsiteMode = 'A';
 }
 
 // ------------------------------------------------------------------------
@@ -1975,14 +1975,6 @@ if (count($inrefs) != 0 && !$historyView) {
 
         // see what we have
         if (count($srevs) != 0) {
-            if ($historyView)
-                echo "<h2>Off-Site Reviews</h2>";
-            else
-                echo "<h2>Editorial Reviews</h2>";
-            
-            echo "<div class=indented>";
-            $divStarted = true;
-
             for ($i = 0 ; $i < count($srevs) ; $i++) {
                 // get this row
                 $srev = $srevs[$i];
@@ -2102,6 +2094,16 @@ if (count($inrefs) != 0 && !$historyView) {
                     $osr .= $txt;
                 } else {
                     // this is for immediate display
+                    if (!$divStarted) {
+                        if ($historyView)
+                            echo "<h2>Off-Site Reviews</h2>";
+                        else
+                            echo "<h2>Editorial Reviews</h2>";
+
+                        echo "<div class=indented>";
+                        $divStarted = true;
+                    }
+
                     echo $txt;
                 }
             }


### PR DESCRIPTION
Fixes iftechfoundation/ifdb-suggestion-tracker#250.

When there are no external reviews to show, the section title shouldn't be shown either.
This is done by delaying the printing of the title until we decide to print the first entry of the section.

I also fixed a small typo (`$offsetMode` → `$offsiteMode`) in a validity test of the column `users.offsite_display`, although I doubt invalid values ever made it to the database.