### PR TITLE
Fix detection of HTML character references in fixDesc

### DIFF
--- a/www/util.php
+++ b/www/util.php
@@ -1299,7 +1299,7 @@ function fixDesc($desc, $specials = 0)
         case '&':
             // if it's &lt;, &gt;, &#xxxxx;, &quot; or &amp;, leave it;
             // otherwise convert the & to &amp;
-            $therest = substr($desc, $ofs + 1, 7);
+            $therest = substr($desc, $ofs + 1, 8);
             if (strncasecmp($therest, "lt;", 3) == 0
                 || strncasecmp($therest, "gt;", 3) == 0) {
                 $ofs += 3;
@@ -1307,8 +1307,10 @@ function fixDesc($desc, $specials = 0)
                 $ofs += 4;
             } else if (strncasecmp($desc, "quot;", 5) == 0) {
                 $ofs += 5;
-            } else if (preg_match("/^#[0-9]{1,5};/", $therest, $match)) {
-                $ofs += strlen($match);
+            } else if (preg_match("/^#[0-9]{1,6};/", $therest, $matches)) {
+                $ofs += strlen($matches[0]);
+            } else if (preg_match("/^#[xX][0-9A-Fa-f]{1,6};/", $therest, $matches)) {
+                $ofs += strlen($matches[0]);
             } else {
                 // not recognized - make it an explicit &amp;
                 $desc = substr_replace($desc, "&amp;", $ofs, 1);


### PR DESCRIPTION
`fixDesc` currently generates a warning when mistaking the output of `preg_match` to be an array instead of string:

```
php > include_once "www/util.php";
php > echo fixDesc("<p>&#11354;</p>");
PHP Warning:  strlen() expects parameter 1 to be string, array given in www/util.php on line 1311
<p>&#11354;</p>
```

This commit fixes it, and also adds detection of hex-style character references such as `&#x1F354;`.
Note that both types can have any number of digits, but I only increased the current code's limit by one, which should be enough for emojis.