### PR TITLE
Remove more x_http_get calls: "search user email" and stopforumspam API

### DIFF
--- a/www/newuser
+++ b/www/newuser
@@ -194,28 +194,20 @@ function sfsCheck($ip, $email, $username, &$banned)
 
     // run the query through stopforumspam.com
     $info = array();
-    $result = x_http_get("http://www.stopforumspam.com/api?"
-                         . "ip=$ip&email=$email&username=$username");
+    $ch = curl_init("https://www.stopforumspam.com/api?json&"
+                    . "ip=$ip&email=$email&username=$username");
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    curl_setopt($ch, CURLOPT_TIMEOUT, 30);
+    $result = curl_exec($ch);
+    curl_close($ch);
 
-    // parse the results
-    $result = explode("\n", $result);
-    $type = false;
-    foreach ($result as $r) {
-        if (preg_match("/<type>([a-z]+)<\/type>/", $r, $match))
-            $type = $match[1];
-        else if (preg_match("/<appears>yes<\/appears>/", $r))
-            $info[$type]['appears'] = true;
-        else if (preg_match("/<lastseen>([-: 0-9]+)<\/lastseen>/", $r, $m))
-            $info[$type]['lastseen'] = substr($m[1], 0, 10);
-        else if (preg_match("/<frequency>([0-9]+)<\/frequency>/", $r, $m))
-            $info[$type]['frequency'] = $m[1];
-    }
+    $info = json_decode($result, true);
 
     // assemble the results into a printable string
     $ret = false;
     $typeMap = array('ip' => 'IP', 'email' => 'Email',
                      'username' => 'Name');
-    foreach (array('ip', 'email', 'username') as $t) {
+    foreach (array_keys($typeMap) as $t) {
         $i = $info[$t];
         if ($i['appears']) {
             $t = $typeMap[$t];

--- a/www/showuser
+++ b/www/showuser
@@ -232,38 +232,6 @@ if ($rss == 'gamenews')
     exit();
 }
 
-// if this is an admin view with a request for an email address search,
-// generate the search results - this is used inside an iframe, so it's
-// the only thing we want on the page in this case
-if ($unlock && get_req_data("search") == "email")
-{
-    // set up a search for the email address
-	$engine = "http://www.bing.com";
-	$uuemail = urlencode($realEmail);
-    $searchUrl = "$engine/search?q=\"$uuemail\"";
-
-    // pass along the client browser string header so that the engine sends
-    // us the right style sheet for the client device
-    $searchHeaders = "";
-    $ua = $_SERVER["HTTP_USER_AGENT"];
-    if ($ua)
-        $searchHeaders .= "User-Agent: $ua\r\n";
-
-    // run the search
-    $searchbody = x_http_get($searchUrl, $searchHeaders);
-    if ($searchbody)
-    {
-        $searchbody = preg_replace(
-            "/<head[^>]*>/i", "$0<base href=\"$engine\">",
-            $searchbody);
-        echo $searchbody;
-    }
-    else
-        echo "Email search failed";
-
-    exit();
-}
-
 pageHeader($pageTitle, false, false, "<script src=\"xmlreq.js\"></script>");
 
 $captchaKey = "showuser.$uid";
@@ -980,30 +948,6 @@ if ($unlock)
 
     // add the admin links
     echo "<a href=\"{$adminUrl}\">Administer user acccount</a><br>";
-
-    // add the email search
-	// (remove this for now - the search engines seem to reject framed searches now)
-	//echo "<div style=\"margin: 1em 0px;\">"
-    //    . "<iframe src=\"showuser?id=$uid&search=email&unlock=$unlockNonce\" "
-    //    . "frameborder=0 style=\"width: 100%; overflow: auto;\" "
-    //    . "onload=\"javascript:onLoadEmailSearchFrame(this)\">"
-    //    . "</iframe>"
-    //    . "</div>";
-    ?>
-    <script>
-    function onLoadEmailSearchFrame(fr)
-    {
-        fr.style.height = "" + getDocHeight(fr.contentWindow.document) + "px";
-    }
-    function getDocHeight(doc)
-    {
-        return Math.max(
-            Math.max(doc.body.scrollHeight, doc.documentElement.scrollHeight),
-            Math.max(doc.body.offsetHeight, doc.documentElement.offsetHeight),
-            Math.max(doc.body.clientHeight, doc.documentElement.clientHeight));
-    }
-    </script>
-    <?php
 }
 
 pageFooter();


### PR DESCRIPTION
As discussed in iftechfoundation/ifdb-suggestion-tracker#237:

1. Remove unused "search user email" admin feature. It's broken, and the URL for it was never exposed and disabled in a comment because it was broken.
2. The stopforumspam API call now uses HTTPS, and switched to JSON output because there's no reason to parse XML with regular expressions.

Notes:
* I only tested the `sfsCheck()` function on its own, and not the full user registration flow.
* The old code wasn't very robust in checking for API errors, and I didn't add any checks. I forced a 404 response, and PHP carried on despite it.