### PR TITLE
Provide expand/collapse functionality for large author lists

### DIFF
--- a/www/allreviews
+++ b/www/allreviews
@@ -268,6 +268,7 @@ if ($errMsg) {
             $gameid = $rec['gameid'];
             $title = htmlspecialcharx($rec['title']);
             $author = htmlspecialcharx($rec['author']);
+            $author = collapsedAuthors($author);
             echo $headlineDiv
                 . "<a href=\"viewgame?id=$gameid\"><b><i>$title</i></b></a>"
                 . ", by $author</div>";

--- a/www/allupdates
+++ b/www/allupdates
@@ -145,6 +145,7 @@ if (mysql_num_rows($result) == 0) {
         // fix up fields for display
         $title = htmlspecialcharx($title);
         $author = htmlspecialcharx($author);
+        $author = collapsedAuthors($author);
 
         // show the entry
         echo "<p><a href=\"viewgame?id=$gameid\"><i>$title</i></a>, "

--- a/www/components/ifdb-recommends.php
+++ b/www/components/ifdb-recommends.php
@@ -353,6 +353,7 @@ if (count($recs) >= 2) {
         $gameid = $r['gameid'];
         $title = htmlspecialcharx($r['title']);
         $author = htmlspecialcharx($r['author']);
+        $author = collapsedAuthors($author);
         $hasart = $r['hasart'];
         list($summary, $len, $trunc) = summarizeHtml($r['desc'], 140);
         $summary = fixDesc($summary);

--- a/www/editgame
+++ b/www/editgame
@@ -125,6 +125,7 @@ if (isset($_REQUEST['search']))
                 $id = $row['id'];
                 $title = htmlspecialcharx($row['title']);
                 $author = htmlspecialcharx($row['author']);
+                $author = collapsedAuthors($author);
 
                 echo "<p><a href=\"editgame?id=$id\"><i>$title</i></a>, "
                     . "by $author <span class=details style='padding-left:1em'>"

--- a/www/editlist
+++ b/www/editlist
@@ -908,6 +908,7 @@ var listVals = [
             if (isset($item['tuid']) && $item['tuid'] != "") {
                 $tuid = jsSpecialChars($item['tuid']);
                 $author = jsSpecialChars($item['author']);
+                $author = collapsedAuthors($author);
                 $pubyear = jsSpecialChars($item['pubyear']);
                 $hasart = $item['hasart'];
             }

--- a/www/gamelink
+++ b/www/gamelink
@@ -88,6 +88,7 @@ if (isset($_REQUEST['id'])) {
             $title = htmlspecialcharx(mysql_result($result, $i, "title"));
             $titleParam = urlencode(mysql_result($result, $i, "title"));
             $author = htmlspecialcharx(mysql_result($result, $i, "author"));
+            $author = collapsedAuthors($author);
             echo "<a href=\"gamelink?id=$id&title=$titleParam\">"
                 . "$title</a>, by $author<br>";
         }

--- a/www/lists.php
+++ b/www/lists.php
@@ -8,6 +8,7 @@ function listMatchItem($match, $num, $showArt, $rating, $hrefTarget)
     $id = htmlspecialcharx($match['id']);
     $title = htmlspecialcharx($match['title']);
     $author = htmlspecialcharx($match['author']);
+    $author = collapsedAuthors($author);
     $pubyear = $match['pubyear'];
     $art = $showArt && $match['hasart'];
 

--- a/www/personal
+++ b/www/personal
@@ -113,6 +113,7 @@ if ($fullReviewCnt == 0) {
             mysql_fetch_row($result);
         $title = htmlspecialcharx($title);
         $author = htmlspecialcharx($author);
+        $author = collapsedAuthors($author);
         $embargo =
             ($embargoDate
              ? " <span class=details>(hidden until $embargoDate)</span> "
@@ -315,7 +316,7 @@ if (mysql_num_rows($result) == 0) {
         echo "<a href=\"viewgame?id=$gameid\"><i>"
             . htmlspecialcharx($title)
             . "</i></a>, by "
-            . htmlspecialcharx($author)
+            . collapsedAuthors(htmlspecialcharx($author))
             . "<br>";
     }
 
@@ -342,7 +343,7 @@ for ($i = 0 ; $i < $maxgames && $i < mysql_num_rows($result) ; $i++) {
     echo "<a href=\"viewgame?id=$gameid\"><i>"
         . htmlspecialcharx($title)
         . "</i></a>, by "
-        . htmlspecialcharx($author)
+        . collapsedAuthors(htmlspecialcharx($author))
         . "<br>";
 }
 
@@ -371,7 +372,7 @@ for ($i = 0 ; $i < $maxgames && $i < mysql_num_rows($result) ; $i++) {
     echo "<a href=\"viewgame?id=$gameid\"><i>"
         . htmlspecialcharx($title)
         . "</i></a>, by "
-        . htmlspecialcharx($author)
+        . collapsedAuthors(htmlspecialcharx($author))
         . "<br>";
 }
 
@@ -481,7 +482,7 @@ if (count($games) == 0) {
     foreach ($games as $g) {
         echo "<a href=\"viewgame?id={$g['id']}\"><i>"
             . htmlspecialcharx($g['title']) . "</i></a>, by "
-            . htmlspecialcharx($g['author'])
+            . collapsedAuthors(htmlspecialcharx($g['author']))
             . "<span class=details> - "
             . ($g['pagevsn'] == 1 ? "created" : "edited")
             . " on {$g['md']}</span><br>";

--- a/www/playlist
+++ b/www/playlist
@@ -216,6 +216,7 @@ if ($errMsg) {
             $gameid = $rec['gameid'];
             $title = htmlspecialcharx($rec['title']);
             $author = htmlspecialcharx($rec['author']);
+            $author = collapsedAuthors($author);
             list($desc, $desclen, $desctrun) = summarizeHtml($rec['desc'], 210);
             $desc = fixDesc($desc);
             $shouldHide = $rec['flags'] & FLAG_SHOULD_HIDE;

--- a/www/playlist
+++ b/www/playlist
@@ -234,7 +234,7 @@ if ($errMsg) {
                     . "</a></td>"
                     . "<td>";
             
-            echo "<p><a href=\"viewgame?id=$gameid\"><i>$title</i></a>, "
+            echo "<a href=\"viewgame?id=$gameid\"><i>$title</i></a>, "
                 . "by $author";
 
             if ($listtype == "reviewideas")

--- a/www/random
+++ b/www/random
@@ -172,6 +172,7 @@ if ($rowcnt == 0) {
         $id = $row['id'];
         $title = output_encode(htmlspecialcharx($row['title']));
         $author = output_encode(htmlspecialcharx($row['author']));
+        $author = collapsedAuthors($author);
         $stars = showStars($row['avgrating']);
         $year = output_encode(htmlspecialcharx($row['pubyear']));
         $art = $row['hasart'];

--- a/www/review
+++ b/www/review
@@ -92,6 +92,7 @@ if (isset($_REQUEST['browse']))
 
                 $title = htmlspecialcharx($title);
                 $author = htmlspecialcharx($author);
+                $author = collapsedAuthors($author);
                 $mode = array();
                 if ($pgid) $mode[] = "on your play list";
                 if ($rating) $mode[] = "you rated it " . showStars($rating);
@@ -166,7 +167,7 @@ if (isset($_REQUEST['browse']))
                 $id = $row['id'];
                 $title = htmlspecialcharx($row['title']);
                 $author = htmlspecialcharx($row['author']);
-
+                $author = collapsedAuthors($author);
                 echo "<p><a href=\"review?id=$id&userid=$userid\"><i>$title</i></a>, "
                     . "by $author <span class=details style='padding-left:1em'>"
                     . "<a href=\"viewgame?id=$id\">View Listing</a> - "
@@ -196,6 +197,7 @@ if (mysql_num_rows($result) == 0)
 // get the game's title and author
 $title = htmlspecialcharx(mysql_result($result, 0, "title"));
 $author = htmlspecialcharx(mysql_result($result, 0, "author"));
+$author = collapsedAuthors($author);
 
 // get the logged-in username
 $result = mysql_query("select name, location, `privileges` from users

--- a/www/search
+++ b/www/search
@@ -1424,6 +1424,7 @@ else if ($term || $browse)
                 }
                 $title = output_encode(htmlspecialcharx($row['title']));
                 $author = output_encode(htmlspecialcharx($row['author']));
+                $author = collapsedAuthors($author);
                 $stars = $shouldHide ? "" : showStars($row['avgrating']);
                 $year = output_encode(htmlspecialcharx($row['pubyear']));
                 $art = $row['hasart'];

--- a/www/showuser
+++ b/www/showuser
@@ -482,6 +482,7 @@ function pingMultiUserSession(sid, gameid, title, author, started)
             $gid = urlencode($rec['id']);
             $title = htmlspecialcharx($rec['title']);
             $author = htmlspecialcharx($rec['author']);
+            $author = collapsedAuthors($author);
             $art = $rec['hasart'];
             $descInfo = summarizeHtml($rec['desc'], 200);
             $desc = fixDesc($descInfo[0]);
@@ -689,6 +690,7 @@ function pingMultiUserSession(sid, gameid, title, author, started)
             // fix up fields for display
             $title = htmlspecialcharx($title);
             $author = htmlspecialcharx($author);
+            $author = collapsedAuthors($author);
             $summary = htmlspecialcharx($summary);
             list($review, $revlen, $revtrunc) = summarizeHtml($review, 140);
             $review = fixDesc($review);
@@ -764,6 +766,7 @@ function pingMultiUserSession(sid, gameid, title, author, started)
                 list($gid, $title, $author) = mysql_fetch_row($result);
                 $title = htmlspecialcharx($title);
                 $author = htmlspecialcharx($author);
+                $author = collapsedAuthors($author);
                 echo "<a href=\"viewgame?id=$gid\"><i>$title</i></a>, "
                     . "by $author<br>";
             }
@@ -794,6 +797,7 @@ function pingMultiUserSession(sid, gameid, title, author, started)
                 list($gid, $title, $author) = mysql_fetch_row($result);
                 $title = htmlspecialcharx($title);
                 $author = htmlspecialcharx($author);
+                $author = collapsedAuthors($author);
                 echo "<a href=\"viewgame?id=$gid\"><i>$title</i></a>, "
                     . "by $author<br>";
             }
@@ -825,6 +829,7 @@ function pingMultiUserSession(sid, gameid, title, author, started)
                 list($gid, $title, $author) = mysql_fetch_row($result);
                 $title = htmlspecialcharx($title);
                 $author = htmlspecialcharx($author);
+                $author = collapsedAuthors($author);
                 echo "<a href=\"viewgame?id=$gid\"><i>$title</i></a>, "
                     . "by $author<br>";
             }

--- a/www/util.php
+++ b/www/util.php
@@ -3132,5 +3132,29 @@ function coverArtThumbnail($id, $size, $params = "") {
     return "<img srcset=\"$thumbnail{$size}x$size$params, $thumbnail{$x15}x$x15$params 1.5x, $thumbnail{$x2}x$x2$params 2x, $thumbnail{$x3}x$x3$params 3x\" src=\"/viewgame?id=$id&coverart&thumbnail={$size}x$size\" height=$size width=$size border=0 alt=\"\">";
 }
 
+// ----------------------------------------------------------------------------
+//
+// Turns a comma-separated list of more than twenty-five authors into
+// a collapsed, expandable list of authors
+//
+
+function collapsedAuthors($authors) {
+    $authorArr = explode(', ', $authors);
+    $str = "";
+    
+    if (count($authorArr) > 25) {
+        $firstAuthor = array_shift($authorArr);
+        $secondAuthor = array_shift($authorArr);
+        
+        $str =  "$firstAuthor, $secondAuthor et al."
+                . "<details><summary>Show other authors</summary>"
+                . implode(', ', $authorArr)
+                . "</details>";
+    }
+    else {
+        $str = $authors;
+    }
+    return $str;
+}
 
 ?>

--- a/www/viewcomp
+++ b/www/viewcomp
@@ -438,6 +438,7 @@ for ($i = 0 ; $i < count($divs) ; $i++) {
         $gameplace = htmlspecialcharx($game["place"]);
         $gametitle = htmlspecialcharx($game["title"]);
         $gameauthor = htmlspecialcharx($game["author"]);
+        $gameauthor = collapsedAuthors($gameauthor);
 
         // display it
         echo "$gameplace: <a href=\"viewgame?id=$gameid\">"

--- a/www/viewgame
+++ b/www/viewgame
@@ -1765,6 +1765,7 @@ if (count($xrefs) != 0) {
     echo "<br>";
     for ($i = 0 ; $i < count($xrefs) ; $i++) {
         $x = $xrefs[$i];
+        $x['author'] = collapsedAuthors($x['author']);
         $fn = $x['fromname'];
         $fn = str_replace(array("<language>", "<system>"),
                           array($languageNameOnly, $system),
@@ -1798,6 +1799,7 @@ if (count($inrefs) != 0 && !$historyView) {
             
         for ( ; $i < $j ; ++$i) {
             $x = $inrefs[$i];
+            $x['author'] = collapsedAuthors($x['author']);
             echo "<span class=notes>"
                 . "<a href=\"viewgame?id={$x['fromid']}\">"
                 . "<i>{$x['title']}</i></a>"


### PR DESCRIPTION
This is a fix for https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/292.

Any time a game has more than twenty-five authors, this fix will change the list to a collapsed, expandable list of authors that takes up much less space.

Currently, the only game that has enough authors to trigger this change is Cragne Manor.

I tried to update all of the pages on the website where game authors are displayed. One exception is the `viewgame` page where we decided to keep the original, hyperlinked author list fully expanded. There were a few other pages where the changes weren't easy to do and/or the probability that anyone would specifically be looking at Cragne Manor on the pages was almost nil. Of course, if I missed something, let me know, and I can fix it.