### PR TITLE
IFComp importer

### DIFF
--- a/ifcomp-importer/.gitignore
+++ b/ifcomp-importer/.gitignore
@@ -1,2 +1,4 @@
 node_modules
+cover-art
+cover-art.json
 microdata.json

--- a/ifcomp-importer/.gitignore
+++ b/ifcomp-importer/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+microdata.json

--- a/ifcomp-importer/.gitignore
+++ b/ifcomp-importer/.gitignore
@@ -2,3 +2,5 @@ node_modules
 cover-art
 cover-art.json
 microdata.json
+microdata-*.json
+*.zip

--- a/ifcomp-importer/README.md
+++ b/ifcomp-importer/README.md
@@ -4,14 +4,19 @@ This importer is designed to grab the game list from https://ifcomp.org/ballot a
 2. `process-cover-art.mjs`: This script reads `microdata.json` and downloads the cover art for all games. Some games have art too large for IFDB's 256KiB limit, so we convert PNGs to JPG, and try lowering the quality bit by bit until the image is small enough to submit. We deposit the art in the `cover-art` directory, and store a record of our results in `cover-art.json`.
 3. `submit-games.mjs`: This script reads `microdata.json` and `cover-art.json`, and uses the IFDB [putific API](https://ifdb.org/api/putific) to create results for all games.
 
-Initially, we'll create the IFDB entries based on the ballot alone; it will take a few days for IF Archive to accept and process the "big zip" of all competition entries. Once that ZIP is available on ifarchive.org, we can compute and set download links.
+    Initially, we'll create the IFDB entries based on the ballot alone; it will take a few days for IF Archive to accept and process the "big zip" of all competition entries. Once that ZIP is available on ifarchive.org, we can compute and set download links.
+4. `compute-download-links.mjs`: Computes the correct download link (including the game file in the download ZIP) using the big zip as input.
+5. `merge-tuids.mjs`: Rather than assuming that `submit-games.mjs` was run, we search IFDB for games published in the current year that match the title of the given IFComp game; this gives us the IFDB "TUID" ID of each game in IFComp.
+
 
 TODO
 
-* parse the big zip; compute download links for each game in the competition
-* compute IFIDs for games in the competition
-* support editing someone else's game (latestVersion parameter)
+* add API for viewing/editing download links https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/365
 * add download links for all games (if they're not already there)
-* create an API to tag all games with "IFComp YYYY" tag, and use it when creating the games
-* API to manage competition entries
-* script to inject IFIDs for games that can detect them
+
+* create an API to tag games https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/366
+* Tag games with "IFComp YYYY" tag
+* Allow bulk-adding games to competitions https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/367
+
+* compute IFIDs for games that are missing them
+* inject IFIDs when we find them

--- a/ifcomp-importer/README.md
+++ b/ifcomp-importer/README.md
@@ -1,0 +1,17 @@
+This importer is designed to grab the game list from https://ifcomp.org/ballot and upload the games to IFDB.
+
+1. `extract-microdata.mjs`: The IFComp Ballot page is populated with https://schema.org/VideoGame microdata. This script downloads the ballot, reads the microdata, and stores it in a more convenient JSON format, in `microdata.json`.
+2. `process-cover-art.mjs`: This script reads `microdata.json` and downloads the cover art for all games. Some games have art too large for IFDB's 256KiB limit, so we convert PNGs to JPG, and try lowering the quality bit by bit until the image is small enough to submit. We deposit the art in the `cover-art` directory, and store a record of our results in `cover-art.json`.
+3. `submit-games.mjs`: This script reads `microdata.json` and `cover-art.json`, and uses the IFDB [putific API](https://ifdb.org/api/putific) to create results for all games.
+
+Initially, we'll create the IFDB entries based on the ballot alone; it will take a few days for IF Archive to accept and process the "big zip" of all competition entries. Once that ZIP is available on ifarchive.org, we can compute and set download links.
+
+TODO
+
+* parse the big zip; compute download links for each game in the competition
+* compute IFIDs for games in the competition
+* support editing someone else's game (latestVersion parameter)
+* add download links for all games (if they're not already there)
+* create an API to tag all games with "IFComp YYYY" tag, and use it when creating the games
+* API to manage competition entries
+* script to inject IFIDs for games that can detect them

--- a/ifcomp-importer/README.md
+++ b/ifcomp-importer/README.md
@@ -10,7 +10,7 @@ This importer is designed to grab the game list from https://ifcomp.org/ballot a
 2. Edit `settings.mjs`, putting in your username, password, and the compStartDate. (If you want to test the scripts against a local IFDB dev environment, also change the url to `http://localhost:8080`.)
 3. Run `node extract-microdata.mjs` to record the ballot data in `microdata.json`.
 4. Run `node process-cover-art.mjs` to download all of the cover art in the `cover-art` directory.
-5. Run `node submit-games.mjs` to submit all of the game listings.
+5. Run `node submit-games.mjs` to submit all of the game listings. (Note that when testing in a dev environment, uploaded images will not appear in the web UI.)
 
 ## Phase 2: Add IF Archive download links for each game on the ballot.
 

--- a/ifcomp-importer/README.md
+++ b/ifcomp-importer/README.md
@@ -1,18 +1,44 @@
 This importer is designed to grab the game list from https://ifcomp.org/ballot and upload the games to IFDB.
 
+# How to use the scripts
+
+## Phase 1: Create IFDB listings for each game on the ballot
+
+(You can skip this phase if someone has already created IFDB listings for each game.)
+
+1. Run `npm install` to install dependencies.
+2. Edit `settings.mjs`, putting in your username, password, and the compStartDate. (If you want to test the scripts against a local IFDB dev environment, also change the url to `http://localhost:8080`.)
+3. Run `node extract-microdata.mjs` to record the ballot data in `microdata.json`.
+4. Run `node process-cover-art.mjs` to download all of the cover art in the `cover-art` directory.
+5. Run `node submit-games.mjs` to submit all of the game listings.
+
+## Phase 2: Add IF Archive download links for each game on the ballot.
+
+This can only happen once the "big zip file" is available, and all links are visible on IF Archive. As a result, these scripts are designed to be able to be run separately, possibly by an entirely different person from the one who created the game listings.
+
+(It's not uncommon for someone to swoop in and manually create all the game listings as soon as the comp starts; that's fine. This script can cope with that.)
+
+1. Run `npm install` to install dependencies.
+2. Edit `settings.mjs`, putting in your username, password, and the compStartDate. (If you want to test the scripts against a local IFDB dev environment, also change the url to `http://localhost:8080`.)
+3. Run `node extract-microdata.mjs` to record the ballot data in `microdata.json`.
+4. Download the "big zip file" from the "download a .zip archive" link from https://ifcomp.org/ballot and save it in this directory as `IFCompYYYY.zip` (matching the `compStartDate` year).
+5. Run `node compute-download-links.mjs` to record the download file names in `microdata-downloads.json`.
+6. Run `node merge-tuids.mjs` to record the IFDB TUIDs in `microdata-downloads-tuids.json`.
+7. Run `node submit-download-links.mjs` to edit each IFDB listing, adding the links we computed.
+
+# List of the scripts
+
 1. `extract-microdata.mjs`: The IFComp Ballot page is populated with https://schema.org/VideoGame microdata. This script downloads the ballot, reads the microdata, and stores it in a more convenient JSON format, in `microdata.json`.
 2. `process-cover-art.mjs`: This script reads `microdata.json` and downloads the cover art for all games. Some games have art too large for IFDB's 256KiB limit, so we convert PNGs to JPG, and try lowering the quality bit by bit until the image is small enough to submit. We deposit the art in the `cover-art` directory, and store a record of our results in `cover-art.json`.
 3. `submit-games.mjs`: This script reads `microdata.json` and `cover-art.json`, and uses the IFDB [putific API](https://ifdb.org/api/putific) to create results for all games.
 
     Initially, we'll create the IFDB entries based on the ballot alone; it will take a few days for IF Archive to accept and process the "big zip" of all competition entries. Once that ZIP is available on ifarchive.org, we can compute and set download links.
-4. `compute-download-links.mjs`: Computes the correct download link (including the game file in the download ZIP) using the big zip as input.
-5. `merge-tuids.mjs`: Rather than assuming that `submit-games.mjs` was run, we search IFDB for games published in the current year that match the title of the given IFComp game; this gives us the IFDB "TUID" ID of each game in IFComp.
+4. `compute-download-links.mjs`: Computes the correct download link (including the game file in the download ZIP) using the big zip as input. This generates `microdata-downloads.json` from `microdata.json`.
+5. `merge-tuids.mjs`: Rather than assuming that `submit-games.mjs` was run, we search IFDB for games published in the current year that match the title of the given IFComp game; this gives us the IFDB "TUID" ID of each game in IFComp. This generates `microdata-downloads-tuids.json` from `microdata-downloads.json`.
+6. `submit-download-links.mjs`: Automatically submits IF Archive download links for all IFComp games, based on `microdata-downloads-tuids.json`.
 
 
 TODO
-
-* add API for viewing/editing download links https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/365
-* add download links for all games (if they're not already there)
 
 * create an API to tag games https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/366
 * Tag games with "IFComp YYYY" tag

--- a/ifcomp-importer/compute-download-links.mjs
+++ b/ifcomp-importer/compute-download-links.mjs
@@ -1,9 +1,9 @@
+import {compYear} from './settings.mjs';
 import {readFile, writeFile} from 'fs/promises';
 import JSZip from 'jszip';
 import leven from 'leven';
 
-const zipFileName = 'IFComp2022.zip';
-const urlBase = `https://ifarchive.org/if-archive/games/competition2022/`;
+const zipFileName = `IFComp${compYear}.zip`;
 const zipFileBytes = await readFile(zipFileName);
 const zip = await JSZip.loadAsync(zipFileBytes);
 const zipKeys = Object.keys(zip.files);

--- a/ifcomp-importer/compute-download-links.mjs
+++ b/ifcomp-importer/compute-download-links.mjs
@@ -90,6 +90,8 @@ for (const game of microdata) {
         
     } else if (game.gamePlatform === 'TADS') {
         result = findCandidatesMatchingExtension(game, zipKeys, ["t3"]);
+    } else if (game.gamePlatform === 'Windows executable') {
+        result = findCandidatesMatchingExtension(game, zipKeys, ["exe"]);
     } else {
         console.log(`no main file for ${game.gamePlatform} ${game.name}`)
     }

--- a/ifcomp-importer/compute-download-links.mjs
+++ b/ifcomp-importer/compute-download-links.mjs
@@ -1,0 +1,98 @@
+import {readFile, writeFile} from 'fs/promises';
+import JSZip from 'jszip';
+import leven from 'leven';
+
+const zipFileName = 'IFComp2022.zip';
+const urlBase = `https://ifarchive.org/if-archive/games/competition2022/`;
+const zipFileBytes = await readFile(zipFileName);
+const zip = await JSZip.loadAsync(zipFileBytes);
+const zipKeys = Object.keys(zip.files);
+const microdata = JSON.parse(await readFile('microdata.json', 'utf8')).sort((a,b) => a.name.localeCompare(b.name));
+const gameZipFileNames = new Set(zipKeys.filter(key => /^Games\/.*\.zip$/.test(key)));
+
+for (const game of microdata) {
+    const strippedName = game.name.replace(/[^A-Za-z0-9 ]/g, '').replace(/\s+/g, ' ');
+    const expectedFileName = `Games/${strippedName}.zip`;
+    if (gameZipFileNames.has(expectedFileName)) {
+        game.zipFileName = expectedFileName;
+        gameZipFileNames.delete(expectedFileName);
+    }
+}
+// find inexact matches
+for (const game of microdata) {
+    if (game.zipFileName) continue;
+    const strippedName = game.name.replace(/[^A-Za-z0-9 ]/g, '').replace(/\s+/g, ' ');
+    const expectedFileName = `Games/${strippedName}.zip`;
+    const [closestMatch] = [...gameZipFileNames].sort((a, b) => leven(expectedFileName, a) - leven(expectedFileName, b));
+    if (leven(closestMatch, expectedFileName) > 5) {
+        console.log(`MISSING ${game.name}, closest match is ${closestMatch}`);
+    } else {
+        game.zipFileName = closestMatch;
+        gameZipFileNames.delete(closestMatch);
+    }
+}
+
+const htmlPlatforms = new Set([
+    'ChoiceScript',
+    'Ink',
+    'Texture',
+    'Twine',
+    'Web-based',
+])
+
+    // 'Z-code',
+    // 'TADS',
+    // 'Glulx',
+
+function findCandidatesMatchingExtension(game, zipKeys, extensions) {
+    let candidates = zipKeys.filter(key => !/\/.*\//.test(key));
+    let matches = candidates.filter(key => {
+        for (const extension of extensions) {
+            if (key.endsWith("." + extension)) return true;
+        }
+        return false;
+    });
+
+    if (matches.length === 0) {
+        if (candidates.length === 1 && candidates[0].endsWith("/")) {
+            candidates = zipKeys.filter(key => !/\/.*\/.*\//.test(key));
+            matches = candidates.filter(key => {
+                for (const extension of extensions) {
+                    if (key.endsWith("." + extension)) return true;
+                }
+                return false;
+            });
+        }
+    }
+
+    if (matches.length === 0) {
+        console.log(`no candidate [${extensions.join(' ')}] files for ${game.name}:\n  ${candidates.join('\n  ')}`);
+    } else if (matches.length === 1) {
+        game.zipMainFile = matches[0];
+        return true;
+    } else {
+        console.log(`too many candidate [${extensions.join(' ')}] files for ${game.name}:\n  ${matches.join('\n  ')}`);
+    }
+}
+
+for (const game of microdata) {
+    if (!game.zipFileName) continue;
+    if (!game.gamePlatform) continue;
+    const gameZip = await JSZip.loadAsync(await zip.files[game.zipFileName].async("arraybuffer"));
+    const zipKeys = Object.keys(gameZip.files);
+    let result;
+    if (htmlPlatforms.has(game.gamePlatform)) {
+        result = findCandidatesMatchingExtension(game, zipKeys, ["html"]);
+    } else if (game.gamePlatform === 'Z-code') {
+        result = findCandidatesMatchingExtension(game, zipKeys, ["zblorb", "z5", "z8"]);
+    } else if (game.gamePlatform === 'Glulx') {
+        result = findCandidatesMatchingExtension(game, zipKeys, ["gblorb", "ulx"]);
+        
+    } else if (game.gamePlatform === 'TADS') {
+        result = findCandidatesMatchingExtension(game, zipKeys, ["t3"]);
+    } else {
+        console.log(`no main file for ${game.gamePlatform} ${game.name}`)
+    }
+}
+
+await writeFile('microdata-downloads.json', JSON.stringify(microdata, null, 2), 'utf8');

--- a/ifcomp-importer/extract-microdata.mjs
+++ b/ifcomp-importer/extract-microdata.mjs
@@ -1,7 +1,7 @@
 import {writeFile} from 'fs/promises';
 import microdata from 'microdata-node';
 
-const response = await fetch('http://localhost:8080/ballot/');
+const response = await fetch('https://ifcomp.org/ballot/');
 const text = await response.text();
 
 const {items} = microdata.toJson(text);
@@ -12,10 +12,15 @@ const games = items.map(item => {
     for (const simpleField of simpleFields) {
         output[simpleField] = properties[simpleField]?.[0];
     }
+    output.description = output.description
+        .replace(/\n +\n/g, '\n')
+        .replace(/\n\n\n\n/g, "\n\n")
+        .replace(/\n\n\n +Content warning/, "\n\nContent warning")
+        .trim();
     output.authors = properties.author?.map(item => item.properties.name[0]);
     const image = properties.image?.[0];
     output.fullCoverArtUrl = image?.properties?.contentUrl?.[0];
     output.thumbnailArtUrl = image?.properties?.thumbnailUrl?.[0];
     return output;
 })
-await writeFile('microdata.json', JSON.stringify(games), 'utf8');
+await writeFile('microdata.json', JSON.stringify(games, null, 2), 'utf8');

--- a/ifcomp-importer/extract-microdata.mjs
+++ b/ifcomp-importer/extract-microdata.mjs
@@ -1,7 +1,7 @@
 import {writeFile} from 'fs/promises';
 import microdata from 'microdata-node';
 
-const response = await fetch('https://ifcomp.org/ballot/');
+const response = await fetch('https://ifcomp.org/ballot/?alphabetize=1');
 const text = await response.text();
 
 const {items} = microdata.toJson(text);

--- a/ifcomp-importer/extract-microdata.mjs
+++ b/ifcomp-importer/extract-microdata.mjs
@@ -1,0 +1,21 @@
+import {writeFile} from 'fs/promises';
+import microdata from 'microdata-node';
+
+const response = await fetch('http://localhost:8080/ballot/');
+const text = await response.text();
+
+const {items} = microdata.toJson(text);
+const games = items.map(item => {
+    const {properties} = item;
+    const output = {};
+    const simpleFields = ['name', 'alternateName', 'description', 'gamePlatform', 'genre', 'size', 'interactivityType', 'downloadUrl'];
+    for (const simpleField of simpleFields) {
+        output[simpleField] = properties[simpleField]?.[0];
+    }
+    output.authors = properties.author?.map(item => item.properties.name[0]);
+    const image = properties.image?.[0];
+    output.fullCoverArtUrl = image?.properties?.contentUrl?.[0];
+    output.thumbnailArtUrl = image?.properties?.thumbnailUrl?.[0];
+    return output;
+})
+await writeFile('microdata.json', JSON.stringify(games), 'utf8');

--- a/ifcomp-importer/merge-tuids.mjs
+++ b/ifcomp-importer/merge-tuids.mjs
@@ -1,3 +1,4 @@
+import {url} from './settings.mjs';
 import {readFile, writeFile} from 'fs/promises';
 import {XMLParser} from 'fast-xml-parser';
 
@@ -7,7 +8,7 @@ const year = new Date().getFullYear();
 for (const game of microdata) {
     //if (game.tuid) continue;
     const queryString = `${game.name} published:${year}`;
-    const searchUrl = `https://ifdb.org/search?xml&game&searchfor=${escape(queryString)}`;
+    const searchUrl = `${url}/search?xml&game&searchfor=${escape(queryString)}`;
     console.log(searchUrl);
     let response;
     try {

--- a/ifcomp-importer/merge-tuids.mjs
+++ b/ifcomp-importer/merge-tuids.mjs
@@ -4,20 +4,6 @@ import {XMLParser} from 'fast-xml-parser';
 const microdata = JSON.parse(await readFile('microdata-downloads.json', 'utf8'));
 const year = new Date().getFullYear();
 
-function escapeXml(unsafe) {
-    return unsafe.replace(/[<>&]/g, function (c) {
-        switch (c) {
-            case '<': return '&lt;';
-            case '>': return '&gt;';
-            case '&': return '&amp;';
-        }
-    });
-}
-
-function escapeRegex(string) {
-    return string.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
-}
-
 for (const game of microdata) {
     //if (game.tuid) continue;
     const queryString = `${game.name} published:${year}`;

--- a/ifcomp-importer/merge-tuids.mjs
+++ b/ifcomp-importer/merge-tuids.mjs
@@ -1,0 +1,49 @@
+import {readFile, writeFile} from 'fs/promises';
+import {XMLParser} from 'fast-xml-parser';
+
+const microdata = JSON.parse(await readFile('microdata-downloads.json', 'utf8'));
+const year = new Date().getFullYear();
+
+function escapeXml(unsafe) {
+    return unsafe.replace(/[<>&]/g, function (c) {
+        switch (c) {
+            case '<': return '&lt;';
+            case '>': return '&gt;';
+            case '&': return '&amp;';
+        }
+    });
+}
+
+function escapeRegex(string) {
+    return string.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+}
+
+for (const game of microdata) {
+    //if (game.tuid) continue;
+    const queryString = `${game.name} published:${year}`;
+    const searchUrl = `https://ifdb.org/search?xml&game&searchfor=${escape(queryString)}`;
+    console.log(searchUrl);
+    let response;
+    try {
+        response = await fetch(searchUrl);
+    } catch (e) {}
+    if (!response?.ok) {
+        throw new Error(`Failed (${response?.status}) loading ${searchUrl}`);
+    }
+    const xml = new XMLParser().parse(await response.text());
+    let games = xml.searchReply.games.game;
+    if (!Array.isArray(games)) {
+        // when there's only one result, the parser inlines the array
+        games = [games];
+    }
+    const matches = games.filter(result => result.title === game.name);
+    if (!matches.length) {
+        console.log(`Couldn't find ${game.name}: ${JSON.stringify(xml)}`);
+    } else if (matches.length > 1) {
+        console.log(`Too many matches for ${game.name}: ${JSON.stringify(xml)}`);
+    } else {
+        game.tuid = matches[0].tuid;
+    }
+}
+
+await writeFile('microdata-downloads-tuids.json', JSON.stringify(microdata, null, 2), 'utf8');

--- a/ifcomp-importer/package-lock.json
+++ b/ifcomp-importer/package-lock.json
@@ -1,0 +1,194 @@
+{
+  "name": "ifcomp-importer",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ifcomp-importer",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "microdata-node": "^2.0.0"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.0",
+        "entities": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
+    "node_modules/domhandler": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "dependencies": {
+        "domelementtype": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "dependencies": {
+        "dom-serializer": "^1.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/htmlparser2": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
+      "integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^3.0.0",
+        "domutils": "^2.0.0",
+        "entities": "^2.0.0"
+      }
+    },
+    "node_modules/htmlparser2/node_modules/domhandler": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
+      "integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
+      "dependencies": {
+        "domelementtype": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/is-absolute-url": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.3.tgz",
+      "integrity": "sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/microdata-node": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/microdata-node/-/microdata-node-2.0.0.tgz",
+      "integrity": "sha512-OHe2h2Vf119DHaXlmctmuOEQ6Wh62kDSU2gSjbG5lWtshZjk4aZG8i9zmlmPBt2G3By/spHRGU+LoNlQA8EvWg==",
+      "dependencies": {
+        "domutils": "^2.1.0",
+        "htmlparser2": "^4.1.0",
+        "is-absolute-url": "^3.0.3"
+      }
+    }
+  },
+  "dependencies": {
+    "dom-serializer": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.0",
+        "entities": "^2.0.0"
+      }
+    },
+    "domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
+    },
+    "domhandler": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "requires": {
+        "domelementtype": "^2.2.0"
+      }
+    },
+    "domutils": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "requires": {
+        "dom-serializer": "^1.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
+      }
+    },
+    "entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+    },
+    "htmlparser2": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-4.1.0.tgz",
+      "integrity": "sha512-4zDq1a1zhE4gQso/c5LP1OtrhYTncXNSpvJYtWJBtXAETPlMfi3IFNjGuQbYLuVY4ZR0QMqRVvo4Pdy9KLyP8Q==",
+      "requires": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^3.0.0",
+        "domutils": "^2.0.0",
+        "entities": "^2.0.0"
+      },
+      "dependencies": {
+        "domhandler": {
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-3.3.0.tgz",
+          "integrity": "sha512-J1C5rIANUbuYK+FuFL98650rihynUOEzRLxW+90bKZRWB6A1X1Tf82GxR1qAWLyfNPRvjqfip3Q5tdYlmAa9lA==",
+          "requires": {
+            "domelementtype": "^2.0.1"
+          }
+        }
+      }
+    },
+    "is-absolute-url": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.3.tgz",
+      "integrity": "sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q=="
+    },
+    "microdata-node": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/microdata-node/-/microdata-node-2.0.0.tgz",
+      "integrity": "sha512-OHe2h2Vf119DHaXlmctmuOEQ6Wh62kDSU2gSjbG5lWtshZjk4aZG8i9zmlmPBt2G3By/spHRGU+LoNlQA8EvWg==",
+      "requires": {
+        "domutils": "^2.1.0",
+        "htmlparser2": "^4.1.0",
+        "is-absolute-url": "^3.0.3"
+      }
+    }
+  }
+}

--- a/ifcomp-importer/package-lock.json
+++ b/ifcomp-importer/package-lock.json
@@ -9,7 +9,132 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "microdata-node": "^2.0.0"
+        "microdata-node": "^2.0.0",
+        "sharp": "^0.31.1"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dom-serializer": {
@@ -63,6 +188,14 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/entities": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
@@ -70,6 +203,24 @@
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
     },
     "node_modules/htmlparser2": {
       "version": "4.1.0",
@@ -96,12 +247,57 @@
         "url": "https://github.com/fb55/domhandler?sponsor=1"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
     "node_modules/is-absolute-url": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.3.tgz",
       "integrity": "sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q==",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+    },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/microdata-node": {
