### PR TITLE
Support editing site news items

### DIFF
--- a/www/adminops
+++ b/www/adminops
@@ -2102,7 +2102,8 @@ else if (isset($_REQUEST['addnews'])) {
              values ('$title', '$ldesc', now())", $db);
 
         if ($result) {
-            echo "<span class=success>The item was successfully added.</span>";
+            $id = mysql_insert_id($db);
+            echo "<span class=success>The item was successfully added. <a href='/news?item=$id'>View it now</a></span>";
             $title = "";
             $ldesc = "";
         } else {

--- a/www/adminops
+++ b/www/adminops
@@ -2091,7 +2091,7 @@ else if (isset($_REQUEST['addnews'])) {
 
     echo "<h1>Add a Site News item</h1>";
 
-    if (isset($_REQUEST['go'])) {
+    if (isset($_POST['go'])) {
 
         // apply the insert
         $title = mysql_real_escape_string(get_req_data('title'), $db);
@@ -2126,6 +2126,73 @@ else if (isset($_REQUEST['addnews'])) {
         . "<p><input type=submit name=submit value=\"Add Item\">"
         . "</form>"
         . "<p><hr class=dots><p>";
+}
+
+else if (isset($_REQUEST['editnews'])) {
+
+    echo "<h1>Edit a Site News item</h1>";
+    $showForm = true;
+    if (!isset($_REQUEST['item'])) {
+        echo "<span class=errmsg>No id specified</span>";
+        $showForm = false;
+    }
+    $id = mysql_real_escape_string(get_req_data('item'), $db);
+    if (isset($_POST['go'])) {
+
+        // apply the update
+        $title = mysql_real_escape_string(get_req_data('title'), $db);
+        $ldesc = mysql_real_escape_string(get_req_data('ldesc'), $db);
+
+        $result = mysql_query(
+            "update sitenews set title = '$title', ldesc = '$ldesc'
+             where itemid=$id", $db);
+
+        if ($result) {
+            echo "<span class=success>Item $id was successfully edited. <a href='/news?item=$id'>View it now</a></span>";
+        } else {
+            echo "<span class=errmsg>Error editing item: "
+                . htmlspecialcharx(mysql_error($db)) . "</span>";
+        }
+        $title = htmlspecialcharx(get_req_data('title'));
+        $ldesc = htmlspecialcharx(get_req_data('ldesc'));
+    } else if (isset($_REQUEST['item'])) {
+        $result = mysql_query(
+            "select title, ldesc from sitenews
+             where itemid=$id", $db);
+        if (!$result) {
+            echo "<span class=errmsg>Error loading item "
+                . htmlspecialcharx(mysql_error($db)) . ": </span>";
+            $showForm = false;
+        } else {
+            $cnt = mysql_num_rows($result);
+            if ($cnt) {
+                $row = mysql_fetch_array($result, MYSQL_ASSOC);
+                $title = htmlspecialcharx($row['title']);
+                $ldesc = htmlspecialcharx($row['ldesc']);
+            } else {
+                echo "<span class=errmsg>Error editing item "
+                    . htmlspecialcharx($id) . ": No such ID</span>";
+                $showForm = false;
+            }
+        }
+    }
+
+    if ($showForm) {
+
+        // show the form
+        echo "<p><form name=\"newsform\" method=post action=\"adminops\">"
+            . "<input type=hidden name=editnews value=1>"
+            . "<input type=hidden name=item value=$id>"
+            . "<input type=hidden name=go value=1>"
+            . "<p><b>Item Title:</b><br>"
+            . "<input type=text size=80 name=title value=\"$title\">"
+            . "<p><b>Description:</b><br>"
+            . "<textarea rows=10 cols=80 name=ldesc>"
+            . "$ldesc</textarea>"
+            . "<p><input type=submit name=submit value=\"Edit Item\">"
+            . "</form>"
+            . "<p><hr class=dots><p>";
+    }
 
 } else if (isset($_REQUEST['osfmtprivs'])) {
 

--- a/www/adminops
+++ b/www/adminops
@@ -2194,6 +2194,62 @@ else if (isset($_REQUEST['editnews'])) {
             . "</form>"
             . "<p><hr class=dots><p>";
     }
+}
+
+else if (isset($_REQUEST['deletenews'])) {
+
+    echo "<h1>Delete a Site News item</h1>";
+    $showForm = true;
+    if (!isset($_REQUEST['item'])) {
+        echo "<span class=errmsg>No id specified</span>";
+        $showForm = false;
+    }
+    $id = mysql_real_escape_string(get_req_data('item'), $db);
+    if ($showForm && isset($_POST['go'])) {
+        $showForm = false;
+        $result = mysql_query(
+            "delete from sitenews where itemid=$id", $db);
+
+        if ($result) {
+            echo "<span class=success>Item $id was successfully deleted.</span>";
+        } else {
+            echo "<span class=errmsg>Error deleting item: "
+                . htmlspecialcharx(mysql_error($db)) . "</span>";
+        }
+    } else if ($showForm) {
+        $result = mysql_query(
+            "select title, ldesc from sitenews
+             where itemid=$id", $db);
+        if (!$result) {
+            echo "<span class=errmsg>Error loading item "
+                . htmlspecialcharx(mysql_error($db)) . ": </span>";
+            $showForm = false;
+        } else {
+            $cnt = mysql_num_rows($result);
+            if ($cnt) {
+                $row = mysql_fetch_array($result, MYSQL_ASSOC);
+                $title = htmlspecialcharx($row['title']);
+                $ldesc = htmlspecialcharx($row['ldesc']);
+            } else {
+                echo "<span class=errmsg>Error deleting item "
+                    . htmlspecialcharx($id) . ": No such ID</span>";
+                $showForm = false;
+            }
+        }
+    }
+
+    if ($showForm) {
+        // show the form
+        echo "<p><form name=\"newsform\" method=post action=\"adminops\">"
+            . "<input type=hidden name=deletenews value=1>"
+            . "<input type=hidden name=item value=$id>"
+            . "<input type=hidden name=go value=1>"
+            . "<p>Are you sure you want to delete news item $id?</p>"
+            . "<p><b>$title</b>: $ldesc"
+            . "<p><input type=submit name=submit value=\"Delete Item\">"
+            . "</form>"
+            . "<p><hr class=dots><p>";
+    }
 
 } else if (isset($_REQUEST['osfmtprivs'])) {
 

--- a/www/news
+++ b/www/news
@@ -175,6 +175,7 @@ for ($i = 0 ; $i < $rowcnt ; $i++) {
     }
     if ($adminPriv) {
         echo "<p><a href='/adminops?editnews&item=".htmlspecialcharx($item)."'>Admin: Edit news item</a></p>";
+        echo "<p><a href='/adminops?deletenews&item=".htmlspecialcharx($item)."'>Admin: Delete news item</a></p>";
     }
 }
 

--- a/www/news
+++ b/www/news
@@ -2,6 +2,8 @@
 
 include_once "session-start.php";
 include_once "dbconnect.php";
+include_once "login-persist.php";
+$userid = checkPersistentLogin();
 $db = dbConnect();
 
 include_once "util.php";
@@ -164,6 +166,16 @@ for ($i = 0 ; $i < $rowcnt ; $i++) {
 
     // display the item
     echo "<p><b>$title</b>: $ldesc";
+
+    if ($item && $userid) {
+        $user_result = mysql_query(
+            "select `privileges` from users where id='$userid'", $db);
+        $userprivs = mysql_result($user_result, 0, "privileges");
+        $adminPriv = (strpos($userprivs, "A") !== false);
+    }
+    if ($adminPriv) {
+        echo "<p><a href='/adminops?editnews&item=".htmlspecialcharx($item)."'>Admin: Edit news item</a></p>";
+    }
 }
 
 echo "$pageCtlBreak$pageCtl<br>";


### PR DESCRIPTION
Deployed to dev.ifdb.org for testing.

To edit a site news item, login as an admin, then go directly to the site news link, e.g. https://dev.ifdb.org/news?item=128

At the bottom you'll see a link, "Admin: Edit news item" which will take you to the "Edit a Site News item" page https://dev.ifdb.org/adminops?editnews&item=128

There, you can make your edits, click "Edit Item" and view the results.