### PR TITLE
Only show top five games in author profile

### DIFF
--- a/www/search
+++ b/www/search
@@ -981,6 +981,9 @@ else {  // ...default is searching games
 //          >What's an IFID?</a>
        ?>)
 
+        <p><b>authorid:<i>id</i></b> lists games by the author with
+            the given id.
+           
        <p><b>played:<i>yes</i>|<i>no</i></b> lists games that
             you have/haven't put on your played list (i.e. "I've played it").
             Only works if you are logged in with a user account.

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -536,7 +536,7 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
                 break;
  
             case 'authorid':
-                // add the gameprofilelinks join if necessary
+                // need to join the gameprofilelinks table to do this query
                 if (!isset($extraJoins[$col])) {
                     $extraJoins[$col] = true;
                     $tableList .= " inner join gameprofilelinks as gpl "

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -232,6 +232,7 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
             "forgiveness:" => array("forgiveness", 0),
             "language:" => array("language", 99),
             "author:" => array("author", 99),
+            "authorid:" => array("authorid", 99),
             "ifid:" => array("/ifid/", 99),
             "downloadable:" => array("/downloadable/", 99),
             "played:" => array("played", 99),
@@ -533,6 +534,15 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
                 $op = (preg_match("/^y.*/i", $txt) ? "!=" : "=");
                 $expr = "gls.numGameLinks $op 0";
                 break;
+ 
+            case 'authorid':
+                // add the gameprofilelinks join if necessary
+                if (!isset($extraJoins[$col])) {
+                    $extraJoins[$col] = true;
+                    $tableList .= " inner join gameprofilelinks as gpl "
+                                  . "on gpl.gameid = games.id "
+                                  . "and gpl.userid = '$txt'";
+                }
 
             case 'played':
                 // Only use this query when the user is logged in

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -543,6 +543,7 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
                                   . "on gpl.gameid = games.id "
                                   . "and gpl.userid = '$txt'";
                 }
+                break;
 
             case 'played':
                 // Only use this query when the user is logged in

--- a/www/showuser
+++ b/www/showuser
@@ -471,8 +471,7 @@ function pingMultiUserSession(sid, gameid, title, author, started)
          where
            gameprofilelinks.userid = '$quid'
          group by games.id