@@ -113,9 +309,372 @@
         "htmlparser2": "^4.1.0",
         "is-absolute-url": "^3.0.3"
       }
+    },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+    },
+    "node_modules/napi-build-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
+    },
+    "node_modules/node-abi": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.26.0.tgz",
+      "integrity": "sha512-jRVtMFTChbi2i/jqo/i2iP9634KMe+7K1v35mIdj3Mn59i5q27ZYhn+sW6npISM/PQg7HrP2kwtRBMmh5Uvzdg==",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/node-addon-api": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.0.0.tgz",
+      "integrity": "sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA=="
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/prebuild-install": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
+      "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/sharp": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.31.1.tgz",
+      "integrity": "sha512-GR8M1wBwOiFKLkm9JPun27OQnNRZdHfSf9VwcdZX6UrRmM1/XnOrLFTF0GAil+y/YK4E6qcM/ugxs80QirsHxg==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.1",
+        "node-addon-api": "^5.0.0",
+        "prebuild-install": "^7.1.1",
+        "semver": "^7.3.7",
+        "simple-get": "^4.0.1",
+        "tar-fs": "^2.1.1",
+        "tunnel-agent": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=14.15.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   },
   "dependencies": {
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "requires": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
+      }
+    },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+    },
+    "color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "requires": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      }
+    },
+    "color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "requires": {
+        "color-name": "~1.1.4"
+      }
+    },
+    "color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "requires": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
+    "decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "requires": {
+        "mimic-response": "^3.1.0"
+      }
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+    },
+    "detect-libc": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
+      "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w=="
+    },
     "dom-serializer": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
