### PR TITLE
Add regular test user to the local dev database

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,11 @@ The IFDB web app is a LAMP app (Linux, Apache, MySQL, PHP). The development envi
 
 3. Run `docker-compose up`. That will launch a MySQL Docker container and an Apache container with PHP, available on port 8080.
 
-4. Go to `http://localhost:8080` on your machine. You should see IFDB running. You can login as `ifdbadmin` at `ifdb.org` with the password `secret` to sign in as an administrator. The administrator has access to the "system maintenance panel" at `http://localhost:8080/adminops`
+4. Go to `http://localhost:8080` on your machine. You should see IFDB running. You can login as `ifdbadmin` at `ifdb.org` with the password `secret` to sign in as an administrator. The administrator has access to the "system maintenance panel" at `http://localhost:8080/adminops`.
 
-5. Optionally, you can query the database using phpMyAdmin at `http://localhost:8081` or run `docker exec -it ifdb_db_1 mysql -psecret ifdb` to use the MySQL command-line interface.
+5. Alternatively, you can login as `test` at `ifdb.org` with the password `secret` to sign in as a regular test user named `Test Tester`.
+
+6. Optionally, you can query the database using phpMyAdmin at `http://localhost:8081` or run `docker exec -it ifdb_db_1 mysql -psecret ifdb` to use the MySQL command-line interface.
 
 # Database Changes
 

--- a/prepare_dev_environment.sh
+++ b/prepare_dev_environment.sh
@@ -12,5 +12,6 @@ mkdir initdb
 cat sql/create-db.sql ifdb-archive.sql > initdb/00-init.sql
 cp sql/patch-schema.sql initdb/01-patch-schema.sql
 cp sql/create-admin.sql initdb/02-create-admin.sql
+cp sql/create-test-user.sql initdb/03-create-test-user.sql
 
 sed 's/"127.0.0.1", "username", "password"/"db", "root", "secret"/' local-credentials.php.template > www/local-credentials.php

--- a/sql/create-test-user.sql
+++ b/sql/create-test-user.sql
@@ -1,0 +1,3 @@
+USE ifdb;
+
+INSERT INTO `users` (`id`, `name`, `created`, `email`, `emailflags`, `profilestatus`, `password`, `pswsalt`, `activationcode`, `acctstatus`, `privileges`) VALUES ('0000000000000001', 'Test Tester', now(), 'test@ifdb.org', '3', 'R', 'e47e74efb16c07efac450882bdfeaeba0677f3df', '02cbc07fd9c2e9a699f7a28df9833771', '3cd02536097bd7c576f1f4fd0c9798ca38fcc227', 'A', '');


### PR DESCRIPTION
This is a fix for issue https://github.com/iftechfoundation/ifdb/issues/84.

Adds a test regular user named `Test Tester` to the local dev database so you don't have to go through the extra steps of registering and the activating a test user.