-         order by starsort desc
-         limit 0, 6", $db);
+         order by starsort desc", $db);
 
     if (($cnt = mysql_num_rows($result)) > 0) {
         echo "<h2>Interactive Fiction by $username</h2>"
@@ -527,7 +526,8 @@ function pingMultiUserSession(sid, gameid, title, author, started)
 
         if (mysql_num_rows($result) > 5) {
             echo "<p><span class=details><a href=\"search?searchfor=authorid:$uid\">"
-                . "See all of this member's games</a></span>";
+                . "See all " . mysql_num_rows($result)
+                . " games by $username</a></span>";
         }
 
         echo "</div>";
@@ -553,8 +553,7 @@ function pingMultiUserSession(sid, gameid, title, author, started)
                 userid = '$quid'
                 and reclistitems.listid = reclists.id
             group by reclistitems.listid
-            order by moddate desc
-            limit 0, 6", $db);
+            order by moddate desc", $db);
 
         for ($i = 0 ; $i < 5 && $i < mysql_num_rows($result) ; $i++) {
             // fetch the next row
@@ -576,7 +575,8 @@ function pingMultiUserSession(sid, gameid, title, author, started)
 
         if (mysql_num_rows($result) > 5) {
             echo "<p><span class=details><a href=\"alllists?user=$uid\">"
-                . "See all of this member's lists</a></span>";
+                . "See all " . mysql_num_rows($result)
+                . " lists by $username</a></span>";
         }
     }
 
@@ -608,9 +608,7 @@ function pingMultiUserSession(sid, gameid, title, author, started)
             group by
                p.pollid
             order by
-               p.created desc
-            limit
-               0, 6", $db);
+               p.created desc", $db);
 
         for ($i = 0 ; $i < 5 && $i < mysql_num_rows($result) ; $i++) {
             // fetch the next row
@@ -636,7 +634,8 @@ function pingMultiUserSession(sid, gameid, title, author, started)
 
         if (mysql_num_rows($result) > 5) {
             echo "<p><span class=details><a href=\"allpolls?user=$uid\">"
-                . "See all of this member's polls</a></span>";
+                . "See all " . mysql_num_rows($result)
+                . " polls by $username</a></span>";
         }
     }
 
@@ -680,8 +679,7 @@ function pingMultiUserSession(sid, gameid, title, author, started)
                and reviews.review is not null
                and games.id = reviews.gameid
                and ifnull(now() >= reviews.embargodate, 1)
-             order by reviews.moddate desc
-             limit 0, 6", $db);
+             order by reviews.moddate desc", $db);
 
         for ($i = 0 ; $i < 5 && $i < mysql_num_rows($result) ; $i++) {
             // retrieve the result
@@ -711,11 +709,12 @@ function pingMultiUserSession(sid, gameid, title, author, started)
 
         if (mysql_num_rows($result) > 5) {
             echo "<p><span class=details><a href=\"allreviews?id=$uid\">"
-                . "See all reviews by this member</a></span>";
+                . "See all " . mysql_num_rows($result)
+                . " reviews by $username</a></span>";
 
             echo "<br><span class=details>"
                 . "<a href=\"allreviews?id=$uid&ratings=yes\">"
-                . "See all ratings and reviews by this member</a></span>";
+                . "See all ratings and reviews by $username</a></span>";
         }
     }
 
@@ -755,11 +754,11 @@ function pingMultiUserSession(sid, gameid, title, author, started)
                  from games, playedgames
                  where games.id = playedgames.gameid
                  and playedgames.userid = '$quid'
-                 order by playedgames.date_added desc
-                 limit 0, 6", $db);
+                 order by playedgames.date_added desc", $db);
 
             if (mysql_num_rows($result) == 0)
-                echo "<i>This member hasn't marked any games as played.</i>";
+                echo "<i>This member hasn't added any games to
+                      $hisHer Played List yet.</i>";
 
             for ($i = 0 ; $i < 5 && $i < mysql_num_rows($result) ; $i++) {
                 list($gid, $title, $author) = mysql_fetch_row($result);
@@ -771,7 +770,8 @@ function pingMultiUserSession(sid, gameid, title, author, started)
 
             if (mysql_num_rows($result) > 5)
                 echo "<p><span class=details><a href=\"playlist?id=$uid\">"
-                    . "View the entire list</a></span><br>";
+                    . "See all " . mysql_num_rows($result)
+                    . " entries in the Played List</a></span><br>";
         }
 
         if ($wishlistPub) {
@@ -784,12 +784,11 @@ function pingMultiUserSession(sid, gameid, title, author, started)
                  from games, wishlists
                  where games.id = wishlists.gameid
                  and wishlists.userid = '$quid'
-                 order by wishlists.date_added desc
-                 limit 0, 6", $db);
+                 order by wishlists.date_added desc", $db);
 
             if (mysql_num_rows($result) == 0)
                 echo "<i>This member hasn't added any games to
-                      $hisHer wish list yet.</i>";
+                      $hisHer Wish List yet.</i>";
 
             for ($i = 0 ; $i < 5 && $i < mysql_num_rows($result) ; $i++) {
                 list($gid, $title, $author) = mysql_fetch_row($result);
@@ -802,7 +801,8 @@ function pingMultiUserSession(sid, gameid, title, author, started)
             if (mysql_num_rows($result) > 5)
                 echo "<p><span class=details>"
                     . "<a href=\"playlist?id=$uid&type=wishlist\">"
-                    . "View the entire list</a></span><br>";
+                    . "See all " . mysql_num_rows($result)
+                    . " entries in the Wish List</a></span><br>";
         }
 
         if ($unwishlistPub) {
@@ -815,12 +815,11 @@ function pingMultiUserSession(sid, gameid, title, author, started)
                  from games, unwishlists
                  where games.id = unwishlists.gameid
                  and unwishlists.userid = '$quid'
-                 order by unwishlists.date_added desc
-                 limit 0, 6", $db);
+                 order by unwishlists.date_added desc", $db);
 
             if (mysql_num_rows($result) == 0)
                 echo "<i>This member hasn't added any games to
-                      $hisHer \"Not Interested\" list yet.</i>";
+                      $hisHer \"Not Interested\" List yet.</i>";
 
             for ($i = 0 ; $i < 5 && $i < mysql_num_rows($result) ; $i++) {
                 list($gid, $title, $author) = mysql_fetch_row($result);
@@ -833,7 +832,8 @@ function pingMultiUserSession(sid, gameid, title, author, started)
             if (mysql_num_rows($result) > 5)
                 echo "<p><span class=details>"
                     . "<a href=\"playlist?id=$uid&type=unwishlist\">"
-                    . "View the entire list</a></span><br>";
+                    . "See all " . mysql_num_rows($result)
+                    . " entries in the \"Not Interested\" List</a></span><br>";
         }
 
         echo "</div>";

--- a/www/showuser
+++ b/www/showuser
@@ -662,7 +662,7 @@ function pingMultiUserSession(sid, gameid, title, author, started)
     if ($revcnt == 0) {
         echo "<i>This member hasn't written any reviews yet.</i><br>";
         if ($ratingcnt != 0) {
-            echo "<span class=details>"
+            echo "<br><span class=details>"
                 . "<a href=\"allreviews?id=$uid&ratings=yes\">"
                 . "See all ratings by this member</a></span>";
         }

--- a/www/showuser
+++ b/www/showuser
@@ -525,7 +525,7 @@ function pingMultiUserSession(sid, gameid, title, author, started)
             }
         }
         
-        echo "<p><span class=details><a href=\"search?authorid=$uid\">"
+        echo "<p><span class=details><a href=\"search?searchfor=authorid:$uid\">"
             . "See all of this member's games</a></span>";
         echo "</div>";
     }

--- a/www/showuser
+++ b/www/showuser
@@ -471,7 +471,8 @@ function pingMultiUserSession(sid, gameid, title, author, started)
          where
            gameprofilelinks.userid = '$quid'
          group by games.id
-         order by games.sort_title", $db);
+         order by starsort desc
+         limit 0, 5", $db);
 
     if (($cnt = mysql_num_rows($result)) > 0) {
         echo "<h2>Interactive Fiction by $username</h2>"
@@ -523,6 +524,9 @@ function pingMultiUserSession(sid, gameid, title, author, started)
                     . "<i>$desc</i></span></div>";
             }
         }
