### PR TITLE
Fix async recommendations

### DIFF
--- a/www/async-recommendations
+++ b/www/async-recommendations
@@ -2,9 +2,9 @@
 include_once "session-start.php";
 include_once "dbconnect.php";
 include_once "util.php";
-include "pagetpl.php";
+include_once "pagetpl.php";
 include_once "login-persist.php";
-include "newitems.php";
+include_once "newitems.php";
 include_once "commentutil.php";
 
 $db = dbConnect();


### PR DESCRIPTION
To reproduce this bug, login as a user with async recommendations (e.g. login as an admin and impersonate dan@fabulich.com)

You'll see a red error at the bottom of the page, "There was an error loading recommendations."

I see this error in the logs:

>PHP Fatal error:  Cannot redeclare basePageHeader() (previously declared in /var/www/html/pagetpl.php:8) in /var/www/html/pagetpl.php on line 8

Converting to `include_once` fixes it.