@@ -149,10 +708,33 @@
         "domhandler": "^4.2.0"
       }
     },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
     "entities": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
       "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
+    },
+    "expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
+    },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+    },
+    "github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw=="
     },
     "htmlparser2": {
       "version": "4.1.0",
@@ -175,10 +757,38 @@
         }
       }
     },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
     "is-absolute-url": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/is-absolute-url/-/is-absolute-url-3.0.3.tgz",
       "integrity": "sha512-opmNIX7uFnS96NtPmhWQgQx6/NYFgsUXYMllcfzwWKUMwfo8kku1TvE6hkNcH+Q1ts5cMVrsY7j0bxXQDciu9Q=="
+    },
+    "is-arrayish": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+      "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "requires": {
+        "yallist": "^4.0.0"
+      }
     },
     "microdata-node": {
       "version": "2.0.0",
@@ -189,6 +799,206 @@
         "htmlparser2": "^4.1.0",
         "is-absolute-url": "^3.0.3"
       }
+    },
+    "mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ=="
+    },
+    "minimist": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q=="
+    },
+    "mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A=="
+    },
+    "napi-build-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
+    },
+    "node-abi": {
+      "version": "3.26.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.26.0.tgz",
+      "integrity": "sha512-jRVtMFTChbi2i/jqo/i2iP9634KMe+7K1v35mIdj3Mn59i5q27ZYhn+sW6npISM/PQg7HrP2kwtRBMmh5Uvzdg==",
+      "requires": {
+        "semver": "^7.3.5"
+      }
+    },
+    "node-addon-api": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.0.0.tgz",
+      "integrity": "sha512-CvkDw2OEnme7ybCykJpVcKH+uAOLV2qLqiyla128dN9TkEWfrYmxG6C2boDe5KcNQqZF3orkqzGgOMvZ/JNekA=="
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "prebuild-install": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
+      "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
+      "requires": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      }
+    },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      }
+    },
+    "readable-stream": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+    },
+    "semver": {
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
+    },
+    "sharp": {
+      "version": "0.31.1",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.31.1.tgz",
+      "integrity": "sha512-GR8M1wBwOiFKLkm9JPun27OQnNRZdHfSf9VwcdZX6UrRmM1/XnOrLFTF0GAil+y/YK4E6qcM/ugxs80QirsHxg==",
+      "requires": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.1",
+        "node-addon-api": "^5.0.0",
+        "prebuild-install": "^7.1.1",
+        "semver": "^7.3.7",
+        "simple-get": "^4.0.1",
+        "tar-fs": "^2.1.1",
+        "tunnel-agent": "^0.6.0"
+      }
+    },
+    "simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q=="
+    },
+    "simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "requires": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
+    "simple-swizzle": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.2.tgz",
+      "integrity": "sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==",
+      "requires": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="
+    },
+    "tar-fs": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
+      "requires": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "requires": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     }
   }
 }