+        
+        echo "<p><span class=details><a href=\"search?authorid=$uid\">"
+            . "See all of this member's games</a></span>";
         echo "</div>";
     }
            

--- a/www/showuser
+++ b/www/showuser
@@ -472,13 +472,13 @@ function pingMultiUserSession(sid, gameid, title, author, started)
            gameprofilelinks.userid = '$quid'
          group by games.id
          order by starsort desc
-         limit 0, 5", $db);
+         limit 0, 6", $db);
 
     if (($cnt = mysql_num_rows($result)) > 0) {
         echo "<h2>Interactive Fiction by $username</h2>"
             . "<div class=indented>";
 
-        for ($i = 0 ; $i < $cnt ; $i++) {
+        for ($i = 0 ; $i < 5 && $i < mysql_num_rows($result) ; $i++) {
             $rec = mysql_fetch_array($result, MYSQL_ASSOC);
             $gid = urlencode($rec['id']);
             $title = htmlspecialcharx($rec['title']);
@@ -513,7 +513,7 @@ function pingMultiUserSession(sid, gameid, title, author, started)
                        " <span class=details>($year)</span><br>" : "")
                     . "<span class=details>$stars</span>"
                     . "<span class=details><i>$desc</i></span>"
-                    . "</td></tr></table>";
+                    . "</td></tr></table><br>";
             }
             else {
                 echo "<a href=\"viewgame?id=$gid\"><b>$title</b></a>, "
@@ -521,12 +521,15 @@ function pingMultiUserSession(sid, gameid, title, author, started)
                     . ($year ? " ($year)" : ""). "<br>"
                     . "<span class=details>$stars</span>"
                     . "<div class=indented><span class=details>"
-                    . "<i>$desc</i></span></div>";
+                    . "<i>$desc</i></span></div><br>";
             }
         }
