### PR TITLE
Fix nav header on pages that include login-persist.php before util.php

### DIFF
--- a/www/session-start.php
+++ b/www/session-start.php
@@ -1,6 +1,19 @@
 <?php
 
-include_once "util.php";
+define("PRODUCTION_SERVER_NAME", "ifdb.org");
+define("STAGING_SERVER_NAME", "dev.ifdb.org");
+
+function isProduction() {
+    return $_SERVER['SERVER_NAME'] === PRODUCTION_SERVER_NAME;
+}
+
+function isStaging() {
+    return $_SERVER['SERVER_NAME'] === STAGING_SERVER_NAME;
+}
+
+function isLocalDev() {
+    return !isProduction() && !isStaging();
+}
 
 session_set_cookie_params([
     'secure' => !isLocalDev(),

--- a/www/util.php
+++ b/www/util.php
@@ -1,5 +1,6 @@
 <?php
 
+include_once "session-start.php";
 include_once "dbconnect.php";
 include_once "images.php";
 include_once "login-check.php";
@@ -28,9 +29,6 @@ function mysql_result($result, $row, $field = 0) {
     return $row[$field];
 }
 function mysql_insert_id($linkid) { return mysqli_insert_id($linkid); }
-
-define("PRODUCTION_SERVER_NAME", "ifdb.org");
-define("STAGING_SERVER_NAME", "dev.ifdb.org");
 
 // --------------------------------------------------------------------------
 //
@@ -3097,18 +3095,6 @@ function send_mail($to, $subject, $message, $additional_headers) {
     } else {
         return mail($to, $subject, $wrapped, $additional_headers);
     }
-}
-
-function isProduction() {
-    return $_SERVER['SERVER_NAME'] === PRODUCTION_SERVER_NAME;
-}
-
-function isStaging() {
-    return $_SERVER['SERVER_NAME'] === STAGING_SERVER_NAME;
-}
-
-function isLocalDev() {
-    return !isProduction() && !isStaging();
 }
 
 function get_root_url() {


### PR DESCRIPTION
The home page, the search page, and others all have an incorrect nav bar after logging in. (The bar says "Log In" when it should say "Profile, Settings, My Activity, Inbox, Logout.") I think this is a regression from my nav header changes PR #193.

PHP does something weird when you introduce circular dependencies; if A includes B and B includes A, it runs B right up until the point where B includes A, then runs A to completion, and then runs B to completion. That's no good when the dependency is something essential for A to run correctly.

So in this PR we're making util.php depend on session-start.php and ensuring that session-start.php depends on nothing, which guarantees that this will be safe.