### PR TITLE
Add putific lastversion parameter, to modify listings from other users

### DIFF
--- a/www/api/putific
+++ b/www/api/putific
@@ -278,6 +278,16 @@ redundant listing for the same game.
 
 <p>Ordinary text parameter; optional.
 
+<p><b>lastversion</b>: This parameter represents the current
+version number of the page. This number is shown in the footer of
+the HTML page ("This is version N of this page") or in the XML
+version of the page in the &gt;pageversion&lt; field.
+
+<p>This parameter is required only when editing an IFDB listing, and
+only when another IFDB user has most recently edited the listing.
+When creating a new listing, or when editing a listing that you
+previously edited, the parameter is not required.
+
 <h2>iFiction records</h2>
 
 <p>The iFiction file included in the request must be syntactically
@@ -674,8 +684,8 @@ from the following list:
    <li>CannotMerge: the game has an existing page, and the last version of
        the page was edited by a different user.  The iFiction record can't
        be used to update the page because it might inadvertently overwrite
-       the other user's changes.  The user must manually update the page
-       via the IFDB Web interface.
+       the other user's changes.  The user must submit a &gt;lastversion&lt;
+       parameter.
    <li>ImageCprInvalid: the imageCopyrightStatus parameter value
        is invalid.
    <li>ImageFormatError: the image contents are invalid.  The image either

--- a/www/putific
+++ b/www/putific
@@ -430,20 +430,25 @@ if ($gameid != "new")
     // presume we won't be changing the links
     $req["links"] = $rec["links"];
 
-    // get the page version we're basing our changes on
-    $req["pagevsn"] = $rec["pagevsn"];
+    $lastversion = get_req_data("lastversion");
 
-    // verify that we're the last editor
-    if ($rec["editedby"] != $curuser)
-        replyError(409, "CannotMerge",
-                   "You are attempting to update an existing IFDB listing, "
-                   . "but this listing was last edited by another user. "
-                   . "IFDB is a collaborative system that allows any member "
-                   . "to edit a game listing. To ensure that your iFiction "
-                   . "updates don't overwrite the other user's changes, "
-                   . "please go to the IFDB Web site and review your "
-                   . "game's listing.  You can then edit the page via the "
-                   . "IFDB Web site if you still want to make any changes.");
+    if ($lastversion) {
+        $req["pagevsn"] = $lastversion;
+    } else {
+        // verify that we're the last editor
+        if ($rec["editedby"] == $curuser) {
+            // get the page version we're basing our own changes on
+            $req["pagevsn"] = $rec["pagevsn"];
+        } else {
+            replyError(409, "CannotMerge",
+                    "You are attempting to update an existing IFDB listing, "
+                    . "but this listing was last edited by another user. "
+                    . "IFDB is a collaborative system that allows any member "
+                    . "to edit a game listing. To ensure that your iFiction "
+                    . "updates don't overwrite the other user's changes, "
+                    . "please add a lastversion parameter to your request.");
+        }
+    }
 
     // Copy all of the parameters from the old record that aren't set
     // in the new record.  This ensures that manually edited fields

--- a/www/viewgame
+++ b/www/viewgame
@@ -609,6 +609,7 @@ if (isset($_REQUEST['ifiction']))
 
     echo "<ifdb xmlns=\"http://ifdb.org/api/xmlns\">";
     xmlField("tuid", $id);
+    xmlField("pageversion", $pagevsn);
     xmlField("link", get_root_url() . "viewgame?id=$id");
     if ($hasart) {
         echo "<coverart>";


### PR DESCRIPTION
Previously, `putific` would only allow you to modify listings if you were the most recent user to edit the listing. But the IFDB web UI has a facility for this. When editing a page, it records the last-known version that you knew about. When you submit, it attempts to merge your changes with the existing document.

The `putific` `lastversion` parameter does the same thing, allowing API users to declare the last version they know about, and allowing the merge to go through normally.

This also requires us to add a `<pageversion>` to the `viewgame` API, so API users can discover the last-known version and make changes based on that.