### PR TITLE
Silence static analyzer errors by adding missing includes, moving functions around

### DIFF
--- a/www/adminops
+++ b/www/adminops
@@ -7,7 +7,7 @@ include_once "login-persist.php";
 $userid = checkPersistentLogin();
 
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "useractivation.php";
 
 include_once "dbconnect.php";

--- a/www/adminops
+++ b/www/adminops
@@ -1601,18 +1601,6 @@ else if (isset($_REQUEST['users'])) {
     echo "<p>Rows successfully updated: $okCnt<br>";
 
 } else if (isset($_REQUEST['cleanpix'])) {
-
-    function adjustImageName($name)
-    {
-        if (isLocalDev()
-            && strpos($name, ":") !== false)
-        {
-            $name = explode(":", $name);
-            $name[0] = "0";
-            $name = implode(":", $name);
-        }
-        return $name;
-    }
     echo "<h1>Scanning for unreferenced images</h1>"
         . "<form name=\"fixpix\" method=post action=\"adminops\">"
         . "<input type=hidden name=cleanpix value=1>";
@@ -2228,6 +2216,18 @@ else if (isset($_REQUEST['addnews'])) {
     }
 
     echo "</table>";
+}
+
+function adjustImageName($name)
+{
+    if (isLocalDev()
+        && strpos($name, ":") !== false)
+    {
+        $name = explode(":", $name);
+        $name[0] = "0";
+        $name = implode(":", $name);
+    }
+    return $name;
 }
 
 function check_table_utf8($table, $idcol, $cols)

--- a/www/alllists
+++ b/www/alllists
@@ -3,7 +3,7 @@ include_once "session-start.php";
 
 
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 include_once "dbconnect.php";
 $db = dbConnect();

--- a/www/allnew
+++ b/www/allnew
@@ -3,7 +3,7 @@
 include_once "session-start.php";
 include_once "dbconnect.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "login-persist.php";
 include "newitems.php";
 

--- a/www/allnew-rss
+++ b/www/allnew-rss
@@ -3,7 +3,7 @@
 include_once "session-start.php";
 include_once "dbconnect.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "login-persist.php";
 include "newitems.php";
 

--- a/www/allpolls
+++ b/www/allpolls
@@ -3,7 +3,7 @@ include_once "session-start.php";
 
 
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 include_once "dbconnect.php";
 $db = dbConnect();

--- a/www/allreviews
+++ b/www/allreviews
@@ -15,7 +15,7 @@ include_once "session-start.php";
 include_once "login-persist.php";
 $curuser = checkPersistentLogin();
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 include_once "dbconnect.php";
 $db = dbConnect();

--- a/www/allupdates
+++ b/www/allupdates
@@ -1,13 +1,13 @@
 <?php
 include_once "session-start.php";
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 include_once "dbconnect.php";
 $db = dbConnect();
 
 // note if we're logged in
-include "login-check.php";
+include_once "login-check.php";
 $curuser = checkPersistentLogin();
 
 // get the request parameter

--- a/www/changepsw
+++ b/www/changepsw
@@ -1,6 +1,6 @@
 <?php
 include_once "session-start.php";
-include "login-check.php";
+include_once "login-check.php";
 if (provisionally_logged_in())
     $usernum = $_SESSION['provisional_logged_in_as'];
 else if (logged_in())
@@ -8,7 +8,7 @@ else if (logged_in())
 else
     exit();
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "dbconnect.php";
 
 // start the page

--- a/www/club
+++ b/www/club
@@ -1,11 +1,11 @@
 <?php
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 include_once "captcha.php";
 include_once "news.php";
 include_once "rss.php";
-include "login-check.php";
+include_once "login-check.php";
 
 include_once "session-start.php";
 

--- a/www/code-of-conduct
+++ b/www/code-of-conduct
@@ -1,5 +1,5 @@
 <?php
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 varPageHeader("IFDB Code of Conduct", false, get_req_data('helpwin'));
 

--- a/www/comment.php
+++ b/www/comment.php
@@ -2,7 +2,7 @@
 
 // we have to be logged in to do this
 include_once "session-start.php";
-include "login-check.php";
+include_once "login-check.php";
 include_once "captcha.php";
 include_once "akismet.php";
 
