### PR TITLE
Fixed JS error when logged out

### DIFF
--- a/www/pagetpl.php
+++ b/www/pagetpl.php
@@ -146,8 +146,11 @@ function pageHeader($title, $focusCtl = false, $extraOnLoad = false,
     ToggleMobileMenu();
 
     // If javascript is enabled, un-hide the mobile menu button & add the 'mobile-menu' class to the main nav wrapper,
-    document.querySelector('#mobile-menu-toggle-button').classList.remove('hidden');
-    document.querySelector('#main-nav-wrapper').classList.add('mobile-menu');
+    const toggle = document.querySelector('#mobile-menu-toggle-button');
+    if (toggle) {
+        toggle.classList.remove('hidden');
+        document.querySelector('#main-nav-wrapper').classList.add('mobile-menu');
+    }
 
 })()
 


### PR DESCRIPTION
When you're logged out, there is no mobile toggle button, which caused a JS error on the console.