### PR TITLE
Load recommendations on the home page asynchronously

### DIFF
--- a/www/async-recommendations
+++ b/www/async-recommendations
@@ -1,0 +1,19 @@
+<?php
+include_once "session-start.php";
+include_once "dbconnect.php";
+include_once "util.php";
+include "pagetpl.php";
+include_once "login-persist.php";
+include "newitems.php";
+include_once "commentutil.php";
+
+$db = dbConnect();
+
+$uid = checkPersistentLogin();
+$quid = mysql_real_escape_string($uid, $db);
+
+$loggedIn = (isset($_SESSION['logged_in']) && $_SESSION['logged_in']);
+
+$async = true;
+include "components/ifdb-recommends.php";
+?>

--- a/www/components/ifdb-recommends.php
+++ b/www/components/ifdb-recommends.php
@@ -18,7 +18,7 @@ if ($loggedIn) {
         $recs = $_SESSION['ifdb_recommendations'];
         $recsrc = $_SESSION['ifdb_recommendations_source'];
 
-    } else {
+    } else if ($async) {
 
         // No recommendations are cached, so come up with some new ones
         // First, generate a list giving the "rating distance" from each
@@ -267,6 +267,27 @@ if ($loggedIn) {
                 if ($debugflag) echo "record count=" . count($recs) . "<br>";
             }
         }
+    } else {
+      ?>
+      <div id="recommendations">Loading...</div>
+      <script>
+        void function() {
+          var element = document.getElementById('recommendations')
+          var xhr = new XMLHttpRequest();
+          xhr.open("GET", '/async-recommendations', true);
+          xhr.onreadystatechange = function() {
+            if (xhr.readyState !== 4) return;
+            if (xhr.status == 200) {
+              element.innerHTML = xhr.responseText;
+            } else {
+              element.innerHTML = "<span class=errmsg>There was an error loading recommendations.</span>";
+            }
+          }
+          xhr.send();
+        }();
+      </script>
+      <?php
+      return;
     }
 }
 

--- a/www/home
+++ b/www/home
@@ -26,7 +26,7 @@ if ($uid) {
     $caughtUpDate = mysql_result($result, 0, "caughtupdate");
 }
 
-$debugflag = $adminPriv && get_req_data('debug') == 'yesDebug';
+$debugflag = get_req_data('debug') == 'yesDebug';
 if ($debugflag) echo "debug mode enabled...<br>";
 ?>
 


### PR DESCRIPTION
The recommendation engine can take seconds to run. It starts by querying all of the games that the current user has rated, and then finds all of the users that have rated those games, then finds all of their ratings. It stores the results in a temporary table to find users who like the same games that you like ("like-minded users"). It then attempts to find games that you haven't rated that are highly rated by the group, and if that fails, it attempts to find games that any like-minded user likes.

That's… a lot.

In this implementation, the "IFDB Recommends" section now loads asynchronously if you're logged in and we're computing recommendations, replacing the "IFDB Recommends" section with "Loading..." and using JavaScript to make a request for recommendations in the background. When the recommendations are computed, we inject them directly into the page, and cache them in a server-side session cache, so refreshing the home page in the future will show recommendations directly in the HTML source.