### PR TITLE
Improve RSS reviews feed

### DIFF
--- a/www/newitems.php
+++ b/www/newitems.php
@@ -726,6 +726,17 @@ function showNewItemsRSS($db, $showcnt)
             if (!is_null($r['summary'])) {
                 $title .= ": \"{$r['summary']}\"";
             }
+            if ($r['rating']) {
+                $stars = " ";
+                for ($i = 0; $i < 5; $i++) {
+                    if ($i < $r['rating']) {
+                        $stars .= "&#9733;"; // &starf;
+                    } else {
+                        $stars .= "&#9734;"; // &star;
+                    }
+                }
+                $title .= $stars;
+            }
             list($summary, $len, $trunc) = summarizeHtml($r['review'], 140);
             $desc = fixDesc($summary);
             $link = get_root_url() . "viewgame?id={$r['gameid']}"

--- a/www/newitems.php
+++ b/www/newitems.php
@@ -737,8 +737,7 @@ function showNewItemsRSS($db, $showcnt)
                 }
                 $title .= $stars;
             }
-            list($summary, $len, $trunc) = summarizeHtml($r['review'], 140);
-            $desc = fixDesc($summary);
+            $desc = fixDesc($r['review'], FixDescSpoiler | FixDescRSS);
             $link = get_root_url() . "viewgame?id={$r['gameid']}"
                     . "&review={$r['reviewid']}";
             $pubDate = $r['d'];

--- a/www/newitems.php
+++ b/www/newitems.php
@@ -723,6 +723,9 @@ function showNewItemsRSS($db, $showcnt)
             } else {
                 $title = "A review of \"{$r['title']}\"";
             }
+            if (!is_null($r['summary'])) {
+                $title .= ": \"{$r['summary']}\"";
+            }
             list($summary, $len, $trunc) = summarizeHtml($r['review'], 140);
             $desc = fixDesc($summary);
             $link = get_root_url() . "viewgame?id={$r['gameid']}"

--- a/www/newitems.php
+++ b/www/newitems.php
@@ -718,10 +718,11 @@ function showNewItemsRSS($db, $showcnt)
         if ($pick == 'R')
         {
             $r = $row;
-            $title = "A review "
-                     . (is_null($r['special'])
-                        ? "by {$r['username']}" : "")
-                     . " of {$r['title']}";
+            if (is_null($r['special'])) {
+                $title = "{$r['username']} reviews \"{$r['title']}\"";
+            } else {
+                $title = "A review of \"{$r['title']}\"";
+            }
             list($summary, $len, $trunc) = summarizeHtml($r['review'], 140);
             $desc = fixDesc($summary);
             $link = get_root_url() . "viewgame?id={$r['gameid']}"


### PR DESCRIPTION
A handful of enhancements to https://ifdb.org/allnew-rss adding the review titles, star rating, and full text.

I tested this on a local dev environment by creating a test review:

Title: `Test <b>bold</b> <i>italic</i> <script>alert('beep')</script>`
Full text: `This is a <b>bold</b> <i>italic</i> <script>alert('beep')</script> <spoiler>spoiler</spoiler>`

I verified that this review looked correct on the site. I copied and pasted my RSS output from `http://localhost:8080` to https://validator.w3.org/feed/#validate_by_input to ensure correctness, and I also loaded the feed up into NetNewsWire for macOS, a popular free RSS newsreader app. My weird test review rendered correctly, and so did a number of other reviews visible on the site.

I've deployed it to the dev site; I was able to load up the RSS feed in NetNewsWire from there using https://iftfuser:xxxxxxx@dev.ifdb.org/allnew-rss (replacing `xxx` with the actual password)

(I also created an "special" review, by reviewing a game and checking the "Special review type" "external" option. To my surprise, when I did that, I found that the review disappeared from the HTML page and from the RSS feed entirely. That left me no way to verify that the `if ($r['special'])` version worked, since those reviews were already automatically missing from the RSS feed, but, if I'm right that these are being hidden on the site, then I scarcely care.)