### PR TITLE
Link to HTTPS parchment with HTTPS ifarchive URLs

### DIFF
--- a/www/viewgame
+++ b/www/viewgame
@@ -877,7 +877,7 @@ for ($foundGame = $foundPC = $foundT3W = $foundHex = $pcUrl = $t3wUrl = $hexUrl 
         && !$link['compression'])
     {
         $foundPC = true;
-        $pcUrl = urlencode($link['url']);
+        $pcUrl = urlencode(urlToMirror($link['url']));
     }
 
     // check for a TADS 3 Web UI game
@@ -904,8 +904,7 @@ if ($foundGame)
 
     // if we have a Parchment-capable game, set up a play-with-Parchment link
     if ($foundPC && $pcUrl) {
-        $parchment = "http://iplayif.com/?story=";
-//        $parchment = "http://parchment.googlecode.com/svn/trunk/parchment.html?story=";
+        $parchment = "https://iplayif.com/?story=";
         $ptarget = (is_kindle() ? "" : "target=\"_blank\"");
         echo "<a href=\"$parchment$pcUrl\" $ptarget "
             . "title=\"Play this game right now in your browser, using "


### PR DESCRIPTION
Right now, IFDB's "Play Online" button links to non-HTTPS parchment, and tends to pass it non-HTTPS URLs, e.g. [Lost Pig](https://ifdb.org/viewgame?id=mohwfk47yjzii14w) links to http://iplayif.com/?story=http%3A%2F%2Fwww.ifarchive.org%2Fif-archive%2Fgames%2Fzcode%2FLostPig.z8

In the downloads section, we use the `urlToMirror()` function to HTTPS-ify IF Archive links, but we weren't using it for Parchment links, so I've added that here.

Parchment already automatically redirects http://iplayif.com to https://iplayif.com, and it preserves saves/sessions even when the game URL is updated to https, so this shouldn't screw up any saved games or anything.

(Well, it turns out that redirecting from http: to https: [broke some old Parchment saves/sessions](https://github.com/curiousdannii/parchment/issues/101), but there's nothing that IFDB can do about that.)