### PR TITLE
Request only headers when contacting IFWiki

### DIFF
--- a/www/ifwiki-check
+++ b/www/ifwiki-check
@@ -6,12 +6,14 @@ $ifid = get_req_data("ifid");
 $qifid = strtoupper(urlencode($ifid));
 
 // look up the page on ifwiki.org
-$body = x_http_get("http://ifwiki.org/index.php?title=IFID:$qifid",
-                   null, $headers);
+$ch = curl_init("http://ifwiki.org/index.php?title=IFID:$qifid");
+curl_setopt($ch, CURLOPT_NOBODY, true);
+curl_setopt($ch, CURLOPT_TIMEOUT, 30);
+curl_exec($ch);
+$status_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+curl_close($ch);
 
-$exists = false;
-if (preg_match("/HTTP\/[.\d]+ +200 /", $headers))
-    $exists = true;
+$exists = ($status_code == 200);
 
 header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
 header("Cache-Control: no-store, no-cache, must-revalidate");


### PR DESCRIPTION
When loading a game page, IFDB contacts IFWiki to see if it has a game page, and puts a link to it at the bottom of the page.

The request was done with a custom `x_http_get` function. I replaced it with a call to the built-in curl, and made it so it only requests IFDB for headers, instead of the whole page. The several lines of curl can be turned to a generic function, but at the moment it's only used in one place.

This is related to my suggestion (iftechfoundation/ifdb-suggestion-tracker#237) to get rid of `x_http_get`.

Futher optimizations are possible:
* Cache the IFWiki status and only fetch it once a day or longer. Once cached, it can be returned with the whole page. There's no need for the browser to contact IFDB to contact IFWiki.
* Start switching the browser ↔ IFDB APIs from XML to JSON or just plain text. In the case of this [`ifwiki-check`](https://ifdb.org/ifwiki-check?ifid=ZCODE-1-070917-994E&xml) API, it only returns a boolean response.