--- a/ifcomp-importer/package-lock.json
+++ b/ifcomp-importer/package-lock.json
@@ -9,6 +9,9 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "fast-xml-parser": "^4.0.11",
+        "jszip": "^3.10.1",
+        "leven": "^4.0.0",
         "microdata-node": "^2.0.0",
         "sharp": "^0.31.1"
       }
@@ -106,6 +109,11 @@
         "color-name": "^1.0.0",
         "simple-swizzle": "^0.2.2"
       }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/decompress-response": {
       "version": "6.0.0",
@@ -212,6 +220,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/fast-xml-parser": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
+      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      },
+      "funding": {
+        "type": "paypal",
+        "url": "https://paypal.me/naturalintelligence"
+      }
+    },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -266,6 +289,11 @@
         }
       ]
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -288,6 +316,68 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+    },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      }
+    },
+    "node_modules/jszip/node_modules/readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/jszip/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
+    "node_modules/jszip/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/leven": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-4.0.0.tgz",
+      "integrity": "sha512-puehA3YKku3osqPlNuzGDUHq8WpwXupUg1V6NXdV38G+gr+gkBwFC8g1b/+YcIvp8gnqVIus+eJCH/eGsRmJNw==",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -360,6 +450,11 @@
         "wrappy": "1"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+    },
     "node_modules/prebuild-install": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
