### PR TITLE
Fix undefined variable in admin users page

### DIFF
--- a/www/adminops
+++ b/www/adminops
@@ -741,7 +741,7 @@ else if (isset($_REQUEST['users'])) {
 
 	echo "<div style=\"margin: 1ex 0px;\">"
 		. "<form>"
-		. "Search by name or email: <input name=\"finduser\" type=\"text\" length=60 value=\"$fldval\">"
+		. "Search by name or email: <input name=\"finduser\" type=\"text\" length=60>"
 		. "  <input type=\"submit\" name=\"go\" value=\"Find\">"
 		. "</form>"
 		. "</div>";


### PR DESCRIPTION
`$fldval` is only used after a search was made to prefill the search field. This fix silences a PHP warning.