### PR TITLE
Explain the Play On-line button when editing links

### DIFF
--- a/www/editgame
+++ b/www/editgame
@@ -762,10 +762,31 @@ function showLinkPopup(event,linkNum)
     return false;
 }
 
-function updateFormatUI(byUser)
+const playableFormats = new Set([
+    'hypertextgame',
+    'zcode',
+    'blorb/zcode',
+    'glulx',
+    'blorb/glulx',
+    'tads2',
+    'tads3',
+    'hugo',
+    'adrift',
+    'adrift38',
+    'adrift39',
+    'adrift5',
+    'adrift5/blorb',
+])
+
+function updateFormatUI(byUser)  
 {
     var ele, vis;
 
+    var linkUrl = document.getElementById("linkurl").value;
+    var linkUrlHost = "";
+    try {
+        linkUrlHost = new URL(document.getElementById("linkurl").value).host;
+    } catch (e) {}
     var selFmtG = document.getElementById("linkfmtG");
     var selFmtNG = document.getElementById("linkfmtNG");
     var selCmp = document.getElementById("linkcomp");
@@ -774,6 +795,7 @@ function updateFormatUI(byUser)
     var selOs = document.getElementById("linkos");
     var selIsg = document.getElementById("linkisgame");
     var selPend = document.getElementById("linkpending");
+    var playOnlineExplanation = document.getElementById("playOnlineExplanation");
     var fmt = fmtmap[selIsg.checked ? selFmtG.value : selFmtNG.value];
 
     selOs.style.display = ((fmt && fmt["exe"]) ? "" : "none");
@@ -783,6 +805,27 @@ function updateFormatUI(byUser)
     } else {
         priFld.style.display = "";
         priNA.style.display = "none";
+    }
+
+    var noButton = "According to the settings above, this link will <b>not</b> include a \"Play On-line\" button, because ";
+
+    if (/Play Online/i.test(document.getElementById("linktitle").value)) {
+        playOnlineExplanation.innerHTML = "According to the settings above, this link will include a \"Play On-line\" button.";
+    } else if (!selIsg.checked) {
+        playOnlineExplanation.innerHTML = noButton + 'the "playable game file" option is not checked.';
+    } else if (!selFmtG.value) {
+        playOnlineExplanation.innerHTML = noButton + 'the "File Type" is blank.';
+    } else if (!playableFormats.has(fmt.externid)) {
+        playOnlineExplanation.innerHTML = noButton + 'we don\'t have a way to play ' + fmt.name + ' game files online.';
+    } else if (selCmp.value && selCmp.value !== '17') {
+        var compressionName = document.querySelector('#linkcomp option[value="' + selCmp.value + '"]').innerHTML;
+        playOnlineExplanation.innerHTML = noButton + 'we don\'t have a way to play ' + compressionName + ' compressed files online.';
+    } else if (selCmp.value === '17' && !/\b(ifarchive\.org|springthing\.net)$/.test(linkUrlHost)) {
+        playOnlineExplanation.innerHTML = noButton + "we can only play ZIP files online when they're hosted on ifarchive.org.";
+    } else if (selCmp.value === '17' && !priFld.value) {
+        playOnlineExplanation.innerHTML = noButton + 'the "Main File" is blank.';
+    } else {
+        playOnlineExplanation.innerHTML = "According to the settings above, this link will include a \"Play On-line\" button.";
     }
 
     if (byUser && fmt && fmt.externid == "tads3web")
@@ -1160,7 +1203,7 @@ function echoGridField($link, $fld, $isFirst = false)
                      <b>URL:</b>
                   </td>
                   <td>
-                     <input type="text" name="linkurl" id="linkurl"
+                     <input type="text" name="linkurl" id="linkurl" oninput="javascript:updateFormatUI()"
                             size=80><br><span class=details>
                         The full URL, linking directly to the downloadable
                         file. For IF Archive links, use the <b>main</b> Archive
