### PR TITLE
Improve home page performance

### DIFF
--- a/www/components/ifdb-recommends.php
+++ b/www/components/ifdb-recommends.php
@@ -289,6 +289,16 @@ if ($loggedIn) {
       <?php
       return;
     }
+} else {
+  $topGamesCacheFile = sys_get_temp_dir() . '/top-games-cache';
+  $isFresh = filemtime($topGamesCacheFile) > time()-25*3600;
+  if ($isFresh) {
+    $input = file_get_contents($topGamesCacheFile);
+    if ($input) {
+      $recs = unserialize($input);
+      $recsrc = 'generic';
+    }
+  }
 }
 
 // if our recommendation list is empty, pick some random 4- and 5-star

--- a/www/components/top-reviewers.php
+++ b/www/components/top-reviewers.php
@@ -4,7 +4,15 @@
 
    <ol>
    <?php
-   $rlst = getTopReviewers($db, 4);
+   $topReviewersCacheFile = sys_get_temp_dir() . '/top-reviewers-cache';
+   $isFresh = filemtime($topReviewersCacheFile) > time()-25*3600;
+   if ($isFresh) {
+      $input = file_get_contents($topReviewersCacheFile);
+      if ($input) {
+         $rlst = unserialize($input);
+      }
+   }
+   if (!$rlst) $rlst = getTopReviewers($db, 4);
    $n = 1;
    foreach ($rlst as $r) {
       list($ruid, $runame, $rscore) = $r;

--- a/www/refresh-top-games
+++ b/www/refresh-top-games
@@ -1,0 +1,39 @@
+<?php
+include_once "dbconnect.php";
+include_once "util.php";
+
+// a cron job will call this to refresh the list of top-rated games
+
+$db = dbConnect();
+
+$maxpicks = 12;
+
+$result = mysql_query(
+        "select
+           games.id as gameid,
+           games.title as title,
+           games.author as author,
+           games.`desc` as `desc`,
+           (games.coverart is not null) as hasart,
+           starsort
+         from
+           games
+           join gameRatingsSandbox0 on games.id = gameid
+         where
+           starsort >= 4
+           and not (games.flags & " . FLAG_SHOULD_HIDE . ")
+         order by
+           starsort desc
+         limit
+           0, $maxpicks", $db);
+
+if (!$result) throw new Exception(mysql_error($db));
+
+$recs = array();
+for ($i = 0 ; $i < mysql_num_rows($result) ; $i++)
+    $recs[] = mysql_fetch_array($result, MYSQL_ASSOC);
+
+$output = serialize($recs);
+
+file_put_contents(sys_get_temp_dir() . '/top-games-cache', $output);
+?>

--- a/www/refresh-top-reviewers
+++ b/www/refresh-top-reviewers
@@ -1,0 +1,16 @@
+<?php
+include_once "dbconnect.php";
+include_once "util.php";
+
+// a cron job will call this to refresh the frequent-fiction top reviewers
+
+$db = dbConnect();
+
+$count = 4;
+
+$reviewers = getTopReviewers($db, $count);
+
+$output = serialize($reviewers);
+
+file_put_contents(sys_get_temp_dir() . '/top-reviewers-cache', $output);
+?>


### PR DESCRIPTION
Here we define two cache files for query results that can take a long time on the home page: the top games list (we query for 12 top games by starsort) and the top reviewers by Frequent Fiction.

The top games list only affects the logged-out home page.
The top reviewers list affects both logged in and logged out.

In a quick test on production ifdb.org, each of these queries sometimes took a few hundred milliseconds, but sometimes took multiple seconds to run, each.