### PR TITLE
Fix author: searches where the last name contains special characters

### DIFF
--- a/www/util.php
+++ b/www/util.php
@@ -313,14 +313,8 @@ function quoteSqlLike($s)
 // quote a SQL RLIKE term - escape regular-expression characters
 function quoteSqlRLike($s)
 {
-    for ($i = 0 ; $i < strlen($s) ; $i++) {
-        if (strpos('^$.*+?|(){}[]\\', $s{$i}) !== false) {
-            $repl = '[[.' . $s{$i} . '.]]';
-            $s = substr_replace($s, $repl, $i, 1);
-            $i += 6;
-        }
-    }
-    return $s;
+    // https://stackoverflow.com/a/53986553/54829
+    preg_quote($s, '&');
 }
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
mjr had apparently handwritten a regexp escaper, and it no longer works in the current version of MySQL. Luckily, we can now use a utility method for this.

I tested it by pulling a giant list of authors and hand-testing a bunch of them, by clicking through to their game details page and clicking on the author name.

Fixes https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/310