### PR TITLE
Improve performance of polls

### DIFF
--- a/sql/patch-schema.sql
+++ b/sql/patch-schema.sql
@@ -52,6 +52,8 @@ ALTER TABLE `users`
     ADD KEY `email` (`email`)
 ;
 
+ALTER TABLE `reviews` ADD KEY `user_game` (userid, gameid);
+
 --
 -- Table structure for table `formatprivs`
 --


### PR DESCRIPTION
The `reviews` table had a `userid` key and a `gameid` key, but MySQL will only use one key at a time. Adding a compound `user_game` key improved the performance of the main query of a the "Games for Beginners" poll from 1.5s to 0.05s.