-        
-        echo "<p><span class=details><a href=\"search?searchfor=authorid:$uid\">"
-            . "See all of this member's games</a></span>";
+
+        if (mysql_num_rows($result) > 5) {
+            echo "<p><span class=details><a href=\"search?searchfor=authorid:$uid\">"
+                . "See all of this member's games</a></span>";
+        }
+
         echo "</div>";
     }
            
@@ -551,9 +554,9 @@ function pingMultiUserSession(sid, gameid, title, author, started)
                 and reclistitems.listid = reclists.id
             group by reclistitems.listid
             order by moddate desc
-            limit 0, 5", $db);
+            limit 0, 6", $db);
 
-        for ($i = 0 ; $i < mysql_num_rows($result) ; $i++) {
+        for ($i = 0 ; $i < 5 && $i < mysql_num_rows($result) ; $i++) {
             // fetch the next row
             list($listid, $title, $desc, $moddate, $itemcnt) =
                 mysql_fetch_row($result);
@@ -571,8 +574,10 @@ function pingMultiUserSession(sid, gameid, title, author, started)
                 . "<i>$desc</i></span></div><br>";
         }
 
-        echo "<p><span class=details><a href=\"alllists?user=$uid\">"
-            . "See all of this member's lists</a></span>";
+        if (mysql_num_rows($result) > 5) {
+            echo "<p><span class=details><a href=\"alllists?user=$uid\">"
+                . "See all of this member's lists</a></span>";
+        }
     }
 
     echo "</div>";
@@ -605,9 +610,9 @@ function pingMultiUserSession(sid, gameid, title, author, started)
             order by
                p.created desc
             limit
-               0, 5", $db);
+               0, 6", $db);
 
-        for ($i = 0 ; $i < mysql_num_rows($result) ; $i++) {
+        for ($i = 0 ; $i < 5 && $i < mysql_num_rows($result) ; $i++) {
             // fetch the next row
             list($pollid, $title, $desc, $created, $votecnt, $gamecnt) =
                 mysql_fetch_row($result);
@@ -629,8 +634,10 @@ function pingMultiUserSession(sid, gameid, title, author, started)
                 . "<i>$desc</i></span></div><br>";
         }
 
-        echo "<p><span class=details><a href=\"allpolls?user=$uid\">"
-            . "See all of this member's polls</a></span>";
+        if (mysql_num_rows($result) > 5) {
+            echo "<p><span class=details><a href=\"allpolls?user=$uid\">"
+                . "See all of this member's polls</a></span>";
+        }
     }
 
     echo "</div>";
@@ -674,9 +681,9 @@ function pingMultiUserSession(sid, gameid, title, author, started)
                and games.id = reviews.gameid
                and ifnull(now() >= reviews.embargodate, 1)
              order by reviews.moddate desc
-             limit 0, 5", $db);
+             limit 0, 6", $db);
 
-        for ($i = 0 ; $i < mysql_num_rows($result) ; $i++) {
+        for ($i = 0 ; $i < 5 && $i < mysql_num_rows($result) ; $i++) {
             // retrieve the result
             list($gameid, $title, $author, $revid, $rating,
                  $summary, $review, $moddate) = mysql_fetch_row($result);
@@ -702,12 +709,14 @@ function pingMultiUserSession(sid, gameid, title, author, started)
             echo "</span></div><br>";
         }
 
-        echo "<p><span class=details><a href=\"allreviews?id=$uid\">"
-            . "See all reviews by this member</a></span>";
+        if (mysql_num_rows($result) > 5) {
+            echo "<p><span class=details><a href=\"allreviews?id=$uid\">"
+                . "See all reviews by this member</a></span>";
 
-        echo "<br><span class=details>"
-            . "<a href=\"allreviews?id=$uid&ratings=yes\">"
-            . "See all ratings and reviews by this member</a></span>";
+            echo "<br><span class=details>"
+                . "<a href=\"allreviews?id=$uid&ratings=yes\">"
+                . "See all ratings and reviews by this member</a></span>";
+        }
     }
 
     echo "</div>";


### PR DESCRIPTION
This is a fix for https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/289.

Note: The `See all games...` link shows up regardless of the total number of games the author has written. I did this intentionally to keep the UI consistent but it should be addressed in the future. The "See all..." links should only show up if there are more than five of any given thing: games, polls, lists, or review/ratings. Note that the `Play Lists` section does the "See all..." links correctly.