### PR TITLE
Fix nav header on pages that don't include session-start

### DIFF
--- a/www/login-persist.php
+++ b/www/login-persist.php
@@ -1,5 +1,7 @@
 <?php
 
+include_once "session-start.php";
+
 include_once "dbconnect.php";
 include_once "util.php";
 


### PR DESCRIPTION
Navigate to a club while logged in. https://ifdb.org/club?id=q77osvrugf7p1i48

Expected: You're logged in, so it should include the Profile, Settings, My Activity, Inbox, and Log Out menu
Actual: It only shows the Login menu item, even though you're already logged in

This is happening because certain pages (club, for example) don't include `session_start.php` before including `pagetpl.php`; it was relying on `session_start.php` as a side-effect from other pages. So in  this PR I'm adding it as an `include_once`.
