### PR TITLE
Don't allow styles iframe to host third-party sites

### DIFF
--- a/www/iframe
+++ b/www/iframe
@@ -6,7 +6,7 @@ $height = $_REQUEST['h'];
 
 echo "<html>"
    . "<body style=\"margin: 0 0 0 0; padding: 0 0 0 0;\">"
-   . "<iframe src=\"$target\" "
+   . "<iframe src=\"/$target\" "
    . "frameborder=0 "
    . "style=\"height: $height; width: $width;\" scrolling=no>"
    . "</object>"


### PR DESCRIPTION
Specifically don't allow attacker to construct an IFDB url hosting third-party login page, e.g. http://localhost:8080/iframe?w=100%&h=100%&t=https://example.com/