@@ -1177,7 +1220,7 @@ function echoGridField($link, $fld, $isFirst = false)
                   </td>
                   <td>
                      <input type="text" name="linktitle" id="linktitle"
-                            size=40>
+                            size=40 oninput="javascript:updateFormatUI()">
                      <br>
                      <span class=details>
                         A short title for the link: "Story File", "User's
@@ -1333,7 +1376,7 @@ foreach ($linkfmts as $lf) {
                   </td>
                   <td>
                      <input type="text" name="linkcomppri" id="linkcomppri"
-                            size=40>
+                            size=40 oninput="javascript:updateFormatUI()">
                      <input type="text" id="linkcomppriNA" value="N/A"
                             readonly size=40
                            style="background:#e0e0e0;color:#404040;">
@@ -1343,6 +1386,21 @@ foreach ($linkfmts as $lf) {
                         application within the compressed file. Choose the
                         most important file for other types, or just
                         leave it blank.
+                     </span>
+                  </td>
+               </tr>
+               <tr>
+                  <td colspan=2>
+                     <hr>
+                  </td>
+               </tr>
+               <tr valign=top>
+                  <td align=right>
+                     <b><nobr>"Play On-line" button:</nobr></b>
+                  </td>
+                  <td>
+                     <span id="playOnlineExplanation">
+                        According to the settings above, this link will <b>not</b> include a "Play On-line" button, because the "playable game file" option is not checked.
                      </span>
                   </td>
                </tr>


### PR DESCRIPTION
Apropos the intfiction threads here:

* <https://intfiction.org/t/how-do-you-prevent-ifdbs-play-on-line-button-to-z-code-games-hosted-on-itch-io/60960>
* <https://intfiction.org/t/resources-for-uploading-games/60717/3?u=dfabulich>
* <https://intfiction.org/t/online-play-for-adrift-and-ifdb/60561>

The IFDB "Play On-line" button is very handy, but it's also extremely complicated. When I worked on this in 2021 and 2022, my goal was to try to expand support for "Play Online" buttons to as many formats as I could, but it's an extremely complicated system now.

The gist of it is as follows:

* If you include the text "Play Online" in the link title, that will trigger a button
* If the link has the "playable game" box checked, and if it's in one of the supported formats (HTML, Z-Code, Glulx, TADS, Hugo, or ADRIFT), that will trigger a button
* … unless you say that the game is compressed
    * We only know how to uncompress ZIP files
    * … and can only do it when the link is on ifarchive.org
        * … but I also put in a hack to make it work for springthing.net, by redirecting to the ifarchive versions
    * … and the user has to specify the "Main File" path, so the IF Archive unbox service knows what to uncompress

I couldn't figure out a good way of explaining this in documentation, so, instead, I've added a bit of UI at the bottom of the "Edit Link" pop-up.

I think this code is quite perilous, because it's essentially reproducing the code from [`viewgame` in PHP](https://github.com/iftechfoundation/ifdb/blob/main/www/viewgame#L902) in JavaScript, so it runs in the user's browser. I'm certain that there are some cases where PHP will show a "Play On-line" button, but my new JS code will falsely say that there won't be a button, or vice versa.

But I think the code I have here is "pretty close" to right, and, in the future, I predict people will be able to use the UI to reason out how to get rid of the button if they want it to go away, or how to make it appear if they want it to be there.

IFDB advisors can test this on dev.ifdb.org now.

# Play Online Enabled

<img width="775" alt="image" src="https://user-images.githubusercontent.com/96150/224865369-bb0864d8-ebf5-428c-bbf3-b84fe1d744f6.png">

# "Playable game" unchecked

<img width="772" alt="image" src="https://user-images.githubusercontent.com/96150/224865686-6d331126-855d-4898-b655-a940fa44c5d8.png">


# ZIP on non-IF Archive domain

<img width="774" alt="image" src="https://user-images.githubusercontent.com/96150/224865593-49315685-bfe0-4813-ba19-b7c755107bfd.png">