### PR TITLE
Show "Delete This Page" link to admins on all game listings

### DIFF
--- a/www/viewgame
+++ b/www/viewgame
@@ -3064,6 +3064,9 @@ dispTags();
                 $deletePageLink =
                     "- <a href=\"delgame?id=$id\">Delete This Page</a>";
             }
+        } else if ($adminPriv) {
+            $deletePageLink =
+                "- <a href=\"delgame?id=$id\">Delete This Page</a>";
         }
 
         // add the footer showing the version/edit links


### PR DESCRIPTION
Previously, the "Delete This Page" link would only show if you're the user who created the page, and if nobody else had edited the page. Moderators would have to manually edit the URL to the `delgame` page. That was silly!