@@ -384,6 +479,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "node_modules/pump": {
       "version": "3.0.0",
@@ -453,6 +553,11 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "node_modules/sharp": {
       "version": "0.31.1",
@@ -542,6 +647,11 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "node_modules/tar-fs": {
       "version": "2.1.1",
@@ -657,6 +767,11 @@
         "simple-swizzle": "^0.2.2"
       }
     },
+    "core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
+    },
     "decompress-response": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
@@ -726,6 +841,14 @@
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
     },
+    "fast-xml-parser": {
+      "version": "4.0.11",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
+      "integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
+      "requires": {
+        "strnum": "^1.0.5"
+      }
+    },
     "fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
@@ -762,6 +885,11 @@
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
     },
+    "immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -781,6 +909,64 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
       "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ=="
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
+    "jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "requires": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
+      },
+      "dependencies": {
+        "readable-stream": {
+          "version": "2.3.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.3",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~2.0.0",
+            "safe-buffer": "~5.1.1",
+            "string_decoder": "~1.1.1",
+            "util-deprecate": "~1.0.1"
+          }
+        },
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+        },
+        "string_decoder": {
+          "version": "1.1.1",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
+        }
+      }
+    },
+    "leven": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-4.0.0.tgz",
+      "integrity": "sha512-puehA3YKku3osqPlNuzGDUHq8WpwXupUg1V6NXdV38G+gr+gkBwFC8g1b/+YcIvp8gnqVIus+eJCH/eGsRmJNw=="
+    },
+    "lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "requires": {
+        "immediate": "~3.0.5"
+      }
     },
     "lru-cache": {
       "version": "6.0.0",
@@ -841,6 +1027,11 @@
         "wrappy": "1"
       }
     },
