### PR TITLE
Switch deprecated curly brace array syntax to square brackets

### DIFF
--- a/www/adminops
+++ b/www/adminops
@@ -776,9 +776,9 @@ else if (isset($_REQUEST['users'])) {
         $stat = isset($statMap[$statCode]) ? $statMap[$statCode] : "";
         $proStat = isset($proStatMap[$proStat]) ? $proStatMap[$proStat] : "";
         for ($priv = array(), $c = 0 ; $c < strlen($privcode) ; $c++) {
-            $priv[] = isset($privMap[$privcode{$c}])
-                      ? $privMap[$privcode{$c}]
-                      : "??? '{$privcode{$c}}'";
+            $priv[] = isset($privMap[$privcode[$c]])
+                      ? $privMap[$privcode[$c]]
+                      : "??? '{$privcode[$c]}'";
         }
         $priv = implode(", ", $priv);
 
@@ -931,7 +931,7 @@ else if (isset($_REQUEST['users'])) {
     }
 
     for ($priv = array(), $c = 0 ; $c < strlen($privcode) ; $c++)
-        $priv[] = $privMap[$privcode{$c}];
+        $priv[] = $privMap[$privcode[$c]];
     $privNames = implode(", ", $priv);
 
     // check if we're logging in as the user
@@ -2379,7 +2379,7 @@ function hilitemarks($str, $showcodes)
     $lst = array();
     $inMark = false;
     for ($i = 0 ; $i < strlen($str) ; $i++) {
-        $c = ord($str{$i});
+        $c = ord($str[$i]);
         if ($c >= 0x80)
             $lst[] = $c;
         if ($c >= 0x80 && !$inMark) {
@@ -2393,7 +2393,7 @@ function hilitemarks($str, $showcodes)
             $lst = array();
             $inMark = false;
         }
-        $ret .= $str{$i};
+        $ret .= $str[$i];
     }
 
     if ($inMark) {
@@ -2415,12 +2415,12 @@ function cleanutf8($str)
 {
     $ret = '';
     for ($i = 0 ; $i < strlen($str) ; $i++) {
-        $c = $str{$i};
+        $c = $str[$i];
         $n = ord($c);
         $ret .= $c;
         if ($n >= 0x80 && $i+1 < strlen($str)) {
             $i++;
-            $c = $str{$i};
+            $c = $str[$i];
             $n = ord($c);
             if (($n & 0xC0) == 0x80) {
                 $n &= 0x3F;
@@ -2428,9 +2428,9 @@ function cleanutf8($str)
                     $n |= 0x40;
             }
             $ret .= chr($n);
-            if ($i+1 < strlen($str) && ((ord($str{$i+1}) & 0xC0) == 0x80)) {
+            if ($i+1 < strlen($str) && ((ord($str[$i+1]) & 0xC0) == 0x80)) {
                 $i++;
-                $c = $str{$i};
+                $c = $str[$i];
                 $n = ord($c);
                 $n &= 0x3F;
                 if ($n != 0x20)

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -309,7 +309,7 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
 
         // find the end of this word
         $start = $ofs;
-        if ($term{$ofs} == '"') {
+        if ($term[$ofs] == '"') {
             // we have a quoted word
             $quoted = true;
 
@@ -317,9 +317,9 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
             // skip stuttered quotes
             for ($start++, $ofs++ ; $ofs < $len ; $ofs++) {
                 // check for a quote
-                if ($term{$ofs} == '"') {
+                if ($term[$ofs] == '"') {
                     // skip stuttered quotes
-                    if ($ofs+1 < $len && $term{$ofs+1} == '"')
+                    if ($ofs+1 < $len && $term[$ofs+1] == '"')
                         $ofs++;
                     else
                         break;
@@ -423,8 +423,8 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
         $likeSubExpr = $and = "";
         foreach ($words as $w) {
             $w = mysql_real_escape_string(quoteSqlLike($w), $db);
-            if ($w != "" && $w{0} != '"') {
-                if (strpos("+=<>\"", $w{0}) !== false)
+            if ($w != "" && $w[0] != '"') {
+                if (strpos("+=<>\"", $w[0]) !== false)
                     $w = substr($w, 1);
                 $likeSubExpr .= "$and $likeCol like '%$w%'";
                 $and = " and";
@@ -640,7 +640,7 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
                     if (count($nl) >= 2) {
                         $expr .= " or author rlike '[[:<:]]"
                                  . mysql_real_escape_string(
-                                     quoteSqlRLike($nl[1]{0}), $db)
+                                     quoteSqlRLike($nl[1][0]), $db)
                                  . ".*[[:space:]]+"
                                  . mysql_real_escape_string(
                                      quoteSqlRLike($nl[0]), $db)

--- a/www/storage-util.php
+++ b/www/storage-util.php
@@ -194,7 +194,7 @@ function getStorageFileInfo($fpath, $fname)
         array("/>/", "/^@/", "/@/"),
         array("", "", ", "),
         $date);
-    $date = strtoupper($date{0}) . substr($date, 1);
+    $date = strtoupper($date[0]) . substr($date, 1);
 
     // figure the plain formatted date as well
     $plainDate = date("n/j/Y g:i a", $mtime);

--- a/www/util.php
+++ b/www/util.php
@@ -1005,7 +1005,7 @@ function fixDesc($desc, $specials = 0)
     $tagSp = -1;
     for ($ofs = 0 ; $ofs < strlen($desc) ; $ofs++) {
         // check what we're looking at
-        switch ($desc{$ofs}) {
+        switch ($desc[$ofs]) {
         case '<':
             // presume we won't need to quote it
             $quoteIt = false;
@@ -1347,8 +1347,8 @@ function fixDesc($desc, $specials = 0)
 
         default:
             // remove all other control characters
-            if ($desc{$ofs} < ' ')
-                $desc{$ofs} = ' ';
+            if ($desc[$ofs] < ' ')
+                $desc[$ofs] = ' ';
         }
     }
 
@@ -1414,7 +1414,7 @@ function findEndTag($str, $tag, $ofs)
     // scan from the given offset
     for ($len = strlen($str) ; $ofs < $len ; $ofs++)
     {
-        if ($str{$ofs} == '<') {
+        if ($str[$ofs] == '<') {
             // find the matching '>'
             $gt = strpos($str, '>', $ofs);
 
@@ -1493,7 +1493,7 @@ function summarizeHtml($str, $maxlen)
          $ofs < strlen($str) ; $ofs++)
     {
         // get the current character
-        $c = $str{$ofs};
+        $c = $str[$ofs];
 
         // process the tag or ordinary text, as appropriate
         if ($inEnt)
@@ -1577,7 +1577,7 @@ function summarizeHtml($str, $maxlen)
                     // skip consecutive spaces - they don't count as
                     // separate output length, since HTML collapses
                     // source-text whitespace on display
-                    while ($ofs+1 < strlen($str) && $str{$ofs+1} == ' ')
+                    while ($ofs+1 < strlen($str) && $str[$ofs+1] == ' ')
                         $ofs++;
                 }
                 else


### PR DESCRIPTION
Support for the curly braces [has been removed in PHP 8.0](https://www.php.net/manual/en/migration80.incompatible.php#migration80.incompatible.core.other).

I changed all the instances I could find.