### PR TITLE
Wrapping browse/search tabs

### DIFF
--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -777,9 +777,9 @@ div.browseBar {
     flex-wrap: wrap;
     padding-bottom: 1px;
 }
-span.browseLabel {
+.browseLabel {
     font-weight: bold;
-    margin-right: 2em;
+    margin-bottom: 0.5em;
 }
 span.browseTab {
     background: #f0f0f0;

--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -775,9 +775,7 @@ div.browseBar {
     text-size-adjust: none;
     -webkit-text-size-adjust: none;
     flex-wrap: wrap;
-}
-div.browseTabs {
-    padding: 6px 0 0 4px;
+    padding-bottom: 1px;
 }
 span.browseLabel {
     font-weight: bold;
@@ -785,13 +783,28 @@ span.browseLabel {
 }
 span.browseTab {
     background: #f0f0f0;
-    padding: 3px 2ex 0 2ex;
-    margin: 0;
     border: 1px solid #c0c0c0;
     border-left: none;
-    border-bottom: none;
     position: relative;
-    bottom: -1px;
+    margin-bottom: -1px;
+}
+
+.browseTabs {
+    text-decoration: none;
+    display: flex;
+    flex-wrap: wrap;
+}
+
+.browseTabs a {
+    text-decoration: none;
+    padding: 0.25em 0.75em 0.25em 0.75em;
+    display: inline-block;
+    white-space: nowrap;
+}
+
+.browseTabs a:hover {
+    text-decoration: underline;
+    background-color: #dcdcdc;
 }
 .browseSummary {
     padding-left: 4px;
@@ -800,8 +813,9 @@ span.browseTab {
 span.firstBrowseTab {
     border-left: 1px solid #c0c0c0;
 }
-span.activeBrowseTab {
+span.activeBrowseTab, .activeBrowseTab a:hover {
     background: #a0ffff;
+    padding: 0.25em 0.75em 0.25em 0.75em;
 }
 
 /*

--- a/www/search
+++ b/www/search
@@ -436,8 +436,7 @@ if (!$browse && !$xml) {
     {
         if ($key == $searchType)
             $otherTabs .= "<span class=\"$tabClass activeBrowseTab\">"
-                          . "<a href=\"search?$key\">"
-                          . "$label</a></span>";
+                            . "$label</span>";
         else
             $otherTabs .= "<span class=\"$tabClass\">"
                           . "<a href=\"search?$key\">"

--- a/www/search
+++ b/www/search
@@ -428,9 +428,10 @@ function helpExtLink($title, $url)
 }
 
 if (!$browse && !$xml) {
-    $otherTabs = "<div class=\"browseBar\">"
-                 . "<div class=\"browseTabs\">"
-                 . "<span class=\"browseLabel\">Searching</span>";
+    $otherTabs = "<div class=\"browseLabel\">Searching</div>"
+                 . "<div class=\"browseBar\">"
+                 . "<div class=\"browseTabs\">";
+                 
     $tabClass = "browseTab firstBrowseTab";
     foreach ($browseTabs as $key => $label)
     {
@@ -1282,8 +1283,7 @@ else if ($term || $browse)
         $otherBrowse = "";
         if ($browse)
         {
-            $otherBrowse = "<div class=\"browseTabs\">"
-                           . "<span class=\"browseLabel\">Browsing</span>";
+            $otherBrowse = "<div class=\"browseTabs\">";
             $tabClass = "browseTab firstBrowseTab";
             foreach ($browseTabs as $key => $label)
             {
@@ -1306,9 +1306,9 @@ else if ($term || $browse)
             $range = ($firstOnPage+1) . "-" . ($lastOnPage+1) . " of $rowcnt";
 
         // show where we are in the results
-        echo "<div class=\"browseBar\"><span>"
-            . ($term != ""
-               ? "Results for <b>" . htmlspecialcharx($term) . "</b>" : "")
+        echo ($term == "" ? "<div class=\"browseLabel\">Browsing</div>" : "")
+            . "<div class=\"browseBar\"><span>"
+            . ($term != "" ? "Results for <b>" . htmlspecialcharx($term) . "</b>" : "")
             . $otherBrowse
             . "</span><div class=\"browseSummary\">$range</div></div>";
 


### PR DESCRIPTION
This PR causes the category tabs on the search and browse pages to wrap on smaller screen sizes, avoiding an overflow.

Before:

<img src="https://user-images.githubusercontent.com/45113412/113965614-b25da880-97fb-11eb-9e82-cf999ccb6adb.jpg" height="210">


After:

<img src="https://user-images.githubusercontent.com/45113412/113964572-ba1c4d80-97f9-11eb-811e-431f9542b744.jpg" height="250">