+    "pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="
+    },
     "prebuild-install": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
@@ -859,6 +1050,11 @@
         "tar-fs": "^2.0.0",
         "tunnel-agent": "^0.6.0"
       }
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "pump": {
       "version": "3.0.0",
@@ -902,6 +1098,11 @@
       "requires": {
         "lru-cache": "^6.0.0"
       }
+    },
+    "setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "sharp": {
       "version": "0.31.1",
@@ -953,6 +1154,11 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ=="
+    },
+    "strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "tar-fs": {
       "version": "2.1.1",

--- a/ifcomp-importer/package.json
+++ b/ifcomp-importer/package.json
@@ -10,6 +10,9 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "fast-xml-parser": "^4.0.11",
+    "jszip": "^3.10.1",
+    "leven": "^4.0.0",
     "microdata-node": "^2.0.0",
     "sharp": "^0.31.1"
   }

--- a/ifcomp-importer/package.json
+++ b/ifcomp-importer/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "ifcomp-importer",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "microdata-node": "^2.0.0"
+  }
+}

--- a/ifcomp-importer/package.json
+++ b/ifcomp-importer/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "microdata-node": "^2.0.0"
+    "microdata-node": "^2.0.0",
+    "sharp": "^0.31.1"
   }
 }

--- a/ifcomp-importer/process-cover-art.mjs
+++ b/ifcomp-importer/process-cover-art.mjs
@@ -1,0 +1,60 @@
+import {readFile, writeFile, mkdir} from 'fs/promises';
+import sharp from 'sharp';
+const games = JSON.parse(await readFile('microdata.json', 'utf8'));
+const urls = games.filter(game => game.thumbnailArtUrl).map(game => game.thumbnailArtUrl);
+try {
+    await mkdir('cover-art');
+} catch (e) {
+    if (e.code !== 'EEXIST') throw e;
+}
+const extensions = {
+    'image/jpeg': 'jpg',
+    'image/png': 'png',
+}
+const coverFiles = {};
+
+const maxImageSize = 262144;
+
+async function resizeJpeg(inputBuffer) {
+    const originalImage = sharp(inputBuffer);
+    let outputBuffer = inputBuffer;
+    let quality = 100;
+    while (outputBuffer.length > maxImageSize) {
+        quality -= 20;
+        console.log({quality});
+        outputBuffer = await originalImage.jpeg({quality}).toBuffer();
+    }
+    return outputBuffer;
+}
+
+await Promise.all(urls.map(async (url) => {
+    const [, entryId] = /\/([^\/]+?)\/cover$/.exec(url);
+    if (!entryId) throw new Error("Couldn't parse entryId from url: " + url);
+    const response = await fetch(url);
+    if (!response.ok) {
+        throw new Error(`Error ${response.status} ${response.statusText} downloading ${url}: ${await response.text()}`);
+    }
+    const contentType = response.headers.get('content-type');
+    let extension = extensions[contentType];
+    if (!extension) {
+        throw new Error(`Couldn't handle ${contentType} image for ${url}`);
+    }
+    let fileName = `cover-art/${entryId}.${extension}`;
+    let image = Buffer.from(await response.arrayBuffer());
+    if (image.length > 250000) {
+        const originalLength = image.length;
+        if (extension === 'jpg') {
+            image = await resizeJpeg(image);
+        } else {
+            extension = 'jpg';
+            fileName = `cover-art/${entryId}.${extension}`;
+            image = await sharp(image).jpeg({quality: 100}).toBuffer();
+            image = await resizeJpeg(image);
+        }
+        console.log(`resizing ${fileName} from ${originalLength} to ${image.length}`);
+    }
+    await writeFile(fileName, image);
+    coverFiles[entryId] = fileName;
+    console.log(fileName);
+}));
+await writeFile("cover-art.json", JSON.stringify(coverFiles, null, 2), 'utf8');

--- a/ifcomp-importer/settings.mjs
+++ b/ifcomp-importer/settings.mjs
@@ -1,0 +1,9 @@
+export const username = 'ifdbadmin@ifdb.org';
+export const password = 'secret';
+// the compStartDate will be the "first published on" date for IFDB listings
+// We'll also look for `IFCompYYYY.zip` based on this date
+// And submit download links pointing to https://ifarchive.org/if-archive/games/competitionYYYY/ based on the year
+export const compStartDate = '2022-10-01';
+export const compYear = compStartDate.substring(0, 4);
+export const url = 'https://ifdb.org';
+// export const url = 'http://localhost:8080';

--- a/ifcomp-importer/submit-download-links.mjs
+++ b/ifcomp-importer/submit-download-links.mjs
@@ -1,11 +1,6 @@
-import { readFile, writeFile } from 'fs/promises';
+import { username, password, url, compYear } from './settings.mjs';
+import { readFile } from 'fs/promises';
 import { XMLParser } from 'fast-xml-parser';
-
-let url = 'https://ifdb.org';
-// url = 'http://localhost:8080'
-
-const username = 'ifdbadmin@ifdb.org';
-const password = 'secret';
 
 const games = JSON.parse(await readFile('microdata-downloads-tuids.json', 'utf8'));
 
