### PR TITLE
Link to intfiction.org on the Create a Poll page

### DIFF
--- a/www/poll
+++ b/www/poll
@@ -838,6 +838,10 @@ if ($id == 'new') {
     pageHeader("Create a New Poll", "newPollForm.title");
 ?>
 
+<div class="tipbox"><h1>Ask a question</h1>
+If you have a question about IF, you can
+<a href="https://intfiction.org">ask at the IF Community Forum</a>.</div>
+
 <h1>Create a New Poll</h1>
 <p>Are you looking for recommendations for a particular type of IF
 to play?  Ask the IFDB community for ideas by creating a public poll.


### PR DESCRIPTION
People sometimes use polls to ask questions that aren't a good fit for IFDB polls.

This adds a tip box to the Create a Poll page linking to the forum so people can ask questions there instead.

This uses the "tipbox" class, but the layout doesn't look great on small screens. Is there a better way?

Resolves https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/224