@@ -12,7 +12,7 @@ if (!logged_in())
 $curuser = $_SESSION['logged_in_as'];
 
 // include some utility modules
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 
 // connect to the database

--- a/www/commentlog
+++ b/www/commentlog
@@ -7,11 +7,11 @@ include_once "login-persist.php";
 $curuser = checkPersistentLogin();
 
 // include some utility modules
-include "pagetpl.php";
+include_once "pagetpl.php";
 include "reviews.php";
 include_once "util.php";
 include_once "commentutil.php";
-include "login-check.php";
+include_once "login-check.php";
 
 // connect to the database
 include_once "dbconnect.php";

--- a/www/contact
+++ b/www/contact
@@ -1,6 +1,6 @@
 <?php
 include_once "session-start.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 include_once "captcha.php";
 

--- a/www/copyright
+++ b/www/copyright
@@ -1,6 +1,6 @@
 <?php
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 
 pageHeader("IFDB Copyright and Trademark Information");
 

--- a/www/crossrec
+++ b/www/crossrec
@@ -11,7 +11,7 @@ include_once "login-check.php";
 include_once "login-persist.php";
 $curuser = checkPersistentLogin();
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 include "starctl.php";
 

--- a/www/css
+++ b/www/css
@@ -1,6 +1,6 @@
 <?php
 include_once "session-start.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 
 include_once "dbconnect.php";

--- a/www/delclub
+++ b/www/delclub
@@ -2,12 +2,12 @@
 
 include_once "session-start.php";
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 include "starctl.php";
 
 // we have to be logged in to edit a competition
-include "login-check.php";
+include_once "login-check.php";
 if (!logged_in())
     exit();
 

--- a/www/delcomp
+++ b/www/delcomp
@@ -2,12 +2,12 @@
 
 include_once "session-start.php";
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 include "starctl.php";
 
 // we have to be logged in to edit a competition
-include "login-check.php";
+include_once "login-check.php";
 if (!logged_in())
     exit();
 

--- a/www/delgame
+++ b/www/delgame
@@ -2,13 +2,13 @@
 
 include_once "session-start.php";
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 include "starctl.php";
 include_once "gamesearchpopup.php";
 
 // we have to be logged in to edit a game
-include "login-check.php";
+include_once "login-check.php";
 if (!logged_in())
     exit();
 

--- a/www/delpoll
+++ b/www/delpoll
@@ -2,12 +2,12 @@
 
 include_once "session-start.php";
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 include "starctl.php";
 
 // we have to be logged in to delete a poll
-include "login-check.php";
+include_once "login-check.php";
 if (!logged_in())
     exit();
 

--- a/www/dladviser
+++ b/www/dladviser
@@ -5,7 +5,7 @@ include_once "session-start.php";
 include_once "login-persist.php";
 $userid = checkPersistentLogin();
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 include_once "dbconnect.php";
 $db = dbConnect();

--- a/www/downloadinfo
+++ b/www/downloadinfo
@@ -1,7 +1,7 @@
 <?php
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 
 include_once "dbconnect.php";
 $db = dbConnect();

--- a/www/editImageCopyright
+++ b/www/editImageCopyright
@@ -1,13 +1,13 @@
 <?php
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 include_once "images.php";
 include "imageuploadhandler.php";
 
 // we have to be logged in to edit a game
 include_once "session-start.php";
-include "login-check.php";
+include_once "login-check.php";
 if (!logged_in())
     exit();
 

--- a/www/editclub
+++ b/www/editclub
@@ -1,6 +1,6 @@
 <?php
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 include_once "combobox.php";
 include_once "starctl.php";
@@ -11,7 +11,7 @@ include_once "profilelink.php";
 
 // we have to be logged in to edit a game
 include_once "session-start.php";
-include "login-check.php";
+include_once "login-check.php";
 if (!logged_in())
     exit();
 

--- a/www/editcomp
+++ b/www/editcomp
@@ -1,6 +1,6 @@
 <?php
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 include_once "combobox.php";
 include_once "profilelink.php";
@@ -8,7 +8,7 @@ include_once "gamesearchpopup.php";
 
 // we have to be logged in to edit a competition
 include_once "session-start.php";