@@ -45,7 +40,7 @@ for (const game of games) {
     }
     const xml = new XMLParser().parse(await response.text());
 
-    const downloadLink = "https://ifarchive.org/if-archive/games/competition2022/" + escape(zipFileName);
+    const downloadLink = `https://ifarchive.org/if-archive/games/competition${compYear}/${escape(zipFileName)}`;
     const downloadTitle = zipFileName.replace(/^Games\//, "");
     let fileType = "";
     if (zipMainFile) {

--- a/ifcomp-importer/submit-download-links.mjs
+++ b/ifcomp-importer/submit-download-links.mjs
@@ -58,10 +58,6 @@ for (const game of games) {
     <ifindex version="1.0" xmlns="http://babel.ifarchive.org/protocol/iFiction/">
     <story>
     <identification><tuid>${tuid}</tuid></identification>
-    <bibliographic>
-    <title>${escapeXml(xml.ifindex.story.bibliographic.title)}</title>
-    <author>${escapeXml(xml.ifindex.story.bibliographic.author)}</author>
-    </bibliographic>
     </story>
     </ifindex>
     `

--- a/ifcomp-importer/submit-download-links.mjs
+++ b/ifcomp-importer/submit-download-links.mjs
@@ -1,0 +1,97 @@
+import { readFile, writeFile } from 'fs/promises';
+import { XMLParser } from 'fast-xml-parser';
+
+let url = 'https://ifdb.org';
+// url = 'http://localhost:8080'
+
+const username = 'ifdbadmin@ifdb.org';
+const password = 'secret';
+
+const games = JSON.parse(await readFile('microdata-downloads-tuids.json', 'utf8'));
+
+const fileTypes = {
+    "html": "hypertextgame",
+    "gblorb": "blorb/glulx",
+    "t3": "tads3",
+    "z5": "zcode",
+    "z8": "zcode",
+    "zblorb": "blorb/zcode",
+    "ulx": "glulx",
+    "exe": "executable"
+}
+
+function escapeXml(unsafe) {
+    return unsafe.replace(/[<>&'"]/g, function (c) {
+        switch (c) {
+            case '<': return '&lt;';
+            case '>': return '&gt;';
+            case '&': return '&amp;';
+            case '\'': return '&apos;';
+            case '"': return '&quot;';
+        }
+    });
+}
+
+for (const game of games) {
+    const { name, tuid, zipFileName, zipMainFile } = game;
+
+    const viewgameUrl = `${url}/viewgame?id=${tuid}&ifiction`;
+    let response;
+    try {
+        response = await fetch(viewgameUrl);
+    } catch (e) { }
+    if (!response?.ok) {
+        throw new Error(`Failed (${response?.status}) loading ${viewgameUrl}`);
+    }
+    const xml = new XMLParser().parse(await response.text());
+
+    const downloadLink = "https://ifarchive.org/if-archive/games/competition2022/" + escape(zipFileName);
+    const downloadTitle = zipFileName.replace(/^Games\//, "");
+    let fileType = "";
+    if (zipMainFile) {
+        const extension = zipMainFile.split(".").pop();
+        fileType = fileTypes[extension];
+        if (!fileType) throw new Error("missing fileType for extension: " + extension);
+    } else {
+        fileType = "storyfile"
+    }
+    const body = new FormData();
+    body.append('username', username);
+    body.append('password', password);
+    const ifiction = `<?xml version="1.0" encoding="UTF-8"?>
+    <ifindex version="1.0" xmlns="http://babel.ifarchive.org/protocol/iFiction/">
+    <story>
+    <identification><tuid>${tuid}</tuid></identification>
+    <bibliographic>
+    <title>${escapeXml(xml.ifindex.story.bibliographic.title)}</title>
+    <author>${escapeXml(xml.ifindex.story.bibliographic.author)}</author>
+    </bibliographic>
+    </story>
+    </ifindex>
+    `
+    body.append('ifiction', new Blob([ifiction], { type: 'text/xml' }));
+    const links = `<?xml version="1.0" encoding="UTF-8"?>
+    <downloads xmlns="http://ifdb.org/api/xmlns"><links>
+    <link>
+    <url>${downloadLink}</url>
+    <title>${downloadTitle}</title>
+    <isGame/>
+    <format>${fileType}</format>
+    ${fileType === 'executable' ? `<os>Windows.</os>`: ''}
+    <compression>zip</compression>
+    ${zipMainFile ? `<compressedPrimary>${zipMainFile}</compressedPrimary>`: ''}
+    </link>
+    </links></downloads>
+    `;
+    body.append('links', new Blob([links], { type: 'text/xml' }));
+    response = await fetch(`${url}/putific`, {
+        method: 'post',
+        body,
+    });
+    const { status, statusText, ok } = response;
+    const text = await response.text();
+    if (!ok) {
+        throw new Error(`Failed ${status} ${statusText} adding download link for ${name}: ${text}`);
+    }
+    console.log(name, `${url}/viewgame?id=${tuid}`, "OK");
+}

--- a/ifcomp-importer/submit-download-links.mjs
+++ b/ifcomp-importer/submit-download-links.mjs
@@ -58,6 +58,7 @@ for (const game of games) {
     const body = new FormData();
     body.append('username', username);
     body.append('password', password);
+    body.append('lastversion', xml.ifindex.story.ifdb.pageversion);
     const ifiction = `<?xml version="1.0" encoding="UTF-8"?>
     <ifindex version="1.0" xmlns="http://babel.ifarchive.org/protocol/iFiction/">
     <story>

--- a/ifcomp-importer/submit-games.mjs
+++ b/ifcomp-importer/submit-games.mjs
@@ -1,14 +1,9 @@
+import { username, password, url, compStartDate } from './settings.mjs';
 import { readFile } from 'fs/promises';
 
-const firstpublished = '2022-10-01';
-
-if ((Date.now() - new Date(firstpublished).getTime()) > 24 * 365 * 60 * 60 * 1000) {
-    throw new Error(`firstpublished date ${firstpublished} is more than a year ago`);
+if ((Date.now() - new Date(compStartDate).getTime()) > 24 * 365 * 60 * 60 * 1000) {
+    throw new Error(`compStartDate date ${compStartDate} is more than a year ago`);
 }
-
-const username = 'ifdbadmin@ifdb.org';
-const password = 'secret';
-const url = 'http://localhost:8080/putific';
 
 function escapeXml(unsafe) {
     return unsafe.replace(/[<>&'"]/g, function (c) {
@@ -64,7 +59,7 @@ for (const game of games) {
         <title>${escapeXml(game.name)}</title>
         <author>${authors}</author>
         ${description ? `<description>${description}</description>` : '' }
-        <firstpublished>${firstpublished}</firstpublished>
+        <firstpublished>${compStartDate}</firstpublished>
         ${game.genre ? `<genre>${escapeXml(game.genre)}</genre>` : ''}
     </bibliographic>
 </story>
@@ -86,7 +81,7 @@ for (const game of games) {
         body.append('coverart', new Blob([image], { type: mimeType }));
     }
 
-    const response = await fetch(url, {
+    const response = await fetch(`${url}/putific`, {
         method: 'post',
         body,
     });

--- a/ifcomp-importer/submit-games.mjs
+++ b/ifcomp-importer/submit-games.mjs
@@ -65,7 +65,6 @@ for (const game of games) {
 </story>
 </ifindex>
 `;
-    console.log(xml);
     body.append('ifiction', new Blob([xml], { type: 'text/xml' }));
     body.append('requireIFID', 'force');
     if (game.thumbnailArtUrl) {

--- a/ifcomp-importer/submit-games.mjs
+++ b/ifcomp-importer/submit-games.mjs
@@ -1,0 +1,116 @@
+import { readFile } from 'fs/promises';
+
+const firstpublished = '2022-10-01';
+
+if ((Date.now() - new Date(firstpublished).getTime()) > 24 * 365 * 60 * 60 * 1000) {
+    throw new Error(`firstpublished date ${firstpublished} is more than a year ago`);
+}
+
+const username = 'ifdbadmin@ifdb.org';
+const password = 'secret';
+const url = 'http://localhost:8080/putific';
+
+function escapeXml(unsafe) {
+    return unsafe.replace(/[<>&'"]/g, function (c) {
+        switch (c) {
+            case '<': return '&lt;';
+            case '>': return '&gt;';
+            case '&': return '&amp;';
+            case '\'': return '&apos;';
+            case '"': return '&quot;';
+        }
+    });
+}
+
+const games = JSON.parse(await readFile('microdata.json', 'utf8'));
+const coverArt = JSON.parse(await readFile('cover-art.json', 'utf8'));
+
+const errors = {};
+
+for (const game of games) {
+    const body = new FormData();
+    body.append('username', username);
+    body.append('password', password);
+    let authors = "";
+    if (game.authors.length === 1) {
+        authors = escapeXml(game.authors[0]);
+    } else {
+        for (let i = 0; i < (game.authors.length - 1); i++) {
+            if (i > 0) authors += ", ";
+            authors += escapeXml(game.authors[i]);
+        }
+        authors += " and " + escapeXml(game.authors[game.authors.length - 1]);
+    }
+    let description = game.description;
+    if (game.alternateName) {
+        if (description.substring(0, game.alternateName.length) != game.alternateName) {
+            description = `${game.alternateName}\n\n${game.description}`;
+        }
+    }
+    if (description) {
+        description = escapeXml(description);
+        description = description.replace(/\n\n/g, "<br/>\n\n");
+    }
+
+    /* firstpublished format description genre */
+    const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<ifindex version="1.0" xmlns="http://babel.ifarchive.org/protocol/iFiction/">
+<story>
+    ${game.gamePlatform ? `<identification>
+        <format>${escapeXml(game.gamePlatform)}</format>
+    </identification>
+    ` : ''}
+    <bibliographic>
+        <title>${escapeXml(game.name)}</title>
+        <author>${authors}</author>
+        ${description ? `<description>${description}</description>` : '' }
+        <firstpublished>${firstpublished}</firstpublished>
+        ${game.genre ? `<genre>${escapeXml(game.genre)}</genre>` : ''}
+    </bibliographic>
+</story>
+</ifindex>
+`;
+    console.log(xml);
+    body.append('ifiction', new Blob([xml], { type: 'text/xml' }));
+    body.append('requireIFID', 'force');
+    if (game.thumbnailArtUrl) {
+        const [, entryId] = /\/([^\/]+?)\/cover$/.exec(game.thumbnailArtUrl);
+        const imageFile = coverArt[entryId];
+        let mimeType;
+        if (/\.png/.test(imageFile)) {
+            mimeType = 'image/png';
+        } else {
+            mimeType = 'image/jpg';
+        }
+        const image = await readFile(imageFile);
+        body.append('coverart', new Blob([image], { type: mimeType }));
+    }
+
+    const response = await fetch(url, {
+        method: 'post',
+        body,
+    });
+    const { status, statusText } = response;
+    const text = await response.text();
+    console.log(JSON.stringify({ name: game.name, status, statusText, text }, null, 2));
+    if (status !== 200) {
+        const [,code] = /<code>(.*?)<\/code>/.exec(text);
+        if (!code) code = "unknown";
+        if (!errors[code]) errors[code] = [];
+        errors[code].push({ name: game.name, status, statusText, text });
+    }
+}
+
+let errorCount = 0;
+if (Object.keys(errors).length) {
+    console.log("ERRORS");
+    for (const code in errors) {
+        console.log("  " + code);
+        for (const error of errors[code]) {
+            errorCount++;
+            console.log("    " + JSON.stringify(error, null, 2));
+        }
+        console.log(`  ${errors[code].length} ${code} error(s)`);
+    }
+    console.log(`${errorCount} error(s)`);
+}


### PR DESCRIPTION
A bunch of scripts to automatically import IFComp ballot entries. See `README.md` for details.

This required merging several PRs to IFDB to address limitations in the `putific` API:
#222 Fix requireIFID to requireIFID by default, per documentation
#224 Return non-200 HTTP status codes on error
#225 Allow API users to insist on creating a game with a duplicate title
#226 Make putific use the iFiction TUID if it's available
#228 Include download links in viewgame ifiction
#229 Make putific support submitting download links with null OS versions
#230 Add putific lastversion parameter, to modify listings from other users
#232 Only require title in request when creating a new listing

In addition, there are new example scripts in the repository, documenting how to use `putific` in general.

https://github.com/iftechfoundation/ifdb/tree/main/examples/putific

This fixes https://github.com/iftechfoundation/ifcomp/issues/339

