### PR TITLE
Don't personalize recommendations on game details page

### DIFF
--- a/www/viewgame
+++ b/www/viewgame
@@ -1445,9 +1445,6 @@ if (!isEmpty($genre)) {
         // who rated this game highly.
 
         // look for lists containing this game
-        $sortMeLast = "";
-        if ($curuser)
-            $sortMeLast = "if(reclists.userid = '$curuser', 2, 1),";
         $result = mysql_query(
             "select
                 reclists.id as listid,
@@ -1464,7 +1461,7 @@ if (!isEmpty($genre)) {
                 and reclists.id = reclistitems.listid
                 and users.id = reclists.userid
              group by reclistitems.listid
-             order by $sortMeLast rand()
+             order by rand()
              limit 0, 4", $db);
 
         // fetch the recommendation lists to show
@@ -1473,10 +1470,6 @@ if (!isEmpty($genre)) {
             $lists[] = mysql_fetch_array($result, MYSQL_ASSOC);
 
         // look for polls with votes for this game
-        $sortMeLast = "";
-        if ($curuser)
-            $sortMeLast = "if(v.userid = '$curuser' or p.userid = '$curuser'"
-                          . ", 2, 1),";
         $result = mysql_query(
             "select
                p.pollid as pollid,
@@ -1492,8 +1485,7 @@ if (!isEmpty($genre)) {
                v.gameid = '$qid'
              group by
                p.pollid
-             order by
-               $sortMeLast rand()
+             order by rand()
              limit
                0, 4", $db);
 
@@ -1506,38 +1498,7 @@ if (!isEmpty($genre)) {
         // were given 4- or 5-star ratings by members who also gave
         // the current game a 4- or 5-star rating, AND which games
         // are unrated AND unplayed by the current user.
-        //
-        // If we're logged in, make sure the ratings are coming from
-        // other users (don't bother generating recommendations based
-        // on the current user's own ratings, for obvious reasons).
-        // Also exclude games that are already on the current user's
-        // play list or wish list - they obviously already know about
-        // these games, so there's no reason to recommend them.
-        if ($curuser && !$cssOverride) {
-            $joinOtherUser = "left outer join reviews as r3"
-                             . "  on r3.gameid = r2.gameid"
-                             . "  and r3.id != r2.id"
-                             . "  and r3.userid = '$curuser'"
-                             . " left outer join playedgames as pg"
-                             . "  on pg.userid = '$curuser'"
-                             . "  and pg.gameid = r2.gameid"
-                             . " left outer join wishlists as wl"
-                             . "  on wl.userid = '$curuser'"
-                             . "  and wl.gameid = r2.gameid"
-                             . " left outer join unwishlists as uw"
-                             . "  on uw.userid = '$curuser'"
-                             . "  and uw.gameid = r2.gameid";
-            $andOtherUser = "and r1.userid != '$curuser'"
-                            . " and r2.userid != '$curuser'"
-                            . " and r3.id is null"
-                            . " and ifnull(now() >= r3.embargodate, 1)"
-                            . " and pg.userid is null"
-                            . " and wl.userid is null"
-                            . " and uw.userid is null";
-        } else {
-            $joinOtherUser = "";
-            $andOtherUser = "";
-        }
+        
         $result = mysql_query(
             "select
                games.id as id,
@@ -1549,7 +1510,6 @@ if (!isEmpty($genre)) {
                (games,
                reviews as r1,
                reviews as r2)
-               $joinOtherUser
             where
                r1.gameid = '$qid'
                and r1.special is null and r2.special is null
@@ -1561,7 +1521,6 @@ if (!isEmpty($genre)) {
                and ifnull(now() >= r1.embargodate, 1)
                and ifnull(now() >= r2.embargodate, 1)
                and not (games.flags & " . FLAG_SHOULD_HIDE . ")
-               $andOtherUser
             group by r2.gameid
             order by rand()
             limit 0, 3", $db);
@@ -1570,30 +1529,6 @@ if (!isEmpty($genre)) {
         $crosscnt = mysql_num_rows($result);
         for ($crossrecs = array(), $i = 0 ; $i < $crosscnt ; $i++)
             $crossrecs[] = mysql_fetch_array($result, MYSQL_ASSOC);
-
-        // add current-user exclusions for explicit cross-recs, if logged in
-        if ($curuser && !$cssOverride) {
-            $joinOtherUser = "left outer join playedgames as pg"
-                             . "  on pg.userid = '$curuser'"
-                             . "  and pg.gameid = c.togame"
-                             . " left outer join wishlists as wl"
-                             . "  on wl.userid = '$curuser'"
-                             . "  and wl.gameid = c.togame"
-                             . " left outer join unwishlists as uw"
-                             . "  on uw.userid = '$curuser'"
-                             . "  and uw.gameid = c.togame"
-                             . " left outer join crossrecs as cmine "
-                             . "  on cmine.fromgame = c.fromgame"
-                             . "  and cmine.togame = c.togame"
-                             . "  and cmine.userid = '$curuser'";
-            $andOtherUser = "and cmine.togame is null"
-                            . " and pg.userid is null"
-                            . " and wl.userid is null"
-                            . " and uw.userid is null";
-        } else {
-            $joinOtherUser = "";
-            $andOtherUser = "";
-        }
 
         // check for explicit cross-recommendations
         $result = mysql_query(
@@ -1611,11 +1546,9 @@ if (!isEmpty($genre)) {
                crossrecs as c
                join games as g on g.id = c.togame
                join crossrecs as c2 on c2.togame = c.togame
-               $joinOtherUser
              where
                c.fromgame = '$qid'
                and not (g.flags & " . FLAG_SHOULD_HIDE . ")
-               $andOtherUser
              group by
                c.fromgame, c.togame
              order by


### PR DESCRIPTION
Fixes https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/223

It's not very clear to me why, but personalizing these recommendations makes the query take 15+ seconds in local dev, and milliseconds without personalization.

This might be a bit excessive; I don't think the queries for recommended lists and/or polls were very impacted by personalization. The main pain point was excluding ratings belonging to the current user when calculating recommended games, and excluding games that the current player had added to their playlist, wishlist, or unwishlist.