### PR TITLE
Re-add Home link for custom themes who hide the header

### DIFF
--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -1166,6 +1166,10 @@ span.headlineRss {
         display: none;
     }
 
+    #topbar-home {
+        display: none;
+    }
+
     #main-nav-wrapper{
         padding: 0;
     }

--- a/www/pagetpl.php
+++ b/www/pagetpl.php
@@ -100,6 +100,7 @@ function pageHeader($title, $focusCtl = false, $extraOnLoad = false,
     <div id="main-nav-wrapper">
         <nav id="main-nav" class="main-nav">
             <div class="nav-left">
+                <a id="topbar-home" href="/">Home</a>
                 <a id="topbar-browse" href="/search?browse">Browse</a>
                 <form class= "searchbar-wrapper" method="get" action="/search" name="search">
                         <input id="topbar-searchbar" type="text" name="searchbar" placeholder="Search for games...">


### PR DESCRIPTION
The Home link is still hidden at mobile sizes, which I *think* is what we want, but I'm not sure…

Deployed to https://dev.ifdb.org/ 

@Iniquit 