### PR TITLE
Improve recommendation performance on game details page

### DIFF
--- a/www/viewgame
+++ b/www/viewgame
@@ -1514,26 +1514,16 @@ if (!isEmpty($genre)) {
         // play list or wish list - they obviously already know about
         // these games, so there's no reason to recommend them.
         if ($curuser && !$cssOverride) {
-            $joinOtherUser = "left outer join reviews as r3"
-                             . "  on r3.gameid = r2.gameid"
-                             . "  and r3.id != r2.id"
-                             . "  and r3.userid = '$curuser'"
-                             . " left outer join playedgames as pg"
-                             . "  on pg.userid = '$curuser'"
-                             . "  and pg.gameid = r2.gameid"
-                             . " left outer join wishlists as wl"
-                             . "  on wl.userid = '$curuser'"
-                             . "  and wl.gameid = r2.gameid"
-                             . " left outer join unwishlists as uw"
-                             . "  on uw.userid = '$curuser'"
-                             . "  and uw.gameid = r2.gameid";
-            $andOtherUser = "and r1.userid != '$curuser'"
-                            . " and r2.userid != '$curuser'"
-                            . " and r3.id is null"
-                            . " and ifnull(now() >= r3.embargodate, 1)"
-                            . " and pg.userid is null"
-                            . " and wl.userid is null"
-                            . " and uw.userid is null";
+            $joinOtherUser = "";
+            $andOtherUser = "and r1.userid != '$curuser'
+                             and r2.userid != '$curuser'
+                             and r2.gameid not in (
+                                select gameid from playedgames pg where pg.userid = '$curuser'
+                                union
+                                select gameid from wishlists wl where wl.userid = '$curuser'
+                                union
+                                select gameid from unwishlists uw where uw.userid = '$curuser'
+                            )";
         } else {
             $joinOtherUser = "";
             $andOtherUser = "";


### PR DESCRIPTION
The old query was doing a bunch of joins to exclude games from the current user's played games, wishlist, and unwishlist. This query grabs all of those game IDs with a subselect, which improves game details performance 100x in my local testing, from 15 seconds down to 0.15 seconds. (But I could never reproduce performance THAT bad on dev.ifdb.org)

(I don't even understand the purpose of joining to the reviews table a third time as long as we're excluding the current user from r1 and r2; I hope this doesn't introduce a weird regression.)

Fixes https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/223