### PR TITLE
Make latest simplest viewgame version be the rel=canonical

### DIFF
--- a/www/viewgame
+++ b/www/viewgame
@@ -644,6 +644,9 @@ if ($hasart) {
     $extraHead .= get_root_url() . "viewgame?coverart&amp;id=$id\"/>";
 }
 
+$extraHead .= "<link rel=\"canonical\" href=\"";
+$extraHead .= get_root_url() . "viewgame?id=$id\" />";
+
 pageHeader("$title - Details", false, false,
            $extraHead, true);
 initReviewVote();


### PR DESCRIPTION
This will send a hint to search engines, suggesting that they prevent history variants from showing up in search results.

https://developers.google.com/search/docs/advanced/crawling/consolidate-duplicate-urls