### PR TITLE
Make putific support submitting download links with null OS versions

### DIFF
--- a/www/putific
+++ b/www/putific
@@ -567,6 +567,7 @@ if ($linkFile)
     for ($i = 0, $osMap = array() ; $i < mysql_num_rows($result) ; $i++) {
         list($osid, $vsnid, $osext, $vsnext) = mysql_fetch_row($result);
         $osMap["$osext.$vsnext"] = array($osid, $vsnid);
+        $osMap["$osext."] = array($osid, null);
     }
 
     // get the original links from the existing record, if any


### PR DESCRIPTION
There are a bunch of games with download links with null OS versions (that's actually the only way to use certain OSes like "Windows Frotz").

This allows users to submit games with `<os>windows-frotz.</os>` and get a download link that works as well as a hand-made link.