-include "login-check.php";
+include_once "login-check.php";
 if (!logged_in())
     exit();
 

--- a/www/editgame
+++ b/www/editgame
@@ -1,6 +1,6 @@
 <?php
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 include_once "combobox.php";
 include_once "starctl.php";
@@ -12,7 +12,7 @@ include_once "editgame-util.php";
 include_once "session-start.php";
 
 // we have to be logged in to edit a game
-include "login-check.php";
+include_once "login-check.php";
 if (!logged_in())
     exit();
 

--- a/www/editlist
+++ b/www/editlist
@@ -1,13 +1,13 @@
 <?php
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 include "lists.php";
 include_once "gamesearchpopup.php";
 
 // we have to be logged in to edit a game
 include_once "session-start.php";
-include "login-check.php";
+include_once "login-check.php";
 if (!logged_in())
     exit();
 

--- a/www/editnews
+++ b/www/editnews
@@ -2,7 +2,7 @@
 
 // we have to be logged in to do this
 include_once "session-start.php";
-include "login-check.php";
+include_once "login-check.php";
 if (!logged_in())
     exit();
 

--- a/www/editprofile
+++ b/www/editprofile
@@ -4,8 +4,8 @@ include_once "captcha.php";
 include_once "akismet.php";
 
 include_once "session-start.php";
-include "login-check.php";
-include "pagetpl.php";
+include_once "login-check.php";
+include_once "pagetpl.php";
 include_once "util.php";
 if (provisionally_logged_in())
     $usernum = $_SESSION['provisional_logged_in_as'];

--- a/www/error403
+++ b/www/error403
@@ -1,5 +1,5 @@
 <?php
-include "pagetpl.php";
+include_once "pagetpl.php";
 
 include_once "session-start.php";
 

--- a/www/error404
+++ b/www/error404
@@ -1,5 +1,5 @@
 <?php
-include "pagetpl.php";
+include_once "pagetpl.php";
 
 include_once "session-start.php";
 

--- a/www/error503
+++ b/www/error503
@@ -1,5 +1,5 @@
 <?php
-include "pagetpl.php";
+include_once "pagetpl.php";
 
 include_once "session-start.php";
 

--- a/www/fileformat
+++ b/www/fileformat
@@ -1,6 +1,6 @@
 <?php
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 
 // we have to be logged in to edit a game

--- a/www/gamelink
+++ b/www/gamelink
@@ -1,6 +1,6 @@
 <?php
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 
 $title = get_req_data('title');
 $titleForm =

--- a/www/help-add-game
+++ b/www/help-add-game
@@ -1,7 +1,7 @@
 <?php
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 helpPageHeader("Guidelines for New Game Listings");
 ?>
 

--- a/www/help-author
+++ b/www/help-author
@@ -1,7 +1,7 @@
 <?php
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 helpPageHeader("Tips for the Author Field");
 ?>
 

--- a/www/help-bafs
+++ b/www/help-bafs
@@ -1,7 +1,7 @@
 <?php
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 helpPageHeader("Baf's Guide Identifiers");
 ?>
 

--- a/www/help-crossrec
+++ b/www/help-crossrec
@@ -1,7 +1,7 @@
 <?php
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 helpPageHeader("Automatic Recommendations");
 ?>
 

--- a/www/help-css
+++ b/www/help-css
@@ -1,7 +1,7 @@
 <?php
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 helpPageHeader("CSS Help");
 ?>
 

--- a/www/help-discussions
+++ b/www/help-discussions
@@ -1,7 +1,7 @@
 <?php
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 helpPageHeader("Discussions");
 ?>
 

--- a/www/help-dla
+++ b/www/help-dla
@@ -1,7 +1,7 @@
 <?php
 include_once "session-start.php";
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 
 pageHeader("How the Download Adviser Works");
 

--- a/www/help-dlsafety
+++ b/www/help-dlsafety
@@ -1,7 +1,7 @@
 <?php
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 helpPageHeader("Notes on Download Safety");
 ?>
 

--- a/www/help-edit-game
+++ b/www/help-edit-game
@@ -1,7 +1,7 @@
 <?php
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 helpPageHeader("Guidelines for Game Listings");
 ?>
 

