### PR TITLE
Adopt `box-sizing: border-box`

### DIFF
--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -57,7 +57,13 @@ CSS unfortunately doesn't have a way to refer indirectly to the dimensions
 from the image file, so you just have to hard-code the actual pixel size.
 */
 
+html {
+    box-sizing: border-box;
+}
 
+*, *:before, *:after {
+  box-sizing: inherit;
+}
 
 /*
 This is the style for the main body of the page - nearly everything

--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -929,7 +929,7 @@ p.nosp {
     margin: 0 0 0 0;
 }
 
-p {
+p, ul, ol {
     max-width: 60ch;
 }
 


### PR DESCRIPTION
Fixes iftechfoundation/ifdb-suggestion-tracker#247
Fixes iftechfoundation/ifdb-suggestion-tracker#248

<https://www.jefftk.com/p/the-revenge-of-the-ie-box-model> explains more about how `box-sizing: border-box` came to be.

<https://developer.mozilla.org/en-US/docs/Web/CSS/box-sizing> explains how to use it.

I'm using the recommended best practice documented here: <https://css-tricks.com/inheriting-box-sizing-probably-slightly-better-best-practice/>

That makes everything use `box-sizing: border-box` except for sections that we deliberately change to `box-sizing: content-box` as needed. (I clicked around and couldn't find any issues, but if we find them, they'll be a one-line fix.)