### PR TITLE
Don't focus search box when loading search page

### DIFF
--- a/www/search
+++ b/www/search
@@ -359,7 +359,7 @@ if (!$xml) {
 
     pageHeader($term == "" && $browse ? "Browse $searchTypeName"
                                       : "Search for $searchTypeName",
-               $browse ? "" : "advsearch.searchfor", false,
+               false, false,
                "<script src=\"xmlreq.js\"></script>");
 
     $commonInstructions =


### PR DESCRIPTION
This leaves the (rather ugly) auto focus mechanism (in `basePageHeader` in `pagetpl.php`) in place as it's being used by some other pages but it may be worth looking into getting rid of it.

Closes iftechfoundation/ifdb-suggestion-tracker#356