--- a/www/help-ff
+++ b/www/help-ff
@@ -1,7 +1,7 @@
 <?php
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 helpPageHeader("Frequent Fiction Points");
 ?>
 

--- a/www/help-forgiveness
+++ b/www/help-forgiveness
@@ -1,7 +1,7 @@
 <?php
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 helpPageHeader("Forgiveness Ratings");
 ?>
 

--- a/www/help-formatting
+++ b/www/help-formatting
@@ -1,7 +1,7 @@
 <?php
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 $review = isset($_REQUEST['review']);
 $comment = isset($_REQUEST['comment']);
 helpPageHeader("Formatting Hints");

--- a/www/help-gameprofilelink
+++ b/www/help-gameprofilelink
@@ -1,7 +1,7 @@
 <?php
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 helpPageHeader("Linking a game to your profile");
 ?>
 

--- a/www/help-ifid
+++ b/www/help-ifid
@@ -1,7 +1,7 @@
 <?php
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 helpPageHeader("What's an IFID?");
 ?>
 

--- a/www/help-image-quota
+++ b/www/help-image-quota
@@ -1,7 +1,7 @@
 <?php
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 helpPageHeader("Why is there an image limit?");
 ?>
 

--- a/www/help-license-type
+++ b/www/help-license-type
@@ -1,7 +1,7 @@
 <?php
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 helpPageHeader("IF License Types");
 ?>
 

--- a/www/help-link-policy
+++ b/www/help-link-policy
@@ -1,7 +1,7 @@
 <?php
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 helpPageHeader("Policy for Download Links");
 ?>
 

--- a/www/help-links
+++ b/www/help-links
@@ -1,7 +1,7 @@
 <?php
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 
 include_once "dbconnect.php";
 $db = dbConnect();

--- a/www/help-new-user-remarks
+++ b/www/help-new-user-remarks
@@ -1,7 +1,7 @@
 <?php
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 helpPageHeader("Guidelines for New Game Listings");
 ?>
 

--- a/www/help-pending-link
+++ b/www/help-pending-link
@@ -1,7 +1,7 @@
 <?php
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 helpPageHeader("Pending Download Links");
 ?>
 

--- a/www/help-polls
+++ b/www/help-polls
@@ -1,7 +1,7 @@
 <?php
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 helpPageHeader("What's an IFDB Poll?");
 ?>
 

--- a/www/help-reclist
+++ b/www/help-reclist
@@ -1,7 +1,7 @@
 <?php
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 helpPageHeader("What's a Recommended List?");
 ?>
 

--- a/www/help-review
+++ b/www/help-review
@@ -1,7 +1,7 @@
 <?php
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 helpPageHeader("Review Guidelines");
 ?>
 

--- a/www/help-review-votes
+++ b/www/help-review-votes
@@ -1,7 +1,7 @@
 <?php
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 helpPageHeader("Review Voting Options");
 ?>
 

--- a/www/help-spamcloaking
+++ b/www/help-spamcloaking
@@ -1,7 +1,7 @@
 <?php
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 helpPageHeader("E-Mail Spam Cloaking");
 ?>
 

--- a/www/help-stars
+++ b/www/help-stars
@@ -1,7 +1,7 @@
 <?php
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 helpPageHeader("Star Ratings");
 ?>
 

--- a/www/help-storyfile
+++ b/www/help-storyfile
@@ -1,7 +1,7 @@
 <?php
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 helpPageHeader("What's a \"Story File\"?");
 ?>
 

--- a/www/help-tag-numbers
+++ b/www/help-tag-numbers
@@ -1,7 +1,7 @@
 <?php
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 helpPageHeader("What do the tag numbers mean?");
 ?>
 

--- a/www/help-tags
+++ b/www/help-tags
@@ -1,7 +1,7 @@
 <?php
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 helpPageHeader("What's a tag?");
 ?>
 

--- a/www/help-top-rev
+++ b/www/help-top-rev
@@ -1,7 +1,7 @@
 <?php
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 helpPageHeader("Who Qualifies for Top Reviewer Status?");
 ?>
 

--- a/www/help-tuid
+++ b/www/help-tuid
@@ -1,7 +1,7 @@
 <?php
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 helpPageHeader("What's a TUID?");
 ?>
 

