### PR TITLE
Fix author: searches where the last name ends with a period

### DIFF
--- a/www/util.php
+++ b/www/util.php
@@ -313,14 +313,8 @@ function quoteSqlLike($s)
 // quote a SQL RLIKE term - escape regular-expression characters
 function quoteSqlRLike($s)
 {
-    for ($i = 0 ; $i < strlen($s) ; $i++) {
-        if (strpos('^$.*+?|(){}[]\\', $s{$i}) !== false) {
-            $repl = '[[.' . $s{$i} . '.]]';
-            $s = substr_replace($s, $repl, $i, 1);
-            $i += 6;
-        }
-    }
-    return $s;
+    // https://stackoverflow.com/a/53986553/54829
+    return preg_quote($s, '&');
 }
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
mjr had apparently handwritten a regexp escaper, and it no longer works in the current version of MySQL. Luckily, we can now use a utility method for this.

Fixes https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/310

This reverts commit 9538be9592774a83d834c3b3a7d72eb8a387f10a.

In my previous attempt, I forgot to return the results of preg_quote. Searches still appeared to work because author searches would go through another code path, but tag searches broke completely.