### PR TITLE
Consolidate mobile styles

### DIFF
--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -218,6 +218,7 @@ div.topctl form {
     flex-wrap: wrap;
     overflow: auto;
     padding: 0em 1em 0em 1em;
+    justify-content: space-between;
 }
 
 .main-nav ul{
@@ -225,7 +226,6 @@ div.topctl form {
     padding: 0px;
     display: flex;
     flex-basis: 0;
-    flex-grow: 999;
     align-items: center;
 }
 

--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -741,7 +741,10 @@ div.edit-popup-win table tr td {
 div#imageUploadCopyrightForm table td {
     font-size: 90%;
 }
-        
+
+input#searchfor, #searchfor2{
+  max-width: calc(100vw - 2rem);
+}
 
 /*
 The "searchSummary" table is used to show the current location in the

--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -747,18 +747,6 @@ input#searchfor, #searchfor2{
 }
 
 /*
-The "searchSummary" table is used to show the current location in the
-result set for a search.
-*/
-table.searchSummary {
-    background: #e0e000;
-    width: 100%;
-}
-table.searchSummary tr td {
-    font-size: 85%;
-}
-
-/*
 "searchHelpList" is used on the search help page for the lists of
 values for special flags, such as the list of file formats on the
 game search page.
@@ -2348,10 +2336,6 @@ span.sfl-save-autodesc {
         background-color: #000000;
         color: #FFFFFF;
         border: 1px solid #323245;
-    }
-    table.searchSummary {
-        background: #202040;
-        color: #ffffff;
     }
     div.tipbox {
         background: #101030;

--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -777,10 +777,16 @@ div.searchHelpList td {
 Tabs for browse-mode search types
 */
 div.browseBar {
-    position: relative;
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
     width: 100%;
     font-size: 85%;
     background: #e0e0e0;
+    margin-bottom: 1em;
+    text-size-adjust: none;
+    -webkit-text-size-adjust: none;
+    flex-wrap: wrap;
 }
 div.browseTabs {
     padding: 6px 0 0 4px;
@@ -799,16 +805,15 @@ span.browseTab {
     position: relative;
     bottom: -1px;
 }
+.browseSummary {
+    padding-left: 4px;
+    padding-right: 4px;
+}
 span.firstBrowseTab {
     border-left: 1px solid #c0c0c0;
 }
 span.activeBrowseTab {
     background: #a0ffff;
-}
-div.browseSummary {
-    position: absolute;
-    right: 0.5ex;
-    bottom: 0px;
 }
 
 /*

--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -1420,6 +1420,7 @@ image file, unfortunately.
     border: none;
     vertical-align: middle;
     margin-right: 1em;
+    padding: 0;
 }
 input.save-button {
     background: url("/savechanges.gif");

--- a/www/legacy-mobile-styles.css
+++ b/www/legacy-mobile-styles.css
@@ -13,10 +13,6 @@ table.gameRightBar {
 span.fmtnotes {
   display: none;
 }
-.new-review {
-   font-size: 12pt;
-}
-
 .rightbar {
    display: none;
 }

--- a/www/legacy-mobile-styles.css
+++ b/www/legacy-mobile-styles.css
@@ -5,10 +5,6 @@
   margin-bottom: 48px;
  }
 
-div.topctl form input[type="text"] {
-  width:195px;
-}
-
 }
 
 img.dla-button {

--- a/www/legacy-mobile-styles.css
+++ b/www/legacy-mobile-styles.css
@@ -65,8 +65,4 @@ div.downloadfloat h3 {
  display:none;
 }
 
-input#searchfor, #searchfor2{
-  width: 95%;
-}
-
 

--- a/www/legacy-mobile-styles.css
+++ b/www/legacy-mobile-styles.css
@@ -1,32 +1,13 @@
 @import url("/ifdb.css?v=1");
 
 @media only screen and (max-device-width: 480px) {
- body {
+  body {
   margin-bottom: 48px;
  }
 
 div.topctl form input[type="text"] {
   width:195px;
 }
-
-div.topctl  table td   {
- text-align:center;
-}
-
-div.topctl table {
-  position: relative;
-  left: -5px;
-  width: 320px;
-}
-
- div.xxxxtopbar {
-    width: 320px;
-    height: 55px;
-   background: url("images/ifdb-topbar-nar.jpg") #c0c0c0 no-repeat;
- }
- body {
-  clear: both;
- } 
 
 }
 

--- a/www/legacy-mobile-styles.css
+++ b/www/legacy-mobile-styles.css
@@ -4,9 +4,6 @@ img.dla-button {
     background-image: none;
     width: 0px;
 }
-table.searchSummary {
-  display: none;
-}
 table.gameRightBar {
   display: none;
 }

--- a/www/legacy-mobile-styles.css
+++ b/www/legacy-mobile-styles.css
@@ -1,12 +1,5 @@
 @import url("/ifdb.css?v=1");
 
-@media only screen and (max-device-width: 480px) {
-  body {
-  margin-bottom: 48px;
- }
-
-}
-
 img.dla-button {
     background-image: none;
     width: 0px;

--- a/www/search
+++ b/www/search
@@ -1307,11 +1307,11 @@ else if ($term || $browse)
             $range = ($firstOnPage+1) . "-" . ($lastOnPage+1) . " of $rowcnt";
 
         // show where we are in the results
-        echo "<div class=\"browseBar\">"
+        echo "<div class=\"browseBar\"><span>"
             . ($term != ""
                ? "Results for <b>" . htmlspecialcharx($term) . "</b>" : "")
             . $otherBrowse
-            . "<div class=\"browseSummary\">$range</div></div>";
+            . "</span><div class=\"browseSummary\">$range</div></div>";
 
         // if this is a game search, show the tip boxes
         if ($searchType == "game") {


### PR DESCRIPTION
`legacy-mobile-styles.css` activates when IFDB detects a phone via user-agent sniffing, but it includes a section at the top that says `@media only screen and (max-device-width: 480px) {` which means that those styles could just be added to the main CSS rules without UA sniffing.

So, I've done that here, moving rules out of the legacy mobile stylesheet and into the main set of rules in as idiomatic a way as I can.

Along the way, this partially helps with https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/213 and fixes https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/287

I recommend reviewing this commit-by-commit.