--- a/www/help-xrefs
+++ b/www/help-xrefs
@@ -1,7 +1,7 @@
 <?php
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 helpPageHeader("Cross-References");
 ?>
 

--- a/www/help-zip-primary
+++ b/www/help-zip-primary
@@ -1,7 +1,7 @@
 <?php
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 
 include_once "dbconnect.php";
 $db = dbConnect();

--- a/www/home
+++ b/www/home
@@ -3,7 +3,7 @@
 include_once "session-start.php";
 include_once "dbconnect.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "login-persist.php";
 include "newitems.php";
 include_once "commentutil.php";

--- a/www/ifarchive-upload
+++ b/www/ifarchive-upload
@@ -7,7 +7,7 @@ include_once "pagetpl.php";
 include_once "dbconnect.php";
 
 // we have to be logged in to upload a game
-include "login-check.php";
+include_once "login-check.php";
 if (!logged_in())
     exit();
 $userid = $_SESSION['logged_in_as'];

--- a/www/login
+++ b/www/login
@@ -1,6 +1,6 @@
 <?php
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 include_once "login-check.php";
 include_once "dbconnect.php";

--- a/www/logout
+++ b/www/logout
@@ -16,7 +16,7 @@ $_SESSION['logged_in_as'] = null;
 // clear the recommendation cache
 shoot_recommendation_cache();
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 pageHeader("Logged out");
 ?>
 <h1>Logged Out</h1>

--- a/www/lostact
+++ b/www/lostact
@@ -1,7 +1,7 @@
 <?php
 
 include_once "session-start.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 include_once "dbconnect.php";
 include_once "captcha.php";

--- a/www/lostpass
+++ b/www/lostpass
@@ -1,7 +1,7 @@
 <?php
 
 include_once "session-start.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 include_once "dbconnect.php";
 include_once "captcha.php";

--- a/www/mergegame
+++ b/www/mergegame
@@ -1,12 +1,12 @@
 <?php
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 include "starctl.php";
 
 // we have to be logged in to edit a game
 include_once "session-start.php";
-include "login-check.php";
+include_once "login-check.php";
 if (!logged_in())
     exit();
 

--- a/www/needjs
+++ b/www/needjs
@@ -1,5 +1,5 @@
 <?php
-include "pagetpl.php";
+include_once "pagetpl.php";
 
 pageHeader("JavaScript Required");
 ?>

