### PR TITLE
Escape all single quotes in tag name argument for deleteTag() link

### DIFF
--- a/www/viewgame
+++ b/www/viewgame
@@ -2431,7 +2431,8 @@ function dispTagTable(tableID, lst, editor, deleteTags)
                s = "<span class=\"cklabel\" onmouseover=\"javascript:"
                 + "ckboxOver('"+ck+"',false);return true;\" "
                 + "onmouseout=\"javascript:ckboxLeave('"+ck+"',false);"
-                + "return true;\" onclick=\"javascript:deleteTag('"+t
+                + "return true;\" onclick=\"javascript:deleteTag('"
+                + t.replace(/'/g,"\\'")
                 + "');return false;\">"
 	    	        + "<input type=image align=absmiddle border=0 id=\"ckImg"+ck+"\""
 	    	        + "src='delrow.gif' >";			


### PR DESCRIPTION
Fix for IFDB Issue #165.

Edited: This is a fix for Issue #165. Ignore the incorrect branch name. Thanks.