### PR TITLE
Fix buggy mysql function calls

### DIFF
--- a/www/adminops
+++ b/www/adminops
@@ -108,7 +108,7 @@ if (isset($_REQUEST['burygame'])) {
                     set flags = '$newflags'
                     where id = '$qid'", $db);
                 if (!$result) {
-                    error_log($mysql_error($db));
+                    error_log(mysql_error($db));
                     echo "There was an error setting the flag.";
                 }
                 $flags = $newflags;
@@ -1289,12 +1289,12 @@ else if (isset($_REQUEST['users'])) {
         if ($rebuild || $sortTitle == "")
             $setVars[] = "sort_title = '"
                          . mysql_real_escape_string(strtoupper(
-                             getSortingTitle($title))) . "'";
+                             getSortingTitle($title)), $db) . "'";
 
         if ($rebuild || $sortAuthor == "")
             $setVars[] = "sort_author = '"
                          . mysql_real_escape_string(strtoupper(
-                             getSortingPersonalNameList($author))) . "'";
+                             getSortingPersonalNameList($author)), $db) . "'";
 
         $setVars = implode(",", $setVars);
         $result = mysql_query(
@@ -1849,7 +1849,7 @@ else if (isset($_REQUEST['users'])) {
                filterID, filterName, ckBoxName, showName, endDate,
                filterType, explanation
              from filters
-             where filterid = '$qFilterID'");
+             where filterid = '$qFilterID'", $db);
         if (mysql_num_rows($result) > 0) {
             list($filterID, $filterName, $ckBoxName, $showName, $endDate,
                  $filterType, $explanation) = mysql_fetch_row($result);

--- a/www/dbconnect.php
+++ b/www/dbconnect.php
@@ -42,7 +42,7 @@ function dbConnect()
     $dbinfo = localCredentials();
 
     // connect and select the correct database
-    $db = mysql_connect($dbinfo[0], $dbinfo[1], $dbinfo[2], true);
+    $db = mysql_connect($dbinfo[0], $dbinfo[1], $dbinfo[2]);
     mysql_set_charset($db, "latin1");
     if ($db != false)
         $result = mysql_select_db("ifdb", $db);
@@ -62,7 +62,7 @@ function imageDbConnect($dbnum)
     $dbinfo = localImageCredentials();
     
     // connect and select the database
-    $db = mysql_connect($dbinfo[0], $dbinfo[1], $dbinfo[2], true);
+    $db = mysql_connect($dbinfo[0], $dbinfo[1], $dbinfo[2]);
     if ($db != false)
         mysql_select_db("ifdb_images" . $dbnum, $db);
 
@@ -77,7 +77,7 @@ function storageDbConnect()
     $sdbinfo = localStorageCredentials();
 
     // connect and select the correct database
-    $sdb = mysql_connect($sdbinfo[0], $sdbinfo[1], $sdbinfo[2], true);
+    $sdb = mysql_connect($sdbinfo[0], $sdbinfo[1], $sdbinfo[2]);
     if ($sdb != false)
         $result = mysql_select_db("storage", $sdb);
 

--- a/www/util.php
+++ b/www/util.php
@@ -2915,7 +2915,7 @@ function close_user_acct($db, $uid, $stat, &$progress)
 
     // unlock tables, if we haven't already
     if ($tableLocks)
-        mysql_query("unlock tables");
+        mysql_query("unlock tables", $db);
 
     // return the success/failure indication
     return $result;


### PR DESCRIPTION
These were found with the static analysis tool [Psalm](https://psalm.dev).

1. Several mysql functions were missing the crucial $db parameter.
2. An error-handler was called with an errant `$`.
3. `mysql_connect` was called with an extra (ignored) parameter.

I didn't test any of these.