--- a/www/news
+++ b/www/news
@@ -5,7 +5,7 @@ include_once "dbconnect.php";
 $db = dbConnect();
 
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 
 // check for RSS
 if (isset($_REQUEST['rss'])) {

--- a/www/newslog
+++ b/www/newslog
@@ -2,7 +2,7 @@
 
 include_once "session-start.php";
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 include_once "dbconnect.php";
 include_once "news.php";

--- a/www/newuser
+++ b/www/newuser
@@ -2,7 +2,7 @@
 
 include_once "session-start.php";
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "dbconnect.php";
 include_once "util.php";
 include_once "captcha.php";

--- a/www/opsys
+++ b/www/opsys
@@ -1,6 +1,6 @@
 <?php
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 
 // we have to be logged in to edit a game

--- a/www/personal
+++ b/www/personal
@@ -1,13 +1,13 @@
 <?php
 
 include_once "session-start.php";
-include "login-check.php";
+include_once "login-check.php";
 if (!logged_in())
     exit();
 
 include_once "dbconnect.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "commentutil.php";
 include_once "storage-util.php";
 

--- a/www/playlist
+++ b/www/playlist
@@ -2,10 +2,10 @@
 include_once "session-start.php";
 
 // note if we're logged in
-include "login-check.php";
+include_once "login-check.php";
 $curuser = checkPersistentLogin();
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 include_once "dbconnect.php";
 $db = dbConnect();

--- a/www/poll
+++ b/www/poll
@@ -1,9 +1,9 @@
 <?php
 
 include_once "session-start.php";
-include "login-check.php";
+include_once "login-check.php";
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 include "lists.php";
 include_once "commentutil.php";

--- a/www/privacy
+++ b/www/privacy
@@ -1,6 +1,6 @@
 <?php
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 varPageHeader("IFDB Privacy Policy", false, get_req_data('helpwin'));
 ?>
 

--- a/www/random
+++ b/www/random
@@ -6,7 +6,7 @@ include_once "session-start.php";
 include_once "login-persist.php";
 checkPersistentLogin();
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 
 include_once "dbconnect.php";

--- a/www/resetpsw
+++ b/www/resetpsw
@@ -1,6 +1,6 @@
 <?php
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "dbconnect.php";
 
 include_once "session-start.php";

--- a/www/review
+++ b/www/review
@@ -1,6 +1,6 @@
 <?php
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 include_once "dbconnect.php";
 include_once "starctl.php";
@@ -8,7 +8,7 @@ include_once "searchutil.php";
 
 // we have to be logged in to enter/edit a review
 include_once "session-start.php";
-include "login-check.php";
+include_once "login-check.php";
 if (!logged_in())
     exit();
 

--- a/www/reviewcommentlog
+++ b/www/reviewcommentlog
@@ -7,7 +7,7 @@ include_once "login-persist.php";
 $curuser = checkPersistentLogin();
 
 // include some utility modules
-include "pagetpl.php";
+include_once "pagetpl.php";
 include "reviews.php";
 include_once "util.php";
 

--- a/www/reviewflag
+++ b/www/reviewflag
@@ -2,14 +2,14 @@
 
 // we have to be logged in to do this
 include_once "session-start.php";
-include "login-check.php";
+include_once "login-check.php";
 if (!logged_in())
     exit();
 
 $curuser = $_SESSION['logged_in_as'];
 
 // include some utility modules
-include "pagetpl.php";
+include_once "pagetpl.php";
 include "reviews.php";
 include_once "util.php";
 

--- a/www/reviews.php
+++ b/www/reviews.php
@@ -2,7 +2,7 @@
 
 // To use this module:
 //
-// include "pagetpl.php";
+// include_once "pagetpl.php";
 //
 // put the following extra text in the <HEAD> section:
 //    <script src="xmlreg.js"></script>

--- a/www/reviewunflag
+++ b/www/reviewunflag
@@ -2,14 +2,14 @@
 
 // we have to be logged in to do this
 include_once "session-start.php";
-include "login-check.php";
+include_once "login-check.php";
 if (!logged_in())
     exit();
 
 $curuser = $_SESSION['logged_in_as'];
 
 // include some utility modules
-include "pagetpl.php";
+include_once "pagetpl.php";
 include "reviews.php";
 include_once "util.php";
 

--- a/www/reviewvote
+++ b/www/reviewvote
@@ -2,8 +2,8 @@
 
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
-include "login-check.php";
+include_once "pagetpl.php";
+include_once "login-check.php";
 
 function sendResponse($statmsg, $errmsg, $detail)
 {

--- a/www/rollbackGameVersion
+++ b/www/rollbackGameVersion
@@ -9,7 +9,7 @@ $curuser = checkPersistentLogin();
 include_once "dbconnect.php";
 $db = dbConnect();
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 include "starctl.php";
 include_once "rss.php";

--- a/www/search
+++ b/www/search
@@ -6,7 +6,7 @@ include_once "session-start.php";
 include_once "login-persist.php";
 checkPersistentLogin();
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 include_once "searchutil.php";
 

--- a/www/search
+++ b/www/search
@@ -283,27 +283,6 @@ if ($pg == 'all') {
     $limit = "limit $firstOnPage, $perPage";
 }
 
-// callback to prepend a "+" to a search word
-function prependPlus($txt)
-{
-    return "+" . $txt;
-}
-
-// is the given string a name suffix?
-function isNameSuffix($s)
-{
-    return in_array(strtolower($s),
-                    array("jr", "jr.", "sr", "sr.", "phd", "ph.d.",
-                          "md", "m.d."));
-}
-
-function unNegate($w)
-{
-    if (substr($w, 0, 1) == '-')
-        $w = substr($w, 1);
-    return $w;
-}
-
 // if we have a search term, find it
 if ($term || $browse) {
 

--- a/www/searchapi
+++ b/www/searchapi
@@ -2,8 +2,8 @@
 
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
-include "login-check.php";
+include_once "pagetpl.php";
+include_once "login-check.php";
 
 function sendResponse($errmsg, $body)
 {

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -3,6 +3,21 @@
 include_once "util.php";
 include_once "login-persist.php";
 
+// is the given string a name suffix?
+function isNameSuffix($s)
+{
+    return in_array(strtolower($s),
+                    array("jr", "jr.", "sr", "sr.", "phd", "ph.d.",
+                          "md", "m.d."));
+}
+
+function unNegate($w)
+{
+    if (substr($w, 0, 1) == '-')
+        $w = substr($w, 1);
+    return $w;
+}
+
 function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
 {
     // we need the current user for some types of queries

--- a/www/setplayed
+++ b/www/setplayed
@@ -2,8 +2,8 @@
 
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
-include "login-check.php";
+include_once "pagetpl.php";
+include_once "login-check.php";
 
 function sendResponse($statmsg, $errmsg, $detail, $newCnt = -1)
 {

--- a/www/setrating
+++ b/www/setrating
@@ -2,8 +2,8 @@
 
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
-include "login-check.php";
+include_once "pagetpl.php";
+include_once "login-check.php";
 
 function sendResponse($statmsg, $errmsg, $detail)
 {

--- a/www/setunwishlist
+++ b/www/setunwishlist
@@ -2,8 +2,8 @@
 
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
-include "login-check.php";
+include_once "pagetpl.php";
+include_once "login-check.php";
 
 function sendResponse($statmsg, $errmsg, $detail, $newCount = -1)
 {

--- a/www/setwishlist
+++ b/www/setwishlist
@@ -2,8 +2,8 @@
 
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
-include "login-check.php";
+include_once "pagetpl.php";
+include_once "login-check.php";
 
 function sendResponse($statmsg, $errmsg, $detail, $newCount = -1)
 {

--- a/www/showtags
+++ b/www/showtags
@@ -6,7 +6,7 @@ include_once "session-start.php";
 include_once "login-persist.php";
 checkPersistentLogin();
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 
 include_once "dbconnect.php";

--- a/www/showuser
+++ b/www/showuser
@@ -1,7 +1,7 @@
 <?php
 include_once "session-start.php";
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 include_once "dbconnect.php";
 include_once "commentutil.php";
@@ -14,7 +14,7 @@ $sdb = storageDbConnect();
 $uid = isset($_REQUEST['id']) ? $_REQUEST['id'] : null;
 
 // check for persistent login
-include "login-check.php";
+include_once "login-check.php";
 $curuser = checkPersistentLogin();
 
 // check for an unlock override - this allows the administrator to

--- a/www/taggame
+++ b/www/taggame
@@ -2,8 +2,8 @@
 
 include_once "session-start.php";
 include_once "util.php";
-include "pagetpl.php";
-include "login-check.php";
+include_once "pagetpl.php";
+include_once "login-check.php";
 
 function sendResponse($statmsg, $errmsg, $detail, $tagInfo)
 {

--- a/www/taggamedelete
+++ b/www/taggamedelete
@@ -2,8 +2,8 @@
 
 @session_start();
 include_once "util.php";
-include "pagetpl.php";
-include "login-check.php";
+include_once "pagetpl.php";
+include_once "login-check.php";
 
 function sendResponse($statmsg, $errmsg, $detail, $tagInfo)
 {

--- a/www/tips
+++ b/www/tips
@@ -1,5 +1,5 @@
 <?php
-include "pagetpl.php";
+include_once "pagetpl.php";
 pageHeader("Tips on Using IFDB", false);
 ?>
 

--- a/www/tos
+++ b/www/tos
@@ -1,5 +1,5 @@
 <?php
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 varPageHeader("IFDB Terms of Service", false, get_req_data('helpwin'));
 

--- a/www/userconfirm
+++ b/www/userconfirm
@@ -1,7 +1,7 @@
 <?php
 
 include_once "session-start.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "dbconnect.php";
 include_once "util.php";
 include_once "useractivation.php";

--- a/www/userfilter
+++ b/www/userfilter
@@ -2,14 +2,14 @@
 
 // we have to be logged in to do this
 include_once "session-start.php";
-include "login-check.php";
+include_once "login-check.php";
 if (!logged_in())
     exit();
 
 $curuser = $_SESSION['logged_in_as'];
 
 // include some utility modules
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 
 // connect to the database

--- a/www/util.php
+++ b/www/util.php
@@ -2,11 +2,15 @@
 
 include_once "dbconnect.php";
 include_once "images.php";
+include_once "login-check.php";
 include_once "login-persist.php";
+include_once "pagetpl.php";
 
 // --------------------------------------------------------------------------
 // mysqli replacements (for compatibility across php versions)
 
+define("MYSQL_ASSOC", MYSQLI_ASSOC);
+define("MYSQL_BOTH",  MYSQLI_BOTH);
 function mysql_connect($server, $user, $password) { return mysqli_connect($server, $user, $password); }
 function mysql_set_charset($linkid, $charset) { return mysqli_set_charset($linkid, $charset); }
 function mysql_select_db($db, $linkid = NULL) { return mysqli_select_db($linkid, $db); }
@@ -24,8 +28,6 @@ function mysql_result($result, $row, $field = 0) {
     return $row[$field];
 }
 function mysql_insert_id($linkid) { return mysqli_insert_id($linkid); }
-define("MYSQL_ASSOC", MYSQLI_ASSOC);
-define("MYSQL_BOTH",  MYSQLI_BOTH);
 
 define("PRODUCTION_SERVER_NAME", "ifdb.org");
 define("STAGING_SERVER_NAME", "dev.ifdb.org");

--- a/www/util.php
+++ b/www/util.php
@@ -355,12 +355,12 @@ function generateTUID($db, $tableCol, $maxtries)
     for ($tries = 0, $result = 1 ; $result && $tries < $maxtries ; $tries++)
     {
         // generate a random ID
-        $tuid = base_convert(rand(0, 46655), 10, 36)
-                . base_convert(rand(0, 46655), 10, 36)
-                . base_convert(rand(0, 46655), 10, 36)
-                . base_convert(rand(0, 46655), 10, 36)
-                . base_convert(rand(0, 46655), 10, 36)
-                . base_convert(rand(0, 35), 10, 36);
+        $tuid = base_convert(strval(rand(0, 46655)), 10, 36)
+                . base_convert(strval(rand(0, 46655)), 10, 36)
+                . base_convert(strval(rand(0, 46655)), 10, 36)
+                . base_convert(strval(rand(0, 46655)), 10, 36)
+                . base_convert(strval(rand(0, 46655)), 10, 36)
+                . base_convert(strval(rand(0, 35)), 10, 36);
 
         if (!$tableCol)
             return $tuid;

--- a/www/viewcomp
+++ b/www/viewcomp
@@ -1,7 +1,7 @@
 <?php
 
 include_once "session-start.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 include_once "news.php";
 include_once "rss.php";

--- a/www/viewgame
+++ b/www/viewgame
@@ -6,7 +6,7 @@ include_once "session-start.php";
 include_once "login-persist.php";
 $curuser = checkPersistentLogin();
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 include "starctl.php";
 include_once "rss.php";

--- a/www/viewlist
+++ b/www/viewlist
@@ -2,7 +2,7 @@
 
 include_once "session-start.php";
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 include "lists.php";
 

--- a/www/whoselist
+++ b/www/whoselist
@@ -2,10 +2,10 @@
 include_once "session-start.php";
 
 // note if we're logged in
-include "login-check.php";
+include_once "login-check.php";
 $curuser = checkPersistentLogin();
 
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 include_once "dbconnect.php";
 $db = dbConnect();

--- a/www/why-captcha
+++ b/www/why-captcha
@@ -1,6 +1,6 @@
 <?php
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 smallPageHeader("Why do I have to enter the code?");
 ?>
 

--- a/www/whylicense
+++ b/www/whylicense
@@ -1,5 +1,5 @@
 <?php
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "util.php";
 varPageHeader("More on Content Licensing", false, get_req_data('helpwin'));
 ?>

--- a/www/xmxlat
+++ b/www/xmxlat
@@ -1,5 +1,7 @@
 <?php
 
+include_once "util.php";
+
 function connect($dom, $uid, $psw, $infoMode)
 {
     $u = "http://xmro.$dom/xstream/login_servlet.jsp";


### PR DESCRIPTION
1. Some files were missing explicit includes (These are already included by including other files).
2. Some helper functions and defines were in the wrong scope.
3. `base_convert` expects a string, so added an explicit conversion from int.