### PR TITLE
Fix username display when location is empty

### DIFF
--- a/www/editcomp
+++ b/www/editcomp
@@ -1602,7 +1602,10 @@ function editGame(divno, rownum)
         echo  "<div class=indented style='margin-top:1ex;' id='divDiv$i'>"
             . "</div>";
     }
-        
+
+	$displayName = $username;
+	if ($userloc != "")
+        $displayName .= " ($userloc)";
 
     // finish the form
     echo "<p><hr class=dots></div><tr><td></td><td><br><br>"
@@ -1631,7 +1634,7 @@ function editGame(divno, rownum)
         . "id='edit-cancel-button'></a>"
 
         . "<br><br><span class=details>"
-        . "<i>Your changes will be attributed to you as $username ($userloc). "
+        . "<i>Your changes will be attributed to you as $displayName. "
         . "<a href=\"" . switchUserAndReturnHRef()
         . "\">Click here</a> to log in as a different user (but note "
         . "that this will discard your unsaved changes above).</i></span>"

--- a/www/editgame
+++ b/www/editgame
@@ -1904,7 +1904,7 @@ for ($i = 0 ; $i < count($reftypes) ; ++$i) {
                <i>Your changes will be attributed to you as
                   "<?php 
                       echo htmlspecialcharx($username);
-                      if (!is_null($userloc))
+                      if ($userloc != "")
                           echo " (" . htmlspecialcharx($userloc) . ")"
                    ?>."
                    <a href="<?php echo switchUserAndReturnHRef() ?>">


### PR DESCRIPTION
If I set my location in my profile, then unset it, it's stored as an empty string instead of null.

Then, if I go to the "edit game" or the "edit competition" pages, I see this message:

>Your changes will be attributed to you as "username ()."

In the game page, this is due to the check being `!isnull()`, which accepts empty strings. I changed it to `!= ""`, to match other places (the review page, `showRecList`).