### PR TITLE
Add Play Online button if a link title contains "play online"

### DIFF
--- a/www/viewgame
+++ b/www/viewgame
@@ -879,6 +879,12 @@ for ($foundGame = $foundAny = $foundHtml = $foundPC = $foundT3W = $foundHex = $h
         $htmlUrl = $link['url'];
     }
 
+    if (!$foundAny && stripos($link['title'], "Play Online") !== false)
+    {
+        $foundGame = $foundHtml = $foundAny = true;
+        $htmlUrl = $link['url'];
+    }
+
     // if this is the first Parchment-capable link, and it's not compressed,
     // note it so that we can set up a Parchment play link to it
     if (!$foundAny


### PR DESCRIPTION
A lot of links forgot to set the link type and/or check "this link contains a playable game," but they did have the presence of mind to title the link "Play Online." In that case, we can/should just show a button based on that.

Here's a SQL query I wrote to find games that wouldn't have a Play Online button but do have a "Play Online" link.

```sql
select gameid,
    substring(games.title, 1, 50) as title,
    year(published) as year,
    gamelinks.title
from gamelinks
    join gameRatingsSandbox0 using (gameid)
    join games on (gameid = games.id)
where
    gameid in (
        select gameid
        from gamelinks
        where gameid in (
                select distinct gameid
                from gamelinks
                where
                    lower(title) like '%play online%'
                    and attrs not in (1, 3)
            )
            and gameid not in (
                select distinct gameid
                from gamelinks
                where attrs in (1, 3)
                    and fmtid in (2,3,4,6,13,25,27,29,35,44,45,48,49,50,53)
                    and compression is null
            )
    )
    and lower(gamelinks.title) like '%play online%'
order by starsort desc;
```

And I've attached the results as an attachment: [results.txt](https://github.com/iftechfoundation/ifdb/files/7696550/results.txt)

There are 673 games here that didn't have Play Online buttons but now do.