### PR TITLE
Adopt a Content Security Policy

### DIFF
--- a/www/captcha.php
+++ b/www/captcha.php
@@ -148,8 +148,8 @@ function captchaMaskEmail($email, $maskMsg)
 
     // generate the reveal link
     $link = "<span id=\"emailMasker$emailNum\">$maskA<a href=\"#\" "
-            . "onclick=\"javascript:showCaptchaForm();return false;\" "
             . "title=\"Click to reveal the full email address\">"
+            . addEventListener('click', "showCaptchaForm(); return false;")
             . "$email</a>$maskB</span>";
 
     // advance the counter
@@ -279,8 +279,8 @@ function captchaSolved(response)
 function captchaAjaxForm($sessionKey)
 {
     echo "<div id='captchaFormDiv' style='display:none;'>"
-        . "<form name='captchaAjaxForm' "
-        . "onsubmit='javascript:submitCaptchaForm();return false;'>"
+        . "<form name='captchaAjaxForm'>"
+        . addEventListener('submit', 'submitCaptchaForm();return false;')
 //        . getCaptchaSubForm($sessionKey, false, false)
         . "<div id='captchaFormCont'></div>"
         . "<div><span id='captchaStatusMsg'></span></div>"

--- a/www/captcha.php
+++ b/www/captcha.php
@@ -167,7 +167,7 @@ function captchaSupportScripts($sessionKey, $okcb = false)
 {
 ?>
    <script src='https://www.google.com/recaptcha/api.js'></script>
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 var RecaptchaOptions = {
     theme: "white"

--- a/www/captcha.php
+++ b/www/captcha.php
@@ -166,7 +166,7 @@ function captchaMaskEmail($email, $maskMsg)
 function captchaSupportScripts($sessionKey, $okcb = false)
 {
 ?>
-   <script src='https://www.google.com/recaptcha/api.js'></script>
+   <script src='https://www.google.com/recaptcha/api.js' nonce="<?php global $nonce; echo $nonce; ?>"></script>
 <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 var RecaptchaOptions = {

--- a/www/combobox.php
+++ b/www/combobox.php
@@ -80,7 +80,7 @@ function comboSupportFuncs()
 {
 ?>
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 var activeCombo = false;
 var overComboMenu = false;

--- a/www/combobox.php
+++ b/www/combobox.php
@@ -25,36 +25,35 @@ function makeComboBox($name, $textlen, $curval, $vals, $onSet = "null")
     // write the input field
     $txt = "<input type=\"text\" name=\"$name\" id=\"$name\" "
            . "size=$textlen value=\"" . htmlspecialcharx($curval)
-           . "\" onkeydown=\"javascript:return comboFieldKey("
-           . "event,'$name','${name}CBSel','D');\" "
-           . "onkeypress=\"javascript:return comboFieldKey("
-           . "event,'$name','{$name}CBSel','P');\">";
+           . "\">"
+           . addSiblingEventListeners([
+                ["keydown", "return comboFieldKey(event,'$name','${name}CBSel','D');"],
+                ["keypress", "return comboFieldKey(event,'$name','${name}CBSel','P');"],
+           ]);
 
     // add the drop arrow
-    $txt .= "<a href=\"needjs\" onkeypress=\"javascript:return "
-           . "comboArrowKey(event,'$name',true,'${name}CBSel');\" "
-           . "onkeydown=\"javascript:return comboArrowKey("
-           . "event,'$name',true,'${name}CBSel');\">"
+    $txt .= "<a href=\"needjs\">"
+           . addEventListener("keypress", "return comboArrowKey(event,'$name',true,'${name}CBSel');")
+           . addEventListener("keydown", "return comboArrowKey(event,'$name',true,'${name}CBSel');")
            . "<img alt=\"Open List\" border=0 "
-           . "src=\"/img/blank.gif\" class=\"combobox-arrow\" "
-           . "onclick=\"javascript:postShowComboMenu("
-           . "'$name',true,'{$name}CBSel');return false;\"></a>";
+           . "src=\"/img/blank.gif\" class=\"combobox-arrow\">"
+           . addSiblingEventListeners([["click", "postShowComboMenu("
+           . "'$name',true,'{$name}CBSel');return false;"]])
+           . "</a>";
 
     // set up the hidden division for the list
     $txt .= "<div id=\"{$name}CBDiv\" "
             . "style=\"position:absolute;display:none;top:0px; "
-            . "left:0px;z-index:20000\" "
-            . "onmouseover=\"javascript:overComboMenu=true;return true;\" "
-            . "onmouseout=\"javascript:overComboMenu=false;return true;\">";
+            . "left:0px;z-index:20000\">"
+            . addEventListener("mouseover", "overComboMenu=true;")
+            . addEventListener("mouseout", "overComboMenu=false;");
 
     // add the hidden list
-    $txt .= "<select size=10 id=\"{$name}CBSel\" "
-            . "onclick=\"javascript:setComboText('$name',this.value,$onSet);\" "
-            . "onkeypress=\"javascript:return comboKeyPress("
-            . "event,'$name',this,$onSet);\" "
-            . "onkeydown=\"javascript:return comboKeyPress("
-            . "event,'$name',this,$onSet);\" "
-            . "onblur=\"javascript:checkClosePopup(null, false);\">";
+    $txt .= "<select size=10 id=\"{$name}CBSel\">"
+            . addEventListener("click", "setComboText('$name',this.value,$onSet);")
+            . addEventListener("keypress", "return comboKeyPress(event,'$name',this,$onSet);")
+            . addEventListener("keydown", "return comboKeyPress(event,'$name',this,$onSet);")
+            . addEventListener("blur", "checkClosePopup(null, false);");
 
     // add the options
     for ($j = 0 ; $j < count($vals) ; $j++) {

--- a/www/combobox.php
+++ b/www/combobox.php
@@ -32,7 +32,7 @@ function makeComboBox($name, $textlen, $curval, $vals, $onSet = "null")
            ]);
 
     // add the drop arrow
-    $txt .= "<a href=\"needjs\">"
+    $txt .= "<a href=\"needjs\" x-name=\"$name\">"
            . addEventListener("keypress", "return comboArrowKey(event,'$name',true,'${name}CBSel');")
            . addEventListener("keydown", "return comboArrowKey(event,'$name',true,'${name}CBSel');")
            . "<img alt=\"Open List\" border=0 "

--- a/www/commentutil.php
+++ b/www/commentutil.php
@@ -439,7 +439,7 @@ function showComment($db,$commentPage, $itemAuthor, $cidx, $coutlst, $i)
         global $plonkedCommentNum;
         if ($plonkedCommentNum++ == 0) {
             ?>
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 function revealPlonkedAuthor(ele, uid, uname)
 {
     ele = ele.parentNode;

--- a/www/commentutil.php
+++ b/www/commentutil.php
@@ -423,15 +423,19 @@ function showComment($db,$commentPage, $itemAuthor, $cidx, $coutlst, $i)
     // if it's plonked, wrap it in a click-through hider
     if ($plonked) {
         echo "<span class=details><i>You've plonked this comment's author</i>"
-            . " - <span><a href=\"needjs\" onclick=\"javascript:"
-            . "revealPlonkedAuthor(this, '$cuserid', '"
-            . str_replace(array('"', '\''),
-                          array("'+String.fromCharCode(34)+'", "\\'"),
-                          $cusername)
-            . "');return false;\">Reveal author</a></span>"
+            . " - <span><a href=\"needjs\">"
+            . addEventListener("click", "revealPlonkedAuthor(this, '$cuserid', '"
+                . str_replace(array('"', '\''),
+                            array("'+String.fromCharCode(34)+'", "\\'"),
+                            $cusername)
+                . "');return false;")
+            . "Reveal author</a></span>"
             . "<span style=\"display:none;\">"
-            . " | <a href=\"needjs\" onclick=\"javascript:"
-            . "revealPlonkedComment(this);return false;\">Reveal comment</a>"
+            . " | <a href=\"needjs\">"
+            . addEventListener(
+                "click", "revealPlonkedComment(this);return false;"
+            )
+            . "Reveal comment</a>"
             . "</span>"
             . "</span>"
             . "<div style=\"display: none;\">";

--- a/www/components/ifdb-recommends.php
+++ b/www/components/ifdb-recommends.php
@@ -271,7 +271,7 @@ if ($loggedIn && !$overloaded) {
     } else {
       ?>
       <div id="recommendations">Loading...</div>
-      <script>
+      <script nonce="<?php global $nonce; echo $nonce; ?>">
         void function() {
           var element = document.getElementById('recommendations')
           var xhr = new XMLHttpRequest();

--- a/www/components/ifdb-recommends.php
+++ b/www/components/ifdb-recommends.php
@@ -410,16 +410,15 @@ if (count($recs) >= 2) {
 
     // explain the source
     echo "<p><span class=details><i>";
-    $href = helpWinHRef("help-crossrec");
     if ($recsrc == 'generic') {
         echo "These are a few randomly-selected games with high
              average member ratings.  If you ";
         if (!$loggedIn)
             echo "<a href=\"login\">log in</a> and ";
         echo "rate a few games yourself, IFDB can offer customized
-              recommendations (<a $href>explain</a>).";
+              recommendations (".helpWinLink("help-crossrec", "explain").").";
     } else {
-        echo "<a $href>Why did IFDB recommend these?</a>";
+        echo helpWinLink("help-crossrec", "Why did IFDB recommend these?");
     }
     echo "</i></span></div>";
 }

--- a/www/components/ifdb-recommends.php
+++ b/www/components/ifdb-recommends.php
@@ -411,8 +411,6 @@ if (count($recs) >= 2) {
     // explain the source
     echo "<p><span class=details><i>";
     $href = helpWinHRef("help-crossrec");
-//    $href = "href=\"needjs\" "
-//            . "onclick=\"javascript:helpWin('help-crossrec');return false;\"";
     if ($recsrc == 'generic') {
         echo "These are a few randomly-selected games with high
              average member ratings.  If you ";

--- a/www/crossrec
+++ b/www/crossrec
@@ -101,8 +101,8 @@ if ($editMode) {
         . "<input type=text size=80 name=searchfor id=searchfor "
         . "value=\"$searchFor\">"
         . " <input type=submit name=submit value=\"Search\"><br>"
-        . "<span class=microhelp>Enter a game title or <a class=silent "
-        . helpWinHRef("help-tuid") . ">TUID</a></span>"
+        . "<span class=microhelp>Enter a game title or "
+        . helpWinLink("help-tuid", "TUID") . "</span>"
         . "</form>";
 
     $returnLink = "<a href=\"viewgame?id=$gameID\">"

--- a/www/csp-nonce.php
+++ b/www/csp-nonce.php
@@ -17,7 +17,7 @@ function random_str(
     $keyspace = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
 ) {
     $str = '';
-    $max = mb_strlen($keyspace, '8bit') - 1;
+    $max = 61; // mb_strlen($keyspace, '8bit') - 1;
     if ($max < 1) {
         throw new Exception('$keyspace must be at least two characters long');
     }

--- a/www/csp-nonce.php
+++ b/www/csp-nonce.php
@@ -29,4 +29,4 @@ function random_str(
 global $nonce;
 $nonce = random_str(8);
 
-header("Content-Security-Policy: default-src 'self' ifdb.org 'nonce-$nonce'; style-src 'self' 'unsafe-inline'; script-src-attr 'unsafe-inline';");
+header("Content-Security-Policy: default-src 'self' ifdb.org 'nonce-$nonce'; style-src 'self' 'unsafe-inline';");

--- a/www/csp-nonce.php
+++ b/www/csp-nonce.php
@@ -29,4 +29,4 @@ function random_str(
 global $nonce;
 $nonce = random_str(8);
 
-header("Content-Security-Policy: default-src 'self' ifdb.org 'nonce-$nonce' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; script-src-attr 'unsafe-inline';");
+header("Content-Security-Policy: default-src 'self' ifdb.org 'nonce-$nonce'; style-src 'self' 'unsafe-inline'; script-src-attr 'unsafe-inline';");

--- a/www/csp-nonce.php
+++ b/www/csp-nonce.php
@@ -1,0 +1,32 @@
+<?php
+// https://stackoverflow.com/a/34149536/54829
+/**
+ * Generate a random string, using a cryptographically secure 
+ * pseudorandom number generator (random_int)
+ * 
+ * For PHP 7, random_int is a PHP core function
+ * For PHP 5.x, depends on https://github.com/paragonie/random_compat
+ * 
+ * @param int $length      How many characters do we want?
+ * @param string $keyspace A string of all possible characters
+ *                         to select from
+ * @return string
+ */
+function random_str(
+    $length,
+    $keyspace = '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ'
+) {
+    $str = '';
+    $max = mb_strlen($keyspace, '8bit') - 1;
+    if ($max < 1) {
+        throw new Exception('$keyspace must be at least two characters long');
+    }
+    for ($i = 0; $i < $length; ++$i) {
+        $str .= $keyspace[random_int(0, $max)];
+    }
+    return $str;
+}
+global $nonce;
+$nonce = random_str(8);
+
+header("Content-Security-Policy: default-src 'self' ifdb.org 'nonce-$nonce' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; script-src-attr 'unsafe-inline';");

--- a/www/csp-nonce.php
+++ b/www/csp-nonce.php
@@ -29,4 +29,4 @@ function random_str(
 global $nonce;
 $nonce = random_str(8);
 
-header("Content-Security-Policy: default-src 'self' ifdb.org 'nonce-$nonce'; style-src 'self' 'unsafe-inline';");
+header("Content-Security-Policy: default-src 'self' ifdb.org www.google.com 'nonce-$nonce'; style-src 'self' 'unsafe-inline';");

--- a/www/delgame
+++ b/www/delgame
@@ -366,12 +366,9 @@ if ($createFwd)
            <b>Target game for forwarding redirect (TUID):</b><br>
            <input name="fwdid" id="fwdid" type="text" size=50
                  value="<?php echo $fwdid ?>">
-           <a href="needjs"
-              onclick="javascript:openGameSearchPopup(
-                 'fwdid', applyFwd, '<?php
-   echo str_replace(array("'", '"'), array("\\'", "&#34;"), $title)
-                 ?>');return false;"
-              >Find game by title</a>
+           <a href="needjs"><?php echo addEventListener("click", "openGameSearchPopup(
+                 'fwdid', applyFwd, '" . str_replace(array("'", '"'), array("\\'", "&#34;"), $title) . "');return false;"); ?>
+              Find game by title</a>
 
 <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--

--- a/www/delgame
+++ b/www/delgame
@@ -373,7 +373,7 @@ if ($createFwd)
                  ?>');return false;"
               >Find game by title</a>
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 function applyFwd(id, title, author)
 {

--- a/www/editclub
+++ b/www/editclub
@@ -435,7 +435,7 @@ $ckbox = "<label><input type=checkbox name=hasPassword value=1 "
          . "affecting existing members.</i></span>";
 
 ?>
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 function showHidePassword(show)
 {

--- a/www/editclub
+++ b/www/editclub
@@ -415,16 +415,17 @@ formCol("contacts", $contacts, "Contacts", "input(80)",
         . "<b>Bob Smith &lt;bob@ifclub.com&gt; <a class=silent href="
         . helpWinHRef("help-tuid") . "\">{TUID}</a></b>.  The {TUID} "
         . "is the IFDB profile link - "
-        . "<a href=\"needjs\" onclick=\"javascript:aplOpen("
-        . "'fld-contacts', 'Contacts');return false;\">Look up a profile</a>. "
+        . "<a href=\"needjs\">"
+        . addEventListener("click", "aplOpen('fld-contacts', 'Contacts');return false;")
+        . "Look up a profile</a>. "
         . "Separate contacts with commas if entering more than one. "
         . "E-mails will only be revealed after an \"enter the code\" "
         . "(CAPTCHA) test to block spam robots.");
 
 $ckbox = "<label><input type=checkbox name=hasPassword value=1 "
-         . "id='ckPassword' " . ($hasPassword ? "checked " : "")
-         . "onclick=\"javascript:showHidePassword(this.checked);"
-         . "return true;\"> <label for='ckPassword'>"
+         . "id='ckPassword' " . ($hasPassword ? "checked " : "") . ">"
+         . addSiblingEventListeners([["click", "showHidePassword(this.checked);"]])
+         . " <label for='ckPassword'>"
          . "Require new members to enter a password to join</label></label><br>"
          . "<span class=details><i>If you check this box, new members "
          . "will only be able to join if they know the password. "

--- a/www/editclub
+++ b/www/editclub
@@ -412,8 +412,8 @@ formCol("url", $url, "Web site", "input(80)",
         "The club's official Web site URL (http://...)");
 formCol("contacts", $contacts, "Contacts", "input(80)",
         "Contact information for club officials: use the format "
-        . "<b>Bob Smith &lt;bob@ifclub.com&gt; <a class=silent href="
-        . helpWinHRef("help-tuid") . "\">{TUID}</a></b>.  The {TUID} "
+        . "<b>Bob Smith &lt;bob@ifclub.com&gt; "
+        . helpWinLink("help-tuid", "{TUID}") . "</b>.  The {TUID} "
         . "is the IFDB profile link - "
         . "<a href=\"needjs\">"
         . addEventListener("click", "aplOpen('fld-contacts', 'Contacts');return false;")

--- a/www/editcomp
+++ b/www/editcomp
@@ -1212,7 +1212,7 @@ if ($show == "divform") {
     echo "<div id=\"divGridDiv\" style=\"margin: 2em 0 2em 0;\"></div>";
 
 ?>
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 var divModel = {
     rowhead: "Division Name</th><th>Description",
@@ -1294,7 +1294,7 @@ var divVals = [
     gameSearchPopupDiv();
 
 ?>
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 function checkClosePopup(event, byMouse)
 {

--- a/www/editcomp
+++ b/www/editcomp
@@ -1381,7 +1381,7 @@ function sortDivByPlace(modelVar, vals)
 
 function divRowTplFld(fldno, i, n, row, typ)
 {
-    var id = eval("divModel" + i).fields[fldno] + n;
+    var id = window["divModel" + i].fields[fldno] + n;
     return "<input name='" + id + "' id='" + id + "' "
         + typ + " value=\"" + jsQuote(row[fldno]) + "\">";
 }

--- a/www/editcomp
+++ b/www/editcomp
@@ -90,16 +90,16 @@ $fields = array(
 
     array("Organizers", "organizersExt", 80,
           "The people who organize the competition - "
-          . "<a href=\"needjs\" "
-          . "onclick=\"javascript:aplOpen('organizersExt', 'Organizers');"
-          . "return false;\">Link to profile</a>",
+          . "<a href=\"needjs\">"
+          . addEventListener("click", "aplOpen('organizersExt', 'Organizers'); return false;")
+          . "Link to profile</a>",
           null, TypeString),
 
     array("Judges", "judgesExt", 80,
           "For a juried competition, the names of the judges - "
-          . "<a href=\"needjs\" "
-          . "onclick=\"javascript:aplOpen('judgesExt', 'Judges');"
-          . "return false;\">Link to profile</a>",
+          . "<a href=\"needjs\">"
+          . addEventListener("click", "aplOpen('judgesExt', 'Judges'); return false;")
+          . "Link to profile</a>",
           null, TypeString),
 
     array("Opening date", "qualopen", 15,
@@ -1045,11 +1045,10 @@ else if ($show == "form") {
 
     // showing the form - set up the form page
     pageHeader($pageTitle, "editcomp.title",
-               "initGrids();",
+               "initGrids();\ndocument.body.addEventListener('mousedown', function (event) { checkClosePopup(event, true); });",
                "<script src=\"gridform.js\"></script>"
                . "<script src=\"xmlreq.js\"></script>",
-               false,
-               "onmousedown=\"checkClosePopup(event, true);\"");
+               false);
 
 
 
@@ -1327,12 +1326,8 @@ function nthOrd(n)
         echo "var divModel$i = { "
             . "addbutton: 'add-game-button', "
 
-            . "addExtra: \" <a href='#' title='Sort by Place' "
-            . "onmouseover=\\\"javascript:window.status='Sort by Place';"
-            . "return true;\\\" "
-            . "onmouseout=\\\"javascript:window.status='';\\\" "
-            . "onclick=\\\"javascript:sortDivByPlace('divModel$i', divVals$i);"
-            . "return false;\\\"><img src='img/blank.gif' "
+            . "addExtra: \" <a href='#' id='sortDivByPlaceButton$i' title='Sort by Place'>"
+            . "<img src='img/blank.gif' "
             . "class='sortByPlaceButton'></a>\", "
 
             . "name: 'divDiv$i', "
@@ -1351,6 +1346,7 @@ function nthOrd(n)
             . "} else p = '1st Place'; "
             . "return ['', p, '', '', '$divid']; },"
             . "onAddRow: function(n) { editGame('$i',n); }, "
+            . "activateListeners: function() { activateListeners('$i',this); }, "
             . "rowfunc: function(n) "
             .           "{ return divRowTpl({$i}, n, divVals{$i}[n]); } "
             . "};";
@@ -1431,12 +1427,11 @@ function divRowTpl(i, n, row)
         + (row[2]
            ? ("<a href=\"viewgame?id=" + row[0] + "\" target='_blank'><i>"
               + encodeHTML(row[2]) + "</i></a>")
-           : ("<a href='needjs' onclick=\"javascript:editGame("
-              + i + "," + n + ");return false;\">"
+           : ("<a href='needjs' class='editLink"+i+"_"+n+"'>"
               + "<i>Not set - click to select a game</i></a>"))
            + "</span><span style='padding-right: 3ex;'></span></td><td>"
-           + "<a href='needjs' onclick=\"javascript:editGame("
-           + i + "," + n + ");return false;\"><img src='img/blank.gif' "
+           + "<a href='needjs' class='editLink"+i+"_"+n+"'>"
+           + "<img src='img/blank.gif' "
            + "class='grid-edit-button'></a>";
 }
 
@@ -1456,6 +1451,86 @@ function editGame(divno, rownum)
         gameSearchPopupClose();
 
     }, '');
+}
+
+function activateListeners(divno, model)
+{
+    document.querySelector('#sortDivByPlaceButton' + divno).addEventListener('click', function(event) {
+        event.preventDefault();
+        sortDivByPlace('divModel' + divno, window["divVals"+divno]);
+    });
+
+    for (var i = 0; i < model.vals.length; i++) {
+        var idx = "" + divno + "_" + i;
+        (function(i){
+            document.querySelectorAll('a.editLink' + idx).forEach(function(editLink) {
+                console.log({editLink});
+                editLink.addEventListener('click', function(event) {
+                    event.preventDefault();
+                    editGame(divno, i);
+                });
+            });
+        })(i);
+
+        document.querySelectorAll('#gameplace'+idx).forEach(function(comboField) {
+            console.log({comboField});
+            comboField.addEventListener('keydown', function(event) {
+                var result = comboFieldKey(event,comboField.name,comboField.name + 'CBSel','D');
+                if (result === false) event.preventDefault();
+            });
+            comboField.addEventListener('keypress', function(event) {
+                var result = comboFieldKey(event,comboField.name,comboField.name + 'CBSel','P');
+                if (result === false) event.preventDefault();
+            });
+        });
+        document.querySelectorAll('a[x-name=gameplace'+idx+']').forEach(function(comboArrow) {
+            console.log({comboArrow});
+            comboArrow.addEventListener('click', function (event) {
+                event.preventDefault();
+                var name = comboArrow.getAttribute("x-name");
+                postShowComboMenu(name,true,name+'CBSel');
+            })
+            comboArrow.addEventListener('keydown', function(event) {
+                var name = comboArrow.getAttribute("x-name");
+                var result = comboArrowKey(event,name,name + 'CBSel','D');
+                if (result === false) event.preventDefault();
+            });
+            comboArrow.addEventListener('keydown', function(event) {
+                var name = comboArrow.getAttribute("x-name");
+                var result = comboArrowKey(event,name,name + 'CBSel','D');
+                if (result === false) event.preventDefault();
+            });
+        });
+
+        document.querySelectorAll('#gameplace'+idx+"CBDiv").forEach(function(comboList) {
+            console.log({comboList});
+            comboList.addEventListener('mouseover', function () {
+                overComboMenu = true;
+            });
+            comboList.addEventListener('mouseout', function () {
+                overComboMenu = false;
+            });
+        });
+
+        document.querySelectorAll('#gameplace'+idx+"CBSel").forEach(function(comboSelect) {
+            console.log({comboSelect});
+            var name = comboSelect.id.substring(0, comboSelect.id.length - 5);
+            comboSelect.addEventListener('click', function (event) {
+                setComboText(name,event.target.value,null);
+            });
+            comboSelect.addEventListener('keypress', function (event) {
+                var result = comboKeyPress(event,name,event.target,null);
+                if (result === false) event.preventDefault();
+            });
+            comboSelect.addEventListener('keydown', function (event) {
+                var result = comboKeyPress(event,name,event.target,null);
+                if (result === false) event.preventDefault();
+            });
+            comboSelect.addEventListener('blur', function (event) {
+                checkClosePopup(null, false);
+            });
+        });
+    }
 }
 
 <?php
@@ -1618,14 +1693,15 @@ function editGame(divno, rownum)
 
         . "<input type=image alt='Reset Form (Discard Changes)' "
         . "src='img/blank.gif' class='reset-form-button' "
-        . "name='discard' value='Reset Form (Discard Changes)' id='edit-reset' "
-        . "onclick=\"javascript:return confirm('"
-        . ($compID == "new"
-           ? "This will discard all of the data you\\'ve entered and reset "
-           . "to a blank form."
-           : "This will discard all of the changes you\\'ve made and "
-           . "reset to the last saved data from the database.")
-        . " Do you wish to proceed?');\">"
+        . "name='discard' value='Reset Form (Discard Changes)' id='edit-reset'>"
+        . addSiblingEventListeners([["click", "return confirm('"
+            . ($compID == "new"
+                ? "This will discard all of the data you\\'ve entered and reset "
+                . "to a blank form."
+                : "This will discard all of the changes you\\'ve made and "
+                . "reset to the last saved data from the database.")
+            . " Do you wish to proceed?');"
+        ]])
 
         . " &nbsp; "
 

--- a/www/editgame
+++ b/www/editgame
@@ -559,7 +559,7 @@ if ($saveErrMsg) {
 ?>
 
 <!-------------------------------------------------------------------------->
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 function helpWin(url) {
     win = window.open(url, null,
@@ -580,7 +580,7 @@ function confirmReset() {
 ?>
 
 <!-------------------------------------------------------------------------->
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 var formatPopupOpen = false;
 var overReviewPopup = false;
@@ -1417,7 +1417,7 @@ foreach ($linkfmts as $lf) {
 // --------------------- add the download-link grid -----------------------
 ?>
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 
 function uploadWindow()
@@ -1636,7 +1636,7 @@ var linkVals = [
                          "extrevSource", 80, "", array_keys($reviewSites),
                          "onComboSelectReviewSite");
                   ?>
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 var revSiteMap = {
     <?php
@@ -1703,7 +1703,7 @@ function onComboSelectReviewSite(val)
          </td>
       </tr>
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 function reviewPopupKey(event)
 {
@@ -1819,7 +1819,7 @@ var reviewVals = [
            gameSearchPopupDiv();
       ?>
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 
 function xrefEditBtnKey(event, n)

--- a/www/editgame
+++ b/www/editgame
@@ -514,11 +514,11 @@ if ($errMsg) {
         // start the page
         pageHeader($pagetitle, "editgame.title",
                    "gfGenForm('linkModel');gfGenForm('reviewModel');"
-                   . "gfGenForm('xrefModel');",
+                   . "gfGenForm('xrefModel');"
+                   . "\ndocument.body.addEventListener('mousedown', function (event) { checkClosePopup(event, true); });",
                    "<script src=\"gridform.js\"></script>"
                    . "<script src=\"xmlreq.js\"></script>",
-                   false,
-                   "onmousedown=\"checkClosePopup(event,true);\"");
+                   false);
 
         initStarControls();
         imageUploadScripts();
@@ -536,19 +536,10 @@ if ($id == "new")
         . helpWinLink("help-add-game", "Guidelines for adding new games")
         . " - "
         . helpWinLink("help-edit-game", "Guidelines for game listing")
-//       <a href=\"needjs\"
-//         onclick=\"javascript:helpWin('help-add-game');return false;\">
-//          Guidelines for adding new games</a> -
-//       <a href=\"needjs\"
-//          onclick=\"javascript:helpWin('help-edit-game');return false;\">
-//          Guidelines for game listings</a>"
         . "</span><br><br>";
 else
     echo "<p><span class=notes> "
         . helpWinLink("help-edit-game", "Guidelines for game listings")
-//          <a href=\"needjs\"
-//           onclick=\"javascript:helpWin('help-edit-game');return false;\">
-//           Guidelines for game listings</a>
         . "</span><br><br>";
 
 if ($saveErrMsg) {
@@ -1155,7 +1146,8 @@ echo "<span class=details><i>List downloads for the game itself
    . "<br>"
    . "<div style=\"margin-top: 1ex; margin-bottom: 1ex;\">"
    . "<b>Are you the author of this game?</b> "
-   . "<a href=\"needjs\" onclick=\"javascript:uploadWindow();return false;\">"
+   . "<a href=\"needjs\">"
+   . addEventListener("click", "uploadWindow();return false;")
    . "Upload it to the IF Archive</a></div>";
 
 
@@ -1171,22 +1163,33 @@ function echoGridField($link, $fld, $isFirst = false)
 // ---------------  display the hidden download-link editor ----------------
 ?>
 <div id="linkpopup" class="edit-popup-frame"
-     style="position:absolute;display:none;top:0px;left:0px;z-index:10000;"
-     onmouseover="javascript:overLinkPopup=true;return true;"
-     onmouseout="javascript:overLinkPopup=false;return true;"
-     onkeydown="javascript:return linkPopupKey(event);"
-     onkeypress="javascript:return linkPopupKey(event);">
+     style="position:absolute;display:none;top:0px;left:0px;z-index:10000;">
+   <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
+    linkpopup.addEventListener('mouseover', function () { overLinkPopup=true });
+    linkpopup.addEventListener('mouseout', function () { overLinkPopup=false });
+    linkpopup.addEventListener('keydown', function (event) {
+        var result = linkPopupKey(event);
+        if (result === false) event.preventDefault();
+    });
+    linkpopup.addEventListener('keypress', function (event) {
+        var result = linkPopupKey(event);
+        if (result === false) event.preventDefault();
+    });
+   </script>
    <div style="position:relative;" class="edit-popup-title">
       <div style="text-align:center;"><b>Edit Link</b></div>
       <span style="position:absolute;top:2px;right:4px;">
          <?php
            echo helpWinLink("help-links", "Help");
-//         <a href="needjs"
-//          onclick="javascript:helpWin('help-links');return false;">
-//            Help</a>
          ?>
          &nbsp;&nbsp;
-         <a href="needjs" onclick="javascript:closeLinkPopup();return false;">
+         <a href="needjs">
+            <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
+                document.currentScript.parentElement.addEventListener('click', function (event) {
+                    event.preventDefault();
+                    closeLinkPopup();
+                })
+            </script>
             Close<img src="img/blank.gif" class="popup-close-button"></a>
          </span>
    </div>
@@ -1203,8 +1206,12 @@ function echoGridField($link, $fld, $isFirst = false)
                      <b>URL:</b>
                   </td>
                   <td>
-                     <input type="text" name="linkurl" id="linkurl" oninput="javascript:updateFormatUI()"
+                     <input type="text" name="linkurl" id="linkurl"
                             size=80><br><span class=details>
+                        <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
+                            linkurl.addEventListener('input', function() {updateFormatUI();})
+                        </script>
+
                         The full URL, linking directly to the downloadable
                         file. For IF Archive links, use the <b>main</b> Archive
                         only (http://www.ifarchive.org/if-archive/...) -
@@ -1220,7 +1227,10 @@ function echoGridField($link, $fld, $isFirst = false)
                   </td>
                   <td>
                      <input type="text" name="linktitle" id="linktitle"
-                            size=40 oninput="javascript:updateFormatUI()">
+                            size=40>
+                        <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
+                            linktitle.addEventListener('input', function() {updateFormatUI();})
+                        </script>
                      <br>
                      <span class=details>
                         A short title for the link: "Story File", "User's
@@ -1251,8 +1261,10 @@ function echoGridField($link, $fld, $isFirst = false)
                   <td>
                      <label>
                      <input type="checkbox" value="1"
-                         name="linkisgame" id="linkisgame"
-                         onclick="javascript:updateIsGame();return true;">
+                         name="linkisgame" id="linkisgame">
+                         <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
+                            linkisgame.addEventListener('click', function() {updateIsGame();})
+                        </script>
                      <label for="linkisgame"> This is a playable game file
                         <i><b>or</b></i> it <b>contains</b> a playable game
                         </label></label>
@@ -1296,8 +1308,10 @@ function echoGridField($link, $fld, $isFirst = false)
                      <b>File Type:</b>
                   </td>
                   <td>
-                     <select name="linkfmtG" id="linkfmtG"
-                             onchange="javascript:updateFormatUI(true)">
+                     <select name="linkfmtG" id="linkfmtG">
+                            <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
+                                linkfmtG.addEventListener('change', function() {updateFormatUI(true);})
+                            </script>
                         <?php
 // write out the GAME formats
 foreach ($linkfmts as $lf) {
@@ -1310,8 +1324,10 @@ foreach ($linkfmts as $lf) {
                         ?>
                      </select>
                      <select name="linkfmtNG" id="linkfmtNG"
-                             style="display:none;"
-                             onchange="javascript:updateFormatUI(true)">
+                             style="display:none;">
+                             <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
+                                linkfmtNG.addEventListener('change', function() {updateFormatUI(true);})
+                            </script>
                         <?php
 // write out the NON-GAME formats
 foreach ($linkfmts as $lf) {
@@ -1354,8 +1370,10 @@ foreach ($oslist as $os) {
                      <b><nobr>Compression:</nobr></b>
                   </td>
                   <td>
-                     <select name="linkcomp" id="linkcomp"
-                        onchange="javascript:updateFormatUI(false)">
+                     <select name="linkcomp" id="linkcomp">
+                        <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
+                            linkcomp.addEventListener('change', function() {updateFormatUI(false);})
+                        </script>
                         <option value="">None</option>
                         <?php
 // write out the compression formats
@@ -1376,7 +1394,10 @@ foreach ($linkfmts as $lf) {
                   </td>
                   <td>
                      <input type="text" name="linkcomppri" id="linkcomppri"
-                            size=40 oninput="javascript:updateFormatUI()">
+                            size=40>
+                            <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
+                                linkcomppri.addEventListener('input', function() {updateFormatUI();})
+                            </script>
                      <input type="text" id="linkcomppriNA" value="N/A"
                             readonly size=40
                            style="background:#e0e0e0;color:#404040;">
@@ -1508,12 +1529,10 @@ var linkModel = {
                "linkcomp", "linkcomppri"],
 
     "rowtpl": "<nobr><input type=\"text\" readonly #1 size=100>"
-        + " <a href=\"needjs\" onkeydown=\"javascript:return linkEditBtnKey("
-        + "event,'##');\" id=\"linkEditBtn##\">"
+        + " <a href=\"needjs\" id=\"linkEditBtn##\">"
         + "<img alt=\"Edit this link\" "
         + "border=0 src=\"/img/blank.gif\" class=\"grid-edit-button\" "
-        + "style=\"cursor:pointer;\" "
-        + "onclick=\"javascript:postLinkPopup(event,'##');return false;\"></a>"
+        + "style=\"cursor:pointer;\"></a>"
         + "<input type=hidden #2>"
         + "<input type=hidden #3>"
         + "<input type=hidden #4>"
@@ -1523,7 +1542,18 @@ var linkModel = {
         + "<input type=hidden #8>"
         + "<input type=hidden #9>"
         + "<input type=hidden #10>"
-        + "</nobr>"
+        + "</nobr>",
+
+    "activateListeners": function() {
+        for (var i = 0; i < linkVals.length; i++) {
+            (function(i) {
+                window['linkEditBtn' + i].addEventListener('click', function(event) {
+                    event.preventDefault();
+                    postLinkPopup(event, i);
+                });
+            })(i);
+        }
+    }
 };
 var linkVals = [
     <?php
@@ -1593,11 +1623,19 @@ var linkVals = [
             ?>
             <div id="reviewpopup" class="edit-popup-frame"
                  style="position:absolute; display:none; top:0px; left:0px;
-                        z-index:10000;"
-                 onmouseover="javascript:overReviewPopup=true;return true;"
-                 onmouseout="javascript:overReviewPopup=false;return true;"
-                 onkeypress="javascript:return reviewPopupKey(event);"
-                 onkeydown="javascript:return reviewPopupKey(event);">
+                        z-index:10000;">
+               <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
+                    reviewpopup.addEventListener('mouseover', function () { overReviewPopup=true });
+                    reviewpopup.addEventListener('mouseout', function () { overReviewPopup=false });
+                    reviewpopup.addEventListener('keydown', function (event) {
+                        var result = reviewPopupKey(event);
+                        if (result === false) event.preventDefault();
+                    });
+                    reviewpopup.addEventListener('keypress', function (event) {
+                        var result = reviewPopupKey(event);
+                        if (result === false) event.preventDefault();
+                    });
+               </script>
                <div style="position:relative;" class="edit-popup-title">
                   <div style="text-align:center;">
                      <b>Edit Review Link</b>
@@ -1606,12 +1644,14 @@ var linkVals = [
                         text-align:right;">
                      <?php
 //                         echo helpWinLink("help-ext-reviews", "Help");
-//                     <a href="needjs"
-//                        onclick="javascript:helpWin('help-ext-reviews');return false;">
-//                        Help</a> &nbsp;&nbsp;
                      ?>
-                     <a href="needjs"
-                        onclick="javascript:closeReviewPopup();return false;">
+                     <a href="needjs">
+                        <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
+                            document.currentScript.parentElement.addEventListener('click', function(event) {
+                                event.preventDefault();
+                                closeReviewPopup();
+                            });
+                        </script>
                         Close<img src="img/blank.gif" class="popup-close-button"></a>
                   </span>
                </div>
@@ -1663,9 +1703,13 @@ function onComboSelectReviewSite(val)
                   <b>Rating:</b> <?php
                       echo showStarCtl("extrevStarCtl", 0,
                                        "setExtRevRating", "null");
-                  ?> <a href="needjs" onclick="javascript:setExtRevRating(0);
-                      setStarCtlValue('extrevStarCtl',0);return false;"
-                      >Remove rating</a><br>
+                  ?> <a href="needjs"><script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
+                        document.currentScript.parentElement.addEventListener('click', function(event) {
+                            event.preventDefault();
+                            setExtRevRating(0);
+                            setStarCtlValue('extrevStarCtl',0);
+                        })
+                    </script>Remove rating</a><br>
                   <input type=hidden name=extrevRating id=extrevRating value=0>
                   <span class=details>If the site uses a different rating
                      system, pick the closest equivalent star rating (e.g.,
@@ -1683,8 +1727,6 @@ function onComboSelectReviewSite(val)
                      own words, or enter a brief excerpt from the
                      full review (a paragraph or two). - <?php
                        echo helpWinLink("help-formatting", "Formatting hints");
-//                     <a href="needjs" onclick="javascript:helpWin(
-//                        'help-formatting');return false;">Formatting hints</a>
                      ?>
                   </span><br>
                   <textarea id="extrevSummary" rows=5 cols=80></textarea>
@@ -1741,20 +1783,28 @@ var reviewModel = {
                 "extrevRating", "extrevHeadline", "extrevSummary"],
 
     "rowtpl": "<nobr><input type=text readonly #1 size=100>"
-        + " <a href=\"needjs\" onkeypress=\"javascript:return "
-        + "reviewEditBtnKey(event,'##');\" onkeydown=\"javascript:return "
-        + "reviewEditBtnKey(event,'##');\" id=\"reviewEditBtn##\">"
+        + " <a href=\"needjs\" id=\"reviewEditBtn##\">"
         + "<img alt=\"Edit this review\" "
         + "border=0 src=\"/img/blank.gif\" class=\"grid-edit-button\" "
-        + "style=\"cursor:pointer;\" "
-        + "onclick=\"javascript:postShowReviewPopup('##');return false;\"></a>"
+        + "style=\"cursor:pointer;\"></a>"
         + "<input type=hidden #2>"
         + "<input type=hidden #3>"
         + "<input type=hidden #4>"
         + "<input type=hidden #5>"
         + "<input type=hidden #6>"
         + "<input type=hidden #7>"
-        + "</nobr>"
+        + "</nobr>",
+    
+    "activateListeners": function() {
+        for (var i = 0; i < reviewVals.length; i++) {
+            (function(i) {
+                window['reviewEditBtn' + i].addEventListener('click', function(event) {
+                    event.preventDefault();
+                    postShowReviewPopup(i);
+                });
+            })(i);
+        }
+    }
 };
 var reviewVals = [
     <?php
@@ -1878,21 +1928,32 @@ for ($i = 0 ; $i < count($reftypes) ; ++$i) {
 ?></select> <input type=\"hidden\" #2><input type=\"hidden\" #3>"
        + "<span id=\"xrefDispTitle##\" style=\"padding: 0 1em 0 1em;\">"
        + (xrefVals[rownum][1] == ""
-          ? "<a href=\"needjs\" onclick=\"javascript:editXRef('##');"
-          + "return false;\"><i>Not set - click to select a game</i></a>"
+          ? "<a href=\"needjs\" xref-name=\"##\"><i>Not set - click to select a game</i></a>"
           : "<a href=\"viewgame?id=$2\" class=\"silent\" target=\"_blank\">"
           + "<i>$3</i></a>")
        + "</td><td>"
-       + "<a href=\"#\" onkeypress=\"javascript:return "
-       + "xrefEditBtnKey(event,'##');\" onkeydown=\"javascript:return "
-       + "xrefEditBtnKey(event,'##');\" "
-       + "id=\"xrefEditBtn##\"><img alt=\"Edit this reference\" "
+       + "<a href=\"#\" id=\"xrefEditBtn##\"><img alt=\"Edit this reference\" "
        + "border=0 src=\"/img/blank.gif\" class=\"grid-edit-button\" "
-       + "style=\"cursor:pointer;\" onclick=\"javascript:editXRef('##');"
-       + "return false;\"></a></nobr>";
+       + "style=\"cursor:pointer;\"></a></nobr>";
     },
     onAddRow: function(rownum) {
         editXRef(rownum);
+    },
+    activateListeners: function() {
+        for (var i = 0; i < xrefVals.length; i++) {
+            (function(i) {
+                window['xrefEditBtn' + i].addEventListener('click', function(event) {
+                    event.preventDefault();
+                    editXRef(i);
+                });
+                document.querySelectorAll("a[xref-name=\""+i+"\"]").forEach(function (xrefLink) {
+                    xrefLink.addEventListener('click', function (event) {
+                        event.preventDefault();
+                        editXRef(i);
+                    });
+                });
+            })(i);
+        }
     }
 
 };
@@ -1950,9 +2011,15 @@ for ($i = 0 ; $i < count($reftypes) ; ++$i) {
             &nbsp;
             <input type=image alt="Reset Form (Discard Changes)"
                    value="Reset Form (Discard Changes)"
-                   name="discard" onclick="javascript:return confirmReset();"
+                   name="discard"
                    src="img/blank.gif" class="reset-form-button"
                    id="editgame-reset-button">
+                   <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
+                       window['editgame-reset-button'].addEventListener('click', function (event) {
+                          var result = confirmReset();
+                          if (result === false) event.preventDefault();
+                       });
+                   </script>
             &nbsp;
             <a href="<?php
                 echo ($id == "new" ? "home" : "viewgame?id=$id");

--- a/www/editgame-util.php
+++ b/www/editgame-util.php
@@ -49,12 +49,18 @@ define("TypeDateOrYear", 5);
 
 // field descriptors
 global $fields;
+global $nonce;
 $fields = array(
     array("Title", "title", 60, "Required", null, TypeString),
     array("Author(s)", "eAuthor", 60,
           "Required; enter Anonymous if the work is unattributed.
-           - <a href=\"needjs\"
-            onclick=\"javascript:aplOpen('eAuthor', 'Author');return false;\">
+           - <a href=\"needjs\">
+            <script type='text/javascript' nonce='$nonce'>
+                document.currentScript.parentElement.addEventListener('click', function(event) {
+                    event.preventDefault();
+                    aplOpen('eAuthor', 'Author');
+                });
+            </script>
             Link to author's profile</a> - "
           . helpWinLink("help-author", "Tips"),
           null, TypeString),

--- a/www/editlist
+++ b/www/editlist
@@ -875,10 +875,7 @@ var listModel = {
         else
         {
             var iid = "disptitle" + row;
-            s += (row+1) + ". <span id=\"" + iid + "\"><a href=\"needjs\" "
-                 + "onclick=\"javascript:openGameSearchPopup('" + iid
-                 + "', function(tuid,t,a) { setGameItem('" + row
-                 + "',tuid,t,a); },'');return false;\">"
+            s += (row+1) + ". <span id=\"" + iid + "\"><a href=\"needjs\">"
                  + "<i>Click to select a game</i></a></span>";
         }
         s += "<br><table border=0 cellspacing=0 cellpadding=0>"
@@ -895,7 +892,22 @@ var listModel = {
             s += "<br>&nbsp;<br>";
 
         return s;
-    }
+    },
+    "activateListeners": function() {
+        for (var i = 0; i < listVals.length; i++) {
+            (function(i) {
+                var iid = 'disptitle' + i;
+                if (window[iid]) {
+                    window[iid].querySelector('a').addEventListener('click', function(event) {
+                        event.preventDefault();
+                        openGameSearchPopup(iid, function (tuid,t,a) {
+                            setGameItem(i,tuid,t,a);
+                        });
+                    });
+                }
+            })(i);
+        }
+    },
 };
 var listVals = [
     <?php

--- a/www/editlist
+++ b/www/editlist
@@ -841,7 +841,7 @@ if ($listid != 'new')
 
             <p>
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 var listModel = {
     "emptylabel": "<i>This list doesn't have any entries yet.</i>",

--- a/www/editprofile
+++ b/www/editprofile
@@ -774,9 +774,6 @@ captchaSupportScripts($captchaKey);
                "cloaked" if you've manually obscured your address to prevent
                spam (<?php
                  echo helpWinLink("help-spamcloaking", "explain");
-//<a href="needjs"
-//               onclick="javascript:helpWin('help-spamcloaking');return false;"
-//               >explain</a>
                ?>) - we'll warn other users about this if so.
             </span>
          </td>

--- a/www/gamesearchpopup.php
+++ b/www/gamesearchpopup.php
@@ -41,7 +41,7 @@
 function gameSearchPopupSupportFuncs()
 {
 ?>
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 
 var gameSearchPopupDoneFunc;

--- a/www/gamesearchpopup.php
+++ b/www/gamesearchpopup.php
@@ -104,11 +104,8 @@ function gameSearchPopupDone(d)
             var title = lst[i].getElementsByTagName('title')[0].firstChild.data;
             var author = lst[i].getElementsByTagName('author')[0].firstChild.data;
 
-            s += "<a href=\"needjs\" onclick=\"javascript:"
-                 + "gameSearchPopupSetID('" + id
-                 + "','" + title.replace(/'/g, '\\\'').replace(/"/g, '&#34;')
-                 + "','" + author.replace(/'/g, '\\\'').replace(/"/g, '&#34;')
-                 + "');return false;\"><i>" + encodeHTML(title) + "</i></a>"
+            s += "<a href=\"needjs\" id='gameSearchPopupLink"+i+"'><i>"
+                 + encodeHTML(title) + "</i></a>"
                  + ", by " + encodeHTML(author)
                  + " - <a href=\"viewgame?id=" + id + "\" target=\"_blank\">"
                  + "view game</a><br>";
@@ -117,6 +114,17 @@ function gameSearchPopupDone(d)
             s = "<b><i>(No matching games found.)</i></b>";
 
         document.getElementById("gameSearchPopupResults").innerHTML = s;
+        for (var i = 0; i < lst.length; i++) {
+            (function(i) {
+                window['gameSearchPopupLink'+i].addEventListener('click', function(event) {
+                    event.preventDefault();
+                    var id = lst[i].getElementsByTagName('tuid')[0].firstChild.data;
+                    var title = lst[i].getElementsByTagName('title')[0].firstChild.data;
+                    var author = lst[i].getElementsByTagName('author')[0].firstChild.data;
+                    gameSearchPopupSetID(id, title, author);
+                })
+            })(i);
+        }
         document.getElementById("gameSearchPopupStep2").style.display = "block";
         setTimeout(function() {
             var ele = document.getElementById("gameSearchPopupDiv");
@@ -152,8 +160,13 @@ function gameSearchPopupDiv()
              <b>Select a Game</b>
              <span style="position:absolute;top:2px;right:2px;
                    text-align:right;">
-                <a href="needjs"
-                 onclick="javascript:gameSearchPopupClose();return false;">
+                <a href="needjs">
+                   <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
+                      document.currentScript.parentElement.addEventListener('click', function (event) {
+                        event.preventDefault();
+                        gameSearchPopupClose();
+                      })
+                   </script>
                    Close<img src="img/blank.gif" class="popup-close-button"></a>
              </span>
           </div>
@@ -163,12 +176,23 @@ function gameSearchPopupDiv()
               echo helpWinLink("help-ifid", "IFID") ?>, or <?php
               echo helpWinLink("help-tuid", "TUID") ?>:
           <br>
-          <input id="gameSearchPopupSearchBox" type=text size=50
-              onkeypress="javascript:return gameSearchPopupKey(event);"
-              onkeydown="javascript:return gameSearchPopupKey(event);">
+          <input id="gameSearchPopupSearchBox" type=text size=50>
           <input type=submit name="gameSearchPopupGoBtn"
-              id="gameSearchPopupGoBtn" value="Search"
-              onclick="javascript:gameSearchPopupGo();return false;">
+              id="gameSearchPopupGoBtn" value="Search">
+          <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
+            gameSearchPopupSearchBox.addEventListener('keypress', function (event) {
+                var result = gameSearchPopupKey(event);
+                if (result === false) event.preventDefault();
+            });
+            gameSearchPopupSearchBox.addEventListener('keydown', function (event) {
+                var result = gameSearchPopupKey(event);
+                if (result === false) event.preventDefault();
+            });
+            gameSearchPopupGoBtn.addEventListener('click', function (event) {
+                event.preventDefault();
+                gameSearchPopupGo();
+            });
+          </script>
           <div id="gameSearchPopupStep2" style="display:none;">
              <p><b>Step 2:</b> Click on a result below to select it:
 

--- a/www/gridform.js
+++ b/www/gridform.js
@@ -3,8 +3,8 @@
 function gfGenForm(modelVar, newRowIdx)
 {
     var i, j;
-    var model = eval(modelVar);
-    var vals = eval(model.vals);
+    var model = window[modelVar];
+    var vals = window[model.vals];
     var fields = model.fields;
     var d = document.getElementById(model.name);
     var s = "<table>";
@@ -169,8 +169,8 @@ function gfGenForm(modelVar, newRowIdx)
 
 function gfReloadVals(modelVar)
 {
-    var model = eval(modelVar);
-    var vals = eval(model.vals);
+    var model = window[modelVar];
+    var vals = window[model.vals];
     var fields = model.fields;
     var valcnt = vals.length;
     var row, fieldnum;
@@ -190,7 +190,7 @@ function gfReloadVals(modelVar)
 function gfInsRow(modelVar, n, newrow)
 {
     gfReloadVals(modelVar);
-    var model = eval(modelVar), vals = eval(model.vals), i;
+    var model = window[modelVar], vals = window[model.vals], i;
     var nrv = model.newRowVals;
 
     if (typeof(nrv) == "function")
@@ -237,7 +237,7 @@ function gfPostDelRow(modelVar, n)
 
 function gfDelRow(modelVar, n)
 {
-    var model = eval(modelVar);
+    var model = window[modelVar];
     var conf = model.confirmRemove || function(rownum) {
         return confirm("Do you really want to delete this row?");
     };
@@ -246,7 +246,7 @@ function gfDelRow(modelVar, n)
         return;
 
     gfReloadVals(modelVar);
-    var model = eval(modelVar), vals = eval(model.vals), i;
+    var model = window[modelVar], vals = window[model.vals], i;
     vals.splice(n, 1);
     gfGenForm(modelVar);
 }
@@ -254,7 +254,7 @@ function gfDelRow(modelVar, n)
 function gfMoveRow(modelVar, n, dir)
 {
     gfReloadVals(modelVar);
-    var model = eval(modelVar), vals = eval(model.vals);
+    var model = window[modelVar], vals = window[model.vals];
 
     var row = vals[n];
     vals.splice(n, 1);

--- a/www/gridform.js
+++ b/www/gridform.js
@@ -99,21 +99,13 @@ function gfGenForm(modelVar, newRowIdx)
         s += "<tr><td valign=\"" + ctlvalign + "\"><nobr>";
 
         if (i > 0)
-            s += "<a href=\"needjs\" title=\"Move up\" "
-                 + "onmouseover=\"javascript:window.status='Move up';return true;\" "
-                 + "onmouseout=\"javascript:window.status='';\" "
-                 + "onclick=\"javascript:gfMoveRow('" + modelVar + "',"
-                 + i + ",-1);return false;\">"
+            s += "<a href=\"needjs\" class='"+modelVar+"MoveUp' x-i='"+i+"' title=\"Move up\">"
                  + "<img src=\"/img/blank.gif\" class=\"grid-move-up\"></a> ";
         else
             s += "<img src=\"/img/blank.gif\" class=\"grid-move-blank\"> "
 
         if (i + 1 < vals.length)
-            s += "<a href=\"needjs\" title=\"Move down\" "
-                 + "onmouseover=\"javascript:window.status='Move down';return true;\" "
-                 + "onmouseout=\"javascript:window.status='';\" "
-                 + "onclick=\"javascript:gfMoveRow('" + modelVar + "',"
-                 + i + ",1);return false\">"
+            s += "<a href=\"needjs\" class='"+modelVar+"MoveDown' x-i='"+i+"' title=\"Move down\">"
                  + "<img src=\"/img/blank.gif\" class=\"grid-move-down\"></a> ";
         else
             s += "<img src=\"/img/blank.gif\" class=\"grid-move-blank\"> ";
@@ -121,30 +113,48 @@ function gfGenForm(modelVar, newRowIdx)
         s += "</nobr></td><td>" + txt + "</td><td valign=\"" + ctlvalign + "\">";
 
         if (model.allowRemove == null || model.allowRemove(i))
-            s += "<a href=\"needjs\" title=\"Remove\" "
-                 + "onmouseover=\"javascript:window.status='Remove';"
-                 + "return true;\" "
-                 + "onmouseout=\"javascript:window.status='';\" "
-                 + "onkeypress=\"javascript:return gfDelRowBtnKey("
-                 + "event,'" + modelVar + "'," + i + ");\" "
-                 + "onclick=\"javascript:gfPostDelRow('" + modelVar + "',"
-                 + i + ");return false\">"
+            s += "<a href=\"needjs\" class='"+modelVar+"Remove' x-i='"+i+"' title=\"Remove\">"
                  + "<img src=\"/img/blank.gif\" class=\"grid-remove-button\"></a> ";
 
         s += "</td></tr>";
     }
 
     s += "<tr><td></td><td>"
-         + "<a href=\"#\" title=\"Add a new item\" "
-         + "onmouseover=\"javascript:window.status='Add a new item';return true;\" "
-         + "onmouseout=\"javascript:window.status='';\" "
-         + "onclick=\"javascript:gfInsRow('" + modelVar + "',"
-         + i + ");return false;\"><img src=\"/img/blank.gif\" class=\""
+         + "<a href=\"#\" class='"+modelVar+"Add' title=\"Add a new item\">"
+         + "<img src=\"/img/blank.gif\" class=\""
          + model.addbutton + "\"></a>"
          + (model.addExtra ? model.addExtra : "")
          + "</td></tr></table>";
 
     d.innerHTML = s;
+
+    d.querySelectorAll("." + modelVar + "MoveUp").forEach(function (link) {
+        link.addEventListener('click', function (event) {
+            event.preventDefault();
+            gfMoveRow(modelVar, link.getAttribute("x-i"), -1);
+        })
+    });
+
+    d.querySelectorAll("." + modelVar + "MoveDown").forEach(function (link) {
+        link.addEventListener('click', function (event) {
+            event.preventDefault();
+            gfMoveRow(modelVar, link.getAttribute("x-i"), 1);
+        })
+    });
+
+    d.querySelectorAll("." + modelVar + "Remove").forEach(function (link) {
+        link.addEventListener('click', function (event) {
+            event.preventDefault();
+            gfDelRow(modelVar, link.getAttribute("x-i"));
+        })
+    });
+
+    d.querySelectorAll("." + modelVar + "Add").forEach(function (link) {
+        link.addEventListener('click', function (event) {
+            event.preventDefault();
+            gfInsRow(modelVar, i);
+        })
+    });
 
     if (model.activateListeners) model.activateListeners();
 

--- a/www/gridform.js
+++ b/www/gridform.js
@@ -131,21 +131,21 @@ function gfGenForm(modelVar, newRowIdx)
     d.querySelectorAll("." + modelVar + "MoveUp").forEach(function (link) {
         link.addEventListener('click', function (event) {
             event.preventDefault();
-            gfMoveRow(modelVar, link.getAttribute("x-i"), -1);
+            gfMoveRow(modelVar, Number(link.getAttribute("x-i")), -1);
         })
     });
 
     d.querySelectorAll("." + modelVar + "MoveDown").forEach(function (link) {
         link.addEventListener('click', function (event) {
             event.preventDefault();
-            gfMoveRow(modelVar, link.getAttribute("x-i"), 1);
+            gfMoveRow(modelVar, Number(link.getAttribute("x-i")), 1);
         })
     });
 
     d.querySelectorAll("." + modelVar + "Remove").forEach(function (link) {
         link.addEventListener('click', function (event) {
             event.preventDefault();
-            gfDelRow(modelVar, link.getAttribute("x-i"));
+            gfDelRow(modelVar, Number(link.getAttribute("x-i")));
         })
     });
 

--- a/www/gridform.js
+++ b/www/gridform.js
@@ -146,6 +146,8 @@ function gfGenForm(modelVar, newRowIdx)
 
     d.innerHTML = s;
 
+    if (model.activateListeners) model.activateListeners();
+
     if (model.popups)
     {
         for (var p in model.popups)

--- a/www/help-review-votes
+++ b/www/help-review-votes
@@ -26,7 +26,7 @@ you) see this user's reviews throughout IFDB.  If you Promote the
 user, you'll see her reviews listed first when viewing a game; if you
 Demote her, her reviews will move to the end of the list.
 (You can view and change your promotions and demotions via the
- <a href="userfilter?list" onclick="return openUserFilter();">user filter
+ <a href="userfilter?list">user filter
 editor</a>.)
 
 <p><a name="plonk"><b>Plonk this user:</b></a>
@@ -36,9 +36,7 @@ If you plonk a user, <b>all</b> of her reviews will be omitted when
 you view game pages throughout IFDB.  This only affects you - it won't
 actually delete the user's reviews or hide them when other members
 view the same game pages.  (You can change your mind and un-plonk
-someone later via the <a href="userfilter?list"
-onclick="javascript:window.opener.location = 'userfilter?list';return false;"
->user filter editor</a>.)
+someone later via the <a href="userfilter?list">user filter editor</a>.)
 
 <p><b>Flag spoilers:</b> Mark this review as containing
 <b>unhidden</b> spoilers.  A spoiler gives away a secret that you're
@@ -56,19 +54,18 @@ review may violate the
 <a href="/tos">Terms of Service</a>.
 
 <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
-function openUserFilter()
-{
-    if (window.opener
-        && window.opener != window
-        && !window.opener.closed)
-    {
-        window.opener.location = "userfilter?list";
-        window.close();
-        return false;
-    }
-    else
-        return true;
-}
+document.querySelectorAll('a[href="userfilter?list"]').forEach(function (link) {
+    link.addEventListener('click', function (event) {
+        if (window.opener
+            && window.opener != window
+            && !window.opener.closed)
+        {
+            window.opener.location = "userfilter?list";
+            window.close();
+            event.preventDefault();
+        }
+    });
+})
 </script>
 
 <?php

--- a/www/help-review-votes
+++ b/www/help-review-votes
@@ -55,7 +55,7 @@ review may violate the
 <a href="/code-of-conduct">Code of Conduct</a> or the
 <a href="/tos">Terms of Service</a>.
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 function openUserFilter()
 {
     if (window.opener

--- a/www/ifarchive-upload
+++ b/www/ifarchive-upload
@@ -166,6 +166,9 @@ games there, to reach players and for historical preservation.</p>
 
 </ul>
 
+<form id="uploadForm" action="http://upload.ifarchive.org/cgi-bin/upload.py"
+      method="POST" enctype="multipart/form-data">
+
 <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 function doSubmit()
 {
@@ -199,21 +202,21 @@ function setFileName()
     var vis = (fname && fname.match(/.*\.zip/i)) ? "" : "none";
     document.getElementById("zipPrimaryRow").style.display = vis;
 }
-</script>
 
-<form action="http://upload.ifarchive.org/cgi-bin/upload.py"
-      method="POST" enctype="multipart/form-data"
-      onsubmit="javascript:return doSubmit();">
+uploadForm.addEventListener('submit', function (event) {
+    var result = doSubmit();
+    if (result === false) event.preventDefault();
+});
+</script>
 
  <input type="hidden" name="ifdbid" value="<?php echo $uploadID ?>"/>
 
 <table border="0" cellspacing="5">
   <tr><td align=right>Filename:</td><td>&nbsp;</td>
     <td><input type="file" name="file.1" size="35" maxlength="100"
-         id="uploadFileName" onchange="javascript:setFileName();" /></td></tr>
+         id="uploadFileName"></td></tr>
   <tr><td align=right>Game file format:</td><td>&nbsp;</td>
-     <td><select name="gameFormat" id="gameFormat"
-         onchange="javascript:setArchivePath(document.getElementById('gameFormat').value,'fmt');">
+     <td><select name="gameFormat" id="gameFormat">
         <option id="storyfile"<?php if (!$fmt) echo " selected";
         ?>>Please Select</option><?php
         foreach ($fmts as $f) {
@@ -230,8 +233,7 @@ function setFileName()
         <option value="executable">None - Native Application</option>
       </select>
 
-      <select style="margin-left: 1ex;" id="opsys" name="opsys"
-           onchange="javascript:setArchivePath(document.getElementById('opsys').value,'os');">
+      <select style="margin-left: 1ex;" id="opsys" name="opsys">
         <option id=""<?php if(!$os) echo " selected";
         ?>>Please Select</option><?php
         foreach ($oses as $o) {
@@ -247,6 +249,15 @@ function setFileName()
         <option value="">Other</option>
       </select>
      </td></tr>
+     <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
+        document.getElementById('uploadFileName').addEventListener('change', function() { setFileName(); });
+        document.getElementById('gameFormat').addEventListener('change', function() {
+            setArchivePath(document.getElementById('gameFormat').value,'fmt');
+        });
+        document.getElementById('opsys').addEventListener('change', function() {
+            setArchivePath(document.getElementById('opsys').value,'os');
+        });
+     </script>
   <tr style="display:none;" valign=top id="zipPrimaryRow">
      <td align=right>Name of game file in ZIP:</td>
      <td>&nbsp;</td>

--- a/www/ifarchive-upload
+++ b/www/ifarchive-upload
@@ -6,6 +6,8 @@ include_once "util.php";
 include_once "pagetpl.php";
 include_once "dbconnect.php";
 
+global $nonce;
+
 // we have to be logged in to upload a game
 include_once "login-check.php";
 if (!logged_in())
@@ -56,7 +58,7 @@ $result = mysql_query(
     "select id, fmtname, externid, fmtclass
      from filetypes
      order by fmtname", $db);
-echo "<script type=\"text/javascript\">\r\n<!--\r\n"
+echo "<script type=\"text/javascript\" nonce=\"$nonce\">\r\n<!--\r\n"
    . "var fmtExtMap = { ";
 for ($rowcnt = mysql_num_rows($result), $fmts = false, $i = 0 ;
      $i < $rowcnt ; $i++) {
@@ -81,7 +83,7 @@ echo "\" \": 0 };\r\n";
 echo "</script>\r\n";
 
 ?>
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 var pathmap = {
     "tads2" : "/tads",
     "tads3" : "/tads",
@@ -164,7 +166,7 @@ games there, to reach players and for historical preservation.</p>
 
 </ul>
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 function doSubmit()
 {
     var fname = document.getElementById("uploadFileName").value;
@@ -286,7 +288,7 @@ function setFileName()
 </table>
 </form>
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 setArchivePath("<?php echo $fmt ?>", "fmt");
 </script>
 

--- a/www/imageUpload
+++ b/www/imageUpload
@@ -18,7 +18,7 @@ if (isset($_REQUEST['setCopyright']))
     ?>
 <html>
 <body>
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 window.parent.imageCopyrightUpdated("<?php echo $errmsg ?>");
 //-->
@@ -46,7 +46,7 @@ $col0 = $_REQUEST['col0'];
    <?php echoStylesheetLink(); ?>
 </head>
 <body style="margin:0; padding:0; border:none;">
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 <?php
 
@@ -112,7 +112,7 @@ window.parent.imageUploadReady("<?php echo $btn ?>");
    </span>
 </form>
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 function uplStart()
 {

--- a/www/imageUpload
+++ b/www/imageUpload
@@ -107,8 +107,7 @@ window.parent.imageUploadReady("<?php echo $btn ?>");
    <input type="hidden" name="tab" value="<?php echo $tab ?>">
    <input type="hidden" name="col0" value="<?php echo $col0 ?>">
    <span id="uplFileSpan" class="details">
-      Select an image file: <input type="file" name="uplFile" id="uplFile"
-         onchange="javascript:uplStart();">
+      Select an image file: <input type="file" name="uplFile" id="uplFile">
    </span>
 </form>
 
@@ -119,11 +118,10 @@ function uplStart()
     setTimeout(function() {
         document.uplUploadForm.submit();
 
-        var ele = document.getElementById("uplFileSpan");
-        ele.innerHTML = "<input type=\"file\" name=\"uplFile\" id=\"uplFile\" "
-                        + "onchange=\"javascript:uplStart();\">";
+        uplFile.value = "";
     }, 100);
 }
+uplFile.addEventListener('change', function() { uplStart(); });
 function uplSelect()
 {
     var ele = document.getElementById("uplFile");

--- a/www/imageuploadhandler.php
+++ b/www/imageuploadhandler.php
@@ -212,11 +212,11 @@ function imageUploadRadio($originalUrl, $noneLabel, $radioname, $curval,
     // add the upload button
     echo "</tr><tr><td>&nbsp;<br></td></tr><tr valign=middle>"
         . "<td colspan='$tableCols'>"
-        . "<a href=\"#\" id=\"$ubtn\" "
-        .   "onclick=\"javascript:imageUploadSelect('$ubtn','$ufr');"
-        .      "return false;\" "
-        .   "onfocus=\"javascript:imageUploadFocus('$ubtn', true);\" "
-        .   "onblur=\"javascript:imageUploadFocus('$ubtn', false);\">"
+        . "<a href=\"#\" id=\"$ubtn\">"
+        . addEventListener('click', "imageUploadSelect('$ubtn','$ufr');"
+        .      "return false;")
+        . addEventListener('focus', "imageUploadFocus('$ubtn',true);")
+        . addEventListener('blur', "imageUploadFocus('$ubtn',false);")
         . "<img src=\"/img/blank.gif\" class=\"upload-image-button\"></a>"
         . "<iframe name=\"$ufr\" id=\"$ufr\" src=\"imageUpload?btn=$ubtn"
         .     "&fr=$ufr&thumbSize=$thumbSiz&radio=$radioname&tab=$utab"
@@ -374,7 +374,8 @@ function setDefaultImageCopyright(def)
 
        <label><input type=radio name="imgcopyright" value="C" id="icrC"
           <?php if ($rbval == 'C') echo "checked"?>
-          onclick="javascript:setDefaultImageCopyright('defCC');">
+          >
+          <?php echo addSiblingEventListeners([["click", "setDefaultImageCopyright('defCC');"]]); ?>
           <label for="icrC">I own the copyright and hereby license the
              image under a
              <a href="http://creativecommons.org/licenses/by/3.0/us/"
@@ -383,21 +384,24 @@ function setDefaultImageCopyright(def)
 
        <br><label><input type=radio name="imgcopyright" value="L" id="icrL"
           <?php if ($rbval == 'L') echo "checked"?>
-          onclick="javascript:setDefaultImageCopyright('defOwner');">
+          >
+          <?php echo addSiblingEventListeners([["click", "setDefaultImageCopyright('defOwner');"]]); ?>
           <label for="icrL">The image is covered by a "Free Software" license
           that allows its use on IFDB. For example, it's part of a free game.
           </label></label>
 
        <br><label><input type=radio name="imgcopyright" value="U" id="icrU"
           <?php if ($rbval == 'U') echo "checked"?>
-          onclick="javascript:setDefaultImageCopyright('defOwner');">
+          >
+          <?php echo addSiblingEventListeners([["click", "setDefaultImageCopyright('defOwner');"]]); ?>
           <label for="icrU">The copyright owner has granted special
              permission for the image to be used on IFDB.
           </label></label>
 
        <br><label><input type=radio name="imgcopyright" value="F" id="icrF"
           <?php if ($rbval == 'F') echo "checked"?>
-          onclick="javascript:setDefaultImageCopyright('defOwner');">
+          >
+          <?php echo addSiblingEventListeners([["click", "setDefaultImageCopyright('defOwner');"]]); ?>
           <label for="icrF">I believe this copyrighted image can be
              legally used on IFDB under the
              <a href="http://en.wikipedia.org/wiki/Fair_use"
@@ -407,7 +411,8 @@ function setDefaultImageCopyright(def)
 
        <br><label><input type=radio name="imgcopyright" value="P" id="icrP"
           <?php if ($rbval == 'P') echo "checked"?>
-          onclick="javascript:setDefaultImageCopyright('');">
+          >
+          <?php echo addSiblingEventListeners([["click", "setDefaultImageCopyright('');"]]); ?>
           <label for="icrP">This image is not copyrighted (it's in the
              <a href="http://en.wikipedia.org/wiki/Public_domain"
                 target="_blank">public
@@ -415,7 +420,8 @@ function setDefaultImageCopyright(def)
 
        <br><label><input type=radio name="imgcopyright" value="" id="icrNULL"
           <?php if ($rbval == '') echo "checked"?>
-          onclick="javascript:setDefaultImageCopyright('');">
+          >
+          <?php echo addSiblingEventListeners([["click", "setDefaultImageCopyright('');"]]); ?>
           <label for="icrNULL">Not specified.</label></label>
 
 

--- a/www/imageuploadhandler.php
+++ b/www/imageuploadhandler.php
@@ -36,7 +36,7 @@ function imageUploadScripts()
    </div>
 </div>
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 
 var imageUploadFocusCtl = null;
@@ -231,7 +231,7 @@ function imageUploadRadio($originalUrl, $noneLabel, $radioname, $curval,
 
     // populate it via javascript
     ?>
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 imageTableUpdate("<?php echo "$utab"; ?>", "<?php echo $radioname; ?>", [<?php
 
@@ -341,7 +341,7 @@ function showImageCopyrightForm($defStatus, $defOwner)
         $defOwner = $defCC;
 
     ?>
-<script>
+<script nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 var imageCopyrightState = {
     lastAutoSet: "",

--- a/www/news.php
+++ b/www/news.php
@@ -70,7 +70,7 @@ function newsSummary($db, $sourceType, $sourceID, $maxItems,
         }
 
 ?>
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 
 function expandNews(n)

--- a/www/news.php
+++ b/www/news.php
@@ -54,8 +54,9 @@ function newsSummary($db, $sourceType, $sourceID, $maxItems,
 
             // display it
             echo "<div class=\"newsItemHeadline\">"
-                . "<a href=\"needjs\" onclick=\"javascript:expandNews($i);"
-                . "return false;\">$newshead</a>"
+                . "<a href=\"needjs\">"
+                . addEventListener('click', "expandNews($i); return false;")
+                . "$newshead</a>"
                 . " <span class=\"newsItemDate\">$newsdate</span>"
                 . "</div>"
                 . "<div id=\"newsBody$i\" class=\"newsItemBody\" "

--- a/www/newuser
+++ b/www/newuser
@@ -91,9 +91,7 @@ if ($errFlagged != false) {
             Password:
          <td>
             <input type="password" name="password" id="password" size=30
-               value="<?php echo get_req_data('password') ?>"
-               onpropertychange="javascript:onPasswordChange(this);return true;"
-               oninput="javascript:onPasswordChange(this);return true;">
+               value="<?php echo get_req_data('password') ?>">
             <span style='font-size: 80%; padding-left:2em;'>Strength:
                <span id="pswStrength">&nbsp;</span>
             </span>
@@ -103,13 +101,19 @@ if ($errFlagged != false) {
             Confirm Password:
          <td>
             <input type="password" name="password2" id="password2" size=30
-               value="<?php echo get_req_data('password2') ?>"
-               onpropertychange="javascript:onPassConfChange(this);return true;"
-               oninput="javascript:onPassConfChange(this);return true;">
+               value="<?php echo get_req_data('password2') ?>">
             <span style='font-size: 80%; padding-left:2em;'>Match:
                <span id="confMatch">&nbsp;</span>
             </span>
    </table>
+   <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
+        document.getElementById('password').addEventListener('input', function(event) {
+            onPasswordChange(event.target);
+        });
+        document.getElementById('password2').addEventListener('input', function(event) {
+            onPassConfChange(event.target);
+        });
+    </script>
 <script type="text/javascript" src="passwords.js">
 </script>
 
@@ -162,14 +166,8 @@ by there.</span><br>
          echo helpWinLink("/code-of-conduct?helpwin=1", "Code of Conduct");
       ?>, our <?php
          echo helpWinLink("/tos?helpwin=1", "Terms of Service");
-//<a href="needjs"
-//        onclick="javascript:helpWin('/tos?helpwin=1');return false;">
-//         Terms of Service</a>
       ?>, and our <?php
          echo helpWinLink("/privacy?helpwin=1", "Privacy Policy");
-//<a href="needjs"
-//        onclick="javascript:helpWin('/privacy?helpwin=1');return false;">
-//         Privacy Policy</a>
       ?>.
 
    <br><br>

--- a/www/opsys
+++ b/www/opsys
@@ -605,7 +605,7 @@ if ($osid == "new" || $osid != 0) {
                  </td>
                  <td>
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 var vsnGridModel = {
    "emptylabel": "<i>No versions are defined for this OS.</i>",

--- a/www/pagetpl.php
+++ b/www/pagetpl.php
@@ -46,16 +46,19 @@ function basePageHeader($title, $focusCtl, $extraOnLoad, $extraHead,
            ckboxSetup();
    ?>
    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+   <?php
+   if ($focusCtl) {
+        $extraOnLoad = "document.$focusCtl.focus();document.$focusCtl.select();$extraOnLoad";
+   }
+   if ($extraOnLoad) {
+        global $nonce;
+        echo "<script type='text/javascript' nonce='$nonce'>\n";
+        echo "addEventListener('load', function () { $extraOnLoad });\n";
+        echo "</script>";
+   }
+   ?>
 </head>
 <body<?php
-
-    if ($focusCtl) {
-        echo " onLoad=\"document.$focusCtl.focus();
-            document.$focusCtl.select();$extraOnLoad\"";
-    } else if ($extraOnLoad) {
-        echo " onLoad=\"$extraOnLoad\"";
-    }
-
     if ($bodyAttrs)
         echo " $bodyAttrs";
      ?>>

--- a/www/pagetpl.php
+++ b/www/pagetpl.php
@@ -317,7 +317,7 @@ function addEventListener($event, $code) {
     global $nonce;
     return "<script nonce='$nonce'>\n" .
         "document.currentScript.parentElement.addEventListener('$event', function (event) {\n" .
-        "var result = (function(){ $code })();\nif (result === false) event.preventDefault();" .
+        "var result = (function(){ $code }).apply(event.target);\nif (result === false) event.preventDefault();" .
         "\n});\n" .
         "</script>";
 }
@@ -327,7 +327,7 @@ function addSiblingEventListeners($listeners) {
     $result = "<script nonce='$nonce'>\n";
     foreach ($listeners as $listener) {
         $result .= "document.currentScript.previousElementSibling.addEventListener('".$listener[0]."', function (event) {\n" .
-        "var result = (function(){ ". $listener[1] ." })();\nif (result === false) event.preventDefault();" .
+        "var result = (function(){ ". $listener[1] ." }).apply(event.target);\nif (result === false) event.preventDefault();" .
         "\n});\n";
     }
     $result .= "</script>";

--- a/www/pagetpl.php
+++ b/www/pagetpl.php
@@ -312,30 +312,39 @@ function ckboxKey(id, event, isRadio, onUpdateFunc)
 <?php
 }
 
+// this function is intended to create a <script> tag to replace inline event attributes
+function addEventListener($event, $code) {
+    global $nonce;
+    return "<script nonce='$nonce'>\n" .
+        "document.currentScript.parentElement.addEventListener('$event', function (event) {\n" .
+        "var result = (function(){ $code })();\nif (result === false) event.preventDefault();" .
+        "\n});\n" .
+        "</script>";
+}
+
 // --------------------------------------------------------------------------
 // Generate a checkbox
 //
 function ckRbString($id, $label, $checked, $onUpdateFunc, $isRadio)
 {
     $label = htmlspecialcharx($label);
-    return "<span class=\"cklabel\" "
-        . "onmouseover=\"javascript:ckboxOver('$id', $isRadio);return true;\" "
-        . "onmouseout=\"javascript:ckboxLeave('$id', $isRadio);return true;\" "
-        . "onclick=\"javascript:ckboxClick('$id', $isRadio, $onUpdateFunc);"
-        . "return false;\"><img src=\"/img/blank.gif\" class=\""
+    echo "<span class=\"cklabel\" >"
+        . addEventListener("mouseover", "ckboxOver('$id', $isRadio);")
+        . addEventListener("mouseout", "ckboxLeave('$id', $isRadio);")
+        . addEventListener("click", "ckboxClick('$id', $isRadio, $onUpdateFunc); return false")
+        . "<img src=\"/img/blank.gif\" class=\""
         . ($isRadio
            ? ($checked ? "radio-checked" : "radio-unchecked")
            : ($checked ? "ckbox-checked" : "ckbox-unchecked"))
         . "\" id=\"ckImg$id\"> "
-        . "<span id=\"ckLbl$id\"><a class=silent href=\"needjs\" "
-        . "onkeypress=\"javascript:ckboxKey("
-        . "'$id', event, $isRadio, $onUpdateFunc);return false;\""
-        . ">$label</a></span>"
+        . "<span id=\"ckLbl$id\"><a class=silent href=\"needjs\">"
+        . addEventListener("keypress", "ckboxKey('$id', event, $isRadio, $onUpdateFunc); return false")
+        . "$label</a></span>"
         . "</span>";
 }
 function ckRbWrite($id, $label, $checked, $onUpdateFunc, $isRadio)
 {
-    echo ckRbString($id, $label, $checked, $onUpdateFunc, $isRadio);
+    ckRbString($id, $label, $checked, $onUpdateFunc, $isRadio);
 }
 function checkboxWrite($id, $label, $checked, $onUpdateFunc)
 {

--- a/www/pagetpl.php
+++ b/www/pagetpl.php
@@ -132,7 +132,7 @@ function pageHeader($title, $focusCtl = false, $extraOnLoad = false,
     </div>
 </div>
 
-<script>
+<script nonce="<?php global $nonce; echo $nonce; ?>">
     function ToggleMobileMenu() {
         document.querySelector('#main-nav ul').classList.toggle('mobile-hidden');
         document.querySelector('.login-link').classList.toggle('mobile-hidden');
@@ -235,7 +235,7 @@ function helpPageFooter()
 function ckboxSetup()
 {
 ?>
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 
 var ckboxStatus = [];

--- a/www/pagetpl.php
+++ b/www/pagetpl.php
@@ -322,6 +322,18 @@ function addEventListener($event, $code) {
         "</script>";
 }
 
+function addSiblingEventListeners($listeners) {
+    global $nonce;
+    $result = "<script nonce='$nonce'>\n";
+    foreach ($listeners as $listener) {
+        $result .= "document.currentScript.previousElementSibling.addEventListener('".$listener[0]."', function (event) {\n" .
+        "var result = (function(){ ". $listener[1] ." })();\nif (result === false) event.preventDefault();" .
+        "\n});\n";
+    }
+    $result .= "</script>";
+    return $result;
+}
+
 // --------------------------------------------------------------------------
 // Generate a checkbox
 //

--- a/www/pagetpl.php
+++ b/www/pagetpl.php
@@ -1,5 +1,6 @@
 <?php
 
+include_once "csp-nonce.php";
 include_once "util.php";
 include_once "login-persist.php";
 

--- a/www/pagetpl.php
+++ b/www/pagetpl.php
@@ -65,16 +65,11 @@ function basePageHeader($title, $focusCtl, $extraOnLoad, $extraHead,
 <?php
 }
 
-function helpWinHRef($href)
-{
-    return "href=\"$href\" target=\"IFDBHelp\" "
-        . "onclick=\"javascript:helpWin('$href');return false;\"";
-}
-
 function helpWinLink($href, $text)
 {
-    $href = helpWinHRef($href);
-    return "<a $href>$text</a>";
+    return "<a href=\"$href\" target=\"IFDBHelp\">"
+        . addEventListener("click", "helpWin('$href');return false;")
+        . "$text</a>";
 }
 
 function pageHeader($title, $focusCtl = false, $extraOnLoad = false,

--- a/www/personal
+++ b/www/personal
@@ -70,9 +70,6 @@ if (mysql_num_rows($result) > 0) {
 
     echo "<p><span class=details>"
         . helpWinLink("help-gameprofilelink", "How do I edit this list?")
-//        . "<a href=\"needjs\" "
-//        . "onclick=\"javascript:helpWin('help-gameprofilelink');return false;\""
-//        . ">How do I edit this list?</a>
         . "</span>";
 
     echo "</div>";
@@ -531,12 +528,6 @@ if ($rankName)
 echo "Number of reviews written: $fullReviewCnt<br>Your "
    . "<a class=silent title=\"What's this?\" " . helpWinHRef("help-ff")
    . "><i>Frequent Fiction</i> Points:</a> $score<br>"
-
-// href=\"needjs\" "
-//   . "onclick=\"javascript:helpWin('help-ff');return false;\" "
-//   . "title=\"What's this?\"><i>Frequent Fiction</i> Points:</a>"
-//   . " $score<br>
-
    . "</td></tr></table>";
 
 // ----------------------- authorship help box ---------------------------
@@ -552,9 +543,6 @@ if (!$foundAuthorCredits) {
                     If you're the author of any of the games listed in IFDB,
                     you can link them to your profile. "
         . helpWinLink("help-gameprofilelink", "Learn more...")
-//                    <a href=\"needjs\"
-//                      onclick=\"javascript:helpWin('help-gameprofilelink');return false;\"
-//                      >Learn more...</a>
         . "</td></tr></table>";
 }
 

--- a/www/personal
+++ b/www/personal
@@ -246,8 +246,8 @@ $pollCnt = mysql_result($result, 0, "c");
 
 if ($pollCnt == 0) {
     echo "<span class=notes><i>You haven't created any Polls yet.</i></span> "
-        . "<span class=details>(<a " . helpWinHRef("help-polls")
-        . ">What's a Poll?</a>)</span><p>";
+        . "<span class=details>(" . helpWinLink("help-polls", "What's a Poll?")
+        . ")</span><p>";
 } else {
     $result = mysql_query(
         "select
@@ -526,8 +526,8 @@ if ($rankName)
     echo "You're a <b>$rankName</b>!<br>";
 
 echo "Number of reviews written: $fullReviewCnt<br>Your "
-   . "<a class=silent title=\"What's this?\" " . helpWinHRef("help-ff")
-   . "><i>Frequent Fiction</i> Points:</a> $score<br>"
+   . helpWinLink("help-ff", "<i>Frequent Fiction</i> Points")
+   . ": $score<br>"
    . "</td></tr></table>";
 
 // ----------------------- authorship help box ---------------------------

--- a/www/poll
+++ b/www/poll
@@ -1083,7 +1083,7 @@ administrators can see who voted for what.)
                 . "<hr class=dots><p>";
         }
 ?>
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 function expandVote(id)
 {

--- a/www/poll
+++ b/www/poll
@@ -219,8 +219,8 @@ if ($userid && isset($_REQUEST['editPoll'])) {
                     . "<p><b>Details:</b> Explain what kind of game "
                     . "you're looking for, to help voters fine-tune their "
                     . "suggestions."
-                    . " &nbsp; <span class=details>(<a "
-                    . helpWinHRef("help-formatting"). ">Formatting Hints</a>)"
+                    . " &nbsp; <span class=details>("
+                    . helpWinLink("help-formatting", "Formatting Hints"). ")"
                     . "</span>"
                     . "<br><textarea name=\"desc\" rows=4 cols=70>"
                     . "$desc</textarea>"
@@ -649,8 +649,8 @@ if ($userid && $id && isset($_REQUEST['addVote'])) {
             . "<p><b>Details:</b> Explain why you think this is a good "
             . "recommendation for the poll.  Just a sentence or two - "
             . "no need to write a full review here. <i>Optional</i>"
-            . " &nbsp; <span class=details>(<a "
-            . helpWinHRef("help-formatting"). ">Formatting Hints</a>)"
+            . " &nbsp; <span class=details>("
+            . helpWinLink("help-formatting", "Formatting Hints"). ")"
             . "</span>"
             . "<br><textarea name=voteDesc rows=3 cols=70>"
             . htmlspecialcharx($voteDesc) . "</textarea>"
@@ -863,9 +863,9 @@ if ($userid && isset($_REQUEST['comment'])) {
                     . "this to give voters feedback about how well you "
                     . "think this game fits what you're looking for, or "
                     . "just to share your own thoughts about the game. "
-                    . "(<span class=details><a "
-                    . helpWinHRef("help-formatting")
-                    . ">Formatting Hints</a>)</span><br>"
+                    . "(<span class=details>"
+                    . helpWinLink("help-formatting", "Formatting Hints")
+                    . ")</span><br>"
                     . "<textarea rows=4 cols=70 name=\"commentText\">"
                     . "$comment</textarea>"
                     . "<p><input type=submit name=commentBtn "
@@ -933,8 +933,8 @@ completes the thought, "I'm looking for..."
 <p><b>2. Explain in a little more detail what you're looking for.</b>
 Tell everyone in a couple of sentences more specifically what you're
 interested in, to help respondents fine-tune their suggestions.
-&nbsp; <span class=details>(<a <?php echo helpWinHRef("help-formatting")
-?>>Formatting Hints</a>)</span>
+&nbsp; <span class=details>(<?php echo helpWinLink("help-formatting", "Formatting Hints")
+?>)</span>
 <br><textarea name="desc" rows=4 cols=70><?php
     echo htmlspecialcharx($newDesc)
 ?></textarea>
@@ -1422,10 +1422,10 @@ function expandVote(id)
             echo "<form name=\"addVoteForm\" method=\"get\" action=\"poll\">"
                 . "<input type=hidden name=id value=\"$id\">"
                 . "<input type=hidden name=addVote value=1>"
-                . "<b>Game Title</b> (<i>or</i> <a class=silent "
-                . helpWinHRef("help-tuid") . " title=\"What's a TUID?\">"
-                . "TUID</a> or <a class=silent " . helpWinHRef("help-ifid")
-                . " title=\"What's an IFID?\">IFID</a>): "
+                . "<b>Game Title</b> (<i>or</i> "
+                . helpWinLink("help-tuid", "TUID")
+                . " or " . helpWinLink("help-ifid", "IFID")
+                . "): "
                 . "<input type=text size=60 name=\"addTitle\">"
                 . " <input type=submit value=\"Vote!\" "
                 . "name=\"addVoteBtn\">"

--- a/www/poll
+++ b/www/poll
@@ -1393,8 +1393,8 @@ function expandVote(id)
                 if (!$anonymous) {
                     echo "<span id=\"voteQ$i\">$qq "
                         . "<span class=details>["
-                        . "<a title=\"Click to see more details\" href=\"needjs\" "
-                        . "onclick=\"javascript:expandVote('$i');return false;\">"
+                        . "<a title=\"Click to see more details\" href=\"needjs\">"
+                        . addEventListener('click', "expandVote('$i');return false;")
                         . "+</a>]</span></span>"
                         . "<span id=\"voteF$i\" style=\"display:none;\">"
                         . "$expQ $rv <i>--<a href=\"showuser?id=$voteUserID\">"

--- a/www/profilelink.php
+++ b/www/profilelink.php
@@ -34,7 +34,7 @@
 function profileLinkSupportFuncs()
 {
 ?>
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 
 var aplFieldEle = null, aplFieldRange = null, aplFieldFocus = null;

--- a/www/profilelink.php
+++ b/www/profilelink.php
@@ -21,7 +21,7 @@
 //
 //  5. For each field where you want to be able to insert a profile
 //     link, use
-//       onclick="javascript:aplOpen('fieldID', 'fieldName');return false;"
+//       addEventListener("click", "aplOpen('fieldID', 'fieldName');return false;")
 //     as the link's script.  This will pop up the link box just under
 //     the field with the given ID.
 //
@@ -211,14 +211,20 @@ function aplSearchDone(d)
         {
             var nm = lst[i].getElementsByTagName('name')[0].firstChild.data;
             var id = lst[i].getElementsByTagName('tuid')[0].firstChild.data;
-            s += "<a href=\"needjs\" onclick=\"aplInsertID('" + id + "');"
-                 + "return false;\">" + encodeHTML(nm) + "</a>"
+            s += "<a href=\"needjs\" x-id='"+id+"'>"
+                 + encodeHTML(nm) + "</a>"
                  + " - <a href=\"showuser?id=" + id + "\" target=\"_blank\">"
                  + "view profile</a><br>";
         }
         if (s == "")
             s = "<b><i>(No member profiles found.)</i></b>";
         document.getElementById("aplSearchResults").innerHTML = s;
+        document.getElementById("aplSearchResults").querySelectorAll('a[x-id]').forEach(function (link) {
+            link.addEventListener('click', function (event) {
+                event.preventDefault();
+                aplInsertID(event.target.getAttribute('x-id'));
+            })
+        })
         document.getElementById("aplStep2").style.display = "";
     }
 }
@@ -246,8 +252,13 @@ function profileLinkDiv()
          <b>Add Link to Member Profile</b>
          <span style="position:absolute;top:2px;right:2px;
                text-align:right;">
-            <a href="needjs"
-             onclick="javascript:aplClose();return false;">
+            <a href="needjs">
+               <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
+                 document.currentScript.parentElement.addEventListener('click', function(event) {
+                    event.preventDefault();
+                    aplClose();
+                 });
+               </script>
                Close<img src="img/blank.gif" class="popup-close-button"></a>
          </span>
       </div>
@@ -255,10 +266,19 @@ function profileLinkDiv()
    <div class="edit-popup-win">
       <p><b>Step 1:</b> Search for an IFDB profile by member name.
       <br>
-      <input id="aplSearchBox" type=text size=50
-         onkeypress="javascript:return aplPopupKey(event);">
+      <input id="aplSearchBox" type=text size=50>
       <input type=submit name="aplSearchGo" id="aplSearchGo"
-         value="Search" onclick="javascript:aplSearch();return false;">
+         value="Search">
+      <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
+        aplSearchBox.addEventListener('keypress', function(event) {
+            var result = aplPopupKey(event);
+            if (result === false) event.preventDefault();
+        })
+        aplSearchGo.addEventListener('click', function (event) {
+            event.preventDefault();
+            aplSearch();
+        })
+      </script>
       <div id="aplStep2" style="display:none;">
          <p><b>Step 2:</b> Click in the <span id="aplFieldName">text</span>
             field above to move the caret <b>just after</b> the displayed

--- a/www/recaptchalib.php
+++ b/www/recaptchalib.php
@@ -261,20 +261,5 @@ function _recaptcha_mailhide_email_parts ($email) {
     return $arr;
 }
 
-/**
- * Gets html to display an email address given a public an private key.
- * to get a key, go to:
- *
- * http://www.google.com/recaptcha/mailhide/apikey
- */
-function recaptcha_mailhide_html($pubkey, $privkey, $email) {
-    $emailparts = _recaptcha_mailhide_email_parts ($email);
-    $url = recaptcha_mailhide_url ($pubkey, $privkey, $email);
-
-    return htmlentities($emailparts[0]) . "<a href='" . htmlentities ($url) .
-        "' onclick=\"window.open('" . htmlentities ($url) . "', '', 'toolbar=0,scrollbars=0,location=0,statusbar=0,menubar=0,resizable=0,width=500,height=300'); return false;\" title=\"Reveal this e-mail address\">...</a>@" . htmlentities ($emailparts [1]);
-
-}
-
 
 ?>

--- a/www/recaptchalib.php
+++ b/www/recaptchalib.php
@@ -119,7 +119,8 @@ function recaptcha_get_html ($pubkey, $error = null, $use_ssl = true)
         if ($error) {
            $errorpart = "&amp;error=" . $error;
         }
-        return '<script type="text/javascript" src="'. $server . '/challenge?k=' . $pubkey . $errorpart . '"></script>
+        global $nonce;
+        return '<script type="text/javascript" src="'. $server . '/challenge?k=' . $pubkey . $errorpart . '" nonce="'.$nonce.'"></script>
 
     <noscript>
           <iframe src="'. $server . '/noscript?k=' . $pubkey . $errorpart . '" height="300" width="500" frameborder="0"></iframe><br/>

--- a/www/review
+++ b/www/review
@@ -754,7 +754,7 @@ if (isset($missingFields['rating']))
    ?>
    <span class=details>(<a href="needjs"
      onclick="setRating(0);return false;">Remove rating</a>)</span>
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 function setRating(rating)
 {

--- a/www/review
+++ b/www/review
@@ -698,9 +698,6 @@ echo helpWinLink("help-review#spoilertags", "&lt;spoiler&gt; tag")
 ?>).
 If you haven't written reviews here before, please read our <?php
    echo helpWinLink("help-review", "review guidelines");
-//
-//<a href="needjs" onclick="javascript:helpWin('help-review');return false;">
-//   review guidelines</a>
 ?>.
 
 <?php
@@ -752,16 +749,17 @@ if (isset($missingFields['rating']))
         initStarControls();
         echo showStarCtl("ratingStars", $rating, "setRating", "null");
    ?>
-   <span class=details>(<a href="needjs"
-     onclick="setRating(0);return false;">Remove rating</a>)</span>
+   <span class=details>(<a id="removeRating" href="needjs">Remove rating</a>)</span>
 <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
-<!--
+document.getElementById('removeRating').addEventListener('click', function (event) {
+    event.preventDefault();
+    setRating(0);
+})
 function setRating(rating)
 {
     document.getElementById("rating").value = rating;
     setStarCtlValue("ratingStars", rating);
 }
-//-->
 </script>
    <input type=hidden name="rating" id="rating" value="<?php echo $rating ?>">
 
@@ -804,10 +802,6 @@ if (isset($missingFields['reviewbody']))
 echo helpWinLink("help-formatting?review", "Formatting Hints");
 echo " - ";
 echo helpWinLink("help-review#spoilertags", "Hiding Spoilers");
-//                 <a href="needjs"
-//                  onclick="javascript:helpWin('help-formatting');return false;">
-//                    Formatting Hints
-//                 </a>
             ?></i></span>
          </td>
       </tr>

--- a/www/reviews.php
+++ b/www/reviews.php
@@ -523,8 +523,7 @@ function showReview($db, $gameid, $rec, $specialNames, $optionFlags = 0)
             . "<tr><td><a href=\"userfilter?list\">"
             . "<nobr>View my user filters</nobr></a>"
             . "</tr></td>"
-            . "<tr><td><a " . helpWinHRef("help-review-votes")
-            . "><nobr>Explain these options</nobr></a>"
+            . "<tr><td>" . helpWinLink("help-review-votes", "<nobr>Explain these options</nobr>")
             . "</tr></td>"
             . "</table>"
             . "</div>"

--- a/www/reviews.php
+++ b/www/reviews.php
@@ -156,9 +156,11 @@ function displayReviewVote(reviewID, vote)
                     "<br>(You voted "
                     + (vote == 'Y' ? "Yes" : "No")
                     + ")";
-            document.getElementById("voteRemove_" + reviewID).innerHTML = "<a href=\"needjs\" "
-            + "onclick=\"javascript:sendReviewVote('" + reviewID + "', 'R');"
-            + "return false;\">Remove vote</a> &nbsp; "
+            document.getElementById("voteRemove_" + reviewID).innerHTML = "<a href=\"needjs\">Remove vote</a> &nbsp; ";
+            document.getElementById("voteRemove_" + reviewID).querySelector('a').addEventListener('click', function (event) {
+                event.preventDefault();
+                sendReviewVote(reviewID, 'R');
+            })
         }
     }
     else {
@@ -464,15 +466,15 @@ function showReview($db, $gameid, $rec, $specialNames, $optionFlags = 0)
 
         echo "<div class=smallfoot><span class=details>"
             . "Was this review helpful to you? &nbsp; "
-            . "<a href=\"needjs\" "
-            . "onclick=\"javascript:sendReviewVote('$reviewid', 'Y');"
-            . "return false;\">Yes</a> &nbsp; "
-            . "<a href=\"needjs\""
-            . "onclick=\"javascript:sendReviewVote('$reviewid', 'N');"
-            . "return false;\">No</a> &nbsp; "
-            . "<span id=\"voteRemove_$reviewid\"><a href=\"needjs\" "
-            . "onclick=\"javascript:sendReviewVote('$reviewid', 'R');"
-            . "return false;\">Remove vote</a> &nbsp; </span>";
+            . "<a href=\"needjs\">"
+            . addEventListener('click', "sendReviewVote('$reviewid', 'Y'); return false;")
+            . "Yes</a> &nbsp; "
+            . "<a href=\"needjs\">"
+            . addEventListener('click', "sendReviewVote('$reviewid', 'N'); return false;")
+            . "No</a> &nbsp; "
+            . "<span id=\"voteRemove_$reviewid\"><a href=\"needjs\">"
+            . addEventListener('click', "sendReviewVote('$reviewid', 'R'); return false;")
+            . "Remove vote</a> &nbsp; </span>";
 
             if (check_admin_privileges($db, $curuser)) {
                 echo "<a href=\"review?id=$gameid&userid=$userid\">Edit</a>&nbsp; ";
@@ -480,16 +482,16 @@ function showReview($db, $gameid, $rec, $specialNames, $optionFlags = 0)
 
 
         echo  "<div style=\"display:inline;position:relative;\">"
-            . "<a href=\"#\" id=\"voteMenuLink_$reviewid\" "
-            . "onclick=\"javascript:popVoteMenu('$reviewid');"
-            . "return false;\">More Options<img src=\"/img/blank.gif\" "
+            . "<a href=\"#\" id=\"voteMenuLink_$reviewid\">"
+            . addEventListener('click', "popVoteMenu('$reviewid'); return false;")
+            . "More Options<img src=\"/img/blank.gif\" "
             . "class=\"popup-menu-arrow\"></a>"
 
             . "<div id=\"voteMenu_$reviewid\" style=\"display: none;"
-            . "position:absolute;left:0px;z-index:20000;\" "
-            . "onclick=\"javascript:closePopupMenu(null);return true;\" "
-            . "onkeypress=\"javascript:return popupMenuKey("
-            . "event,'$reviewid');\"><br>"
+            . "position:absolute;left:0px;z-index:20000;\">"
+            . addEventListener('click', "closePopupMenu(null);")
+            . addEventListener('keypress', "return popupMenuKey(event,'$reviewid');")
+            . "<br>"
             . "<div class=\"popupMenu\">"
             . "<table border=0 cellspacing=0 cellpadding=0>"
             . "<tr><td><a href=\"userfilter?user=$userid&action=promote\" "

--- a/www/reviews.php
+++ b/www/reviews.php
@@ -133,7 +133,7 @@ function initSpecialNames($db)
 function initReviewVote()
 {
 ?>
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 
 function sendReviewVote(reviewID, vote)
@@ -460,6 +460,7 @@ function showReview($db, $gameid, $rec, $specialNames, $optionFlags = 0)
             if (mysql_num_rows($result) > 0)
                 $oldvote = "'" . mysql_result($result, 0, "vote") . "'";
         }
+        global $nonce;
 
         echo "<div class=smallfoot><span class=details>"
             . "Was this review helpful to you? &nbsp; "
@@ -532,7 +533,7 @@ function showReview($db, $gameid, $rec, $specialNames, $optionFlags = 0)
             . "&nbsp;<span id=\"voteMsg_$reviewid\" class=\"xmlstatmsg\">"
             . "</span><span id=\"voteStat_$reviewid\"></span>"
             . "</span></div>"
-            . "<script type=\"text/javascript\">\r\n<!--\r\n"
+            . "<script type=\"text/javascript\" nonce=\"$nonce\">\r\n<!--\r\n"
             . "displayReviewVote('$reviewid', $oldvote);"
             . "\r\n//-->\r\n</script>\r\n";
 

--- a/www/reviewunflag
+++ b/www/reviewunflag
@@ -44,8 +44,9 @@ pageHeader("Delete Flag");
 
 if (mysql_num_rows($result) == 0) {
     echo "This flag has already been deleted."
-        . "<p><a href=\"needjs\" onclick=\"javascript:window.close();"
-        . "return false;\">Close window</a>";
+        . "<p><a href=\"needjs\">"
+        . addEventListener('click', "window.close(); return false;")
+        . "Close window</a>";
 
     pageFooter();
     exit();
@@ -64,8 +65,9 @@ if (!$flagName) $errMsg = "Invalid flag type.";
 if ($reviewOwner != $curuser)
 {
     echo "You can only delete flags on your own reviews."
-        . "<p><a href=\"needjs\" onclick=\"javascript:window.close();"
-        . "return false;\">Close window</a>";
+        . "<p><a href=\"needjs\">"
+        . addEventListener('click', "window.close(); return false;")
+        . "Close window</a>";
 
     pageFooter();
     exit();
@@ -89,8 +91,9 @@ if ($confirm == 'Y' && !$errMsg) {
         echo "<span class=success>This flag has been successfully "
             . "deleted.</span>"
 
-            . "<p><a href=\"needjs\" onclick=\"javascript:window.close();"
-            . "return false;\">Close window</a>";
+            . "<p><a href=\"needjs\">"
+            . addEventListener('click', "window.close(); return false;")
+            . "Close window</a>";
 
     } else {
 
@@ -119,8 +122,9 @@ if (!$confirm || $errMsg) {
         . "you honestly feel the flag is not warranted."
         . "<p><a href=\"reviewunflag?review=$reviewID&flagger=$flagger"
         . "&type=$flagType&confirm=Y\">Yes, delete this flag</a><br>"
-        . "<a href=\"needjs\" onclick=\"javascript:window.close();"
-        . "return false;\">No, keep flag and close window</a>";
+        . "<a href=\"needjs\">"
+        . addEventListener('click', "window.close(); return false;")
+        . "No, keep flag and close window</a>";
 }
 
 pageFooter();

--- a/www/search
+++ b/www/search
@@ -428,7 +428,7 @@ if (!$browse && !$xml) {
     echo $otherTabs;
 
     ?>
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 
 function openHelpList(id, tableWid, params)
 {
@@ -1690,7 +1690,7 @@ else if ($term || $browse)
 
 if (!$xml) {
 ?>
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 function newSearch(typ)
 {

--- a/www/search
+++ b/www/search
@@ -1612,9 +1612,9 @@ else if ($term || $browse)
                     $badge[] = "<b>{$badgeInfo[1]}</b>";
                 }
                 if ($score) {
-                    $badge[] = "$score <a class=silent "
-                               . helpWinHRef("help-ff")
-                               . "><i>Frequent Fiction</i></a> point"
+                    $badge[] = "$score "
+                               . helpWinLink("help-ff", "<i>Frequent Fiction</i>")
+                               . " point"
                                . ($score == 1 ? "" : "s");
                 }
                 if ($badge) {

--- a/www/search
+++ b/www/search
@@ -391,9 +391,8 @@ function helpListLink($title, $id, $tableWid, $params)
         $tableWid = 4;
 
     echo "<div class=\"searchHelpList\" id=\"helpList.$id\">"
-        . "<a href=\"javascript:void(0);\" class=\"silent\" "
-        .    "onclick=\"javascript:openHelpList('$id', $tableWid, '$params');"
-        .      "return false;\">"
+        . "<a href=\"javascript:void(0);\" class=\"silent\">"
+        . addEventListener('click', "openHelpList('$id', $tableWid, '$params'); return false;")
         . "<img border=0 src=\"/img/blank.gif\" class=\"listarrow\">$title</a>"
         . "</div>";
 }
@@ -956,8 +955,6 @@ else {  // ...default is searching games
        <p><b>ifid:<i>xxx</i></b> searches for a game with the given IFID.
        (<?php
           echo helpWinLink("help-ifid", "What's an IFID?");
-//<a href="needjs" onclick="javascript:helpWin('help-ifid');return false;"
-//          >What's an IFID?</a>
        ?>)
 
         <p><b>authorid:<i>id</i></b> lists games by the author with

--- a/www/showuser
+++ b/www/showuser
@@ -286,8 +286,8 @@ if ($errMsg) {
     if ($lastlogin != "")
         echo "Last visited $lastlogin<br>";
 
-    echo "Profile ID (<a class=silent " . helpWinHRef("help-tuid")
-        . ">TUID</a>): $uid<br>";
+    echo "Profile ID (" . helpWinLink("help-tuid", "TUID")
+        . "): $uid<br>";
 
     if ($pubemail != "" && !$pendingReview) {
         if (!$emailcaptcha) {

--- a/www/showuser
+++ b/www/showuser
@@ -287,8 +287,6 @@ if ($errMsg) {
         echo "Last visited $lastlogin<br>";
 
     echo "Profile ID (<a class=silent " . helpWinHRef("help-tuid")
-//        . "<a href=\"needjs\" onclick=\"javascript:helpWin("
-//        . "'help-tuid');return false;\" class=silent"
         . ">TUID</a>): $uid<br>";
 
     if ($pubemail != "" && !$pendingReview) {
@@ -299,10 +297,6 @@ if ($errMsg) {
                 echo "<i>Note: this address might be "
                     . "\"cloaked\" against spam - "
                     . helpWinLink("help-spamcloaking", "Help")
-//                    . "<a href=\"needjs\" "
-//                    . "onclick=\"javascript:helpWin('help-spamcloaking');"
-//                    . "return false;\">"
-//                    . "Help</a>"
                     . "</i><br>";
             }
         }

--- a/www/starctl.php
+++ b/www/starctl.php
@@ -24,7 +24,7 @@ function initStarControls()
 
         ?>
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 function mouseClickStarCtl(id, e, clickFunc)
 {
@@ -51,7 +51,7 @@ function setStarCtlValue(id, val)
         // with automatic mouse rollover highlighting.
 
         ?>
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 var starRatings = {};
 function starsFromMouse(id, e)
@@ -131,8 +131,8 @@ function showStarCtl($id, $init, $clickFunc, $leaveFunc)
 
     } else {
         // standard version - use the star images
-
-        $str = "<script type=\"text/javascript\">\r\n"
+        global $nonce;
+        $str = "<script type=\"text/javascript\" nonce=\"$nonce\">\r\n"
                . "<!--\r\n"
                . "starRatings['$id'] = $init;\r\n"
                . "//-->\r\n"

--- a/www/starctl.php
+++ b/www/starctl.php
@@ -114,11 +114,10 @@ function showStarCtl($id, $init, $clickFunc, $leaveFunc)
     if ($accessibility) {
         // accessible version - use a simple drop list
 
-        $str = "<select id=\"$id\" "
-               . "onchange=\"javascript:mouseClickStarCtl("
-               .   "'$id', event, $clickFunc);\" "
-               . "onblur=\"javascript:mouseOutStrCtl("
-               .   "'$id', event, $leaveFunc);\">";
+        $str = "<select id=\"$id\">"
+               . addEventListener('change', "mouseClickStarCtl('$id', event, $clickFunc);")
+               . addEventListener('blur', "mouseOutStarCtl('$id', event, $leaveFunc);")
+               ;
         $disps = array("Not Rated", "1 Star", "2 Stars", "3 Stars",
                        "4 Stars", "5 Stars");
         for ($i = 0 ; $i <= 5 ; $i++) {
@@ -141,11 +140,13 @@ function showStarCtl($id, $init, $clickFunc, $leaveFunc)
         $str .= "<img id=\"{$id}\" "
                 . "style=\"vertical-align:middle;cursor:pointer;"
                 . "display: inline;\" "
-                . "onmouseover=\"javascript:mouseOverStarCtl('$id', event);\" "
-                . "onmousemove=\"javascript:mouseOverStarCtl('$id', event);\" "
-                . "onmouseout=\"javascript:mouseOutStarCtl('$id', event, $leaveFunc);\" "
-                . "onclick=\"javascript:mouseClickStarCtl('$id', event, $clickFunc);\" "
-                . "src=\"img/blank.gif\" class=\"star$init\">";
+                . "src=\"img/blank.gif\" class=\"star$init\">"
+                . addSiblingEventListeners([
+                    ['mouseover', "mouseOverStarCtl('$id', event);"],
+                    ['mousemove', "mouseOverStarCtl('$id', event);"],
+                    ['mouseout', "mouseOutStarCtl('$id', event, $leaveFunc);"],
+                    ['click', "mouseClickStarCtl('$id', event, $clickFunc);"],
+                ]);
     }
 
     return $str;

--- a/www/stylepics
+++ b/www/stylepics
@@ -463,8 +463,13 @@ if ($mainErrMsg)
 ?>
 
 <form name="stylepicedit" id="stylepicedit"
-      method="post" action="stylepics" align=center
-      onsubmit="javascript:return validateImageForm();">
+      method="post" action="stylepics" align=center>
+   <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
+      stylepicedit.addEventListener('submit', function (event) {
+        var result = validateImageForm();
+        if (result === false) event.preventDefault();
+      });
+   </script>
 
    <input type="hidden" name="formid" value="edit">
    <input type="hidden" name="oldfname" value="<?php
@@ -662,8 +667,13 @@ function applyDefaultFilename()
 
     <form name="stylepicupload" id="stylepicupload" class="stylepicform"
           method="post" enctype="multipart/form-data"
-          action="stylepics" align=center
-          onsubmit="javascript:return validateImageForm();">
+          action="stylepics" align=center>
+        <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
+            stylepicupload.addEventListener('submit', function (event) {
+                var result = validateImageForm();
+                if (result === false) event.preventDefault();
+            });
+        </script>
 
        <h2>Upload a new image</h2>
 
@@ -681,8 +691,12 @@ function applyDefaultFilename()
        <b>1. Select a file to upload from your computer:</b><br>
        <span class=notes>Accepted formats: JPEG, GIF, and PNG for images;
        TTF (TrueType) for fonts.</span><br>
-       <input type="file" name="imagefile" id="imagefile"
-              onchange="applyDefaultFilename();">
+       <input type="file" name="imagefile" id="imagefile">
+        <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
+            imagefile.addEventListener('change', function (event) {
+                applyDefaultFilename();
+            });
+        </script>
 
        <br><br><b>2. Name on server:</b><br>
        <span class=notes>Must be unique among your images;

--- a/www/stylepics
+++ b/www/stylepics
@@ -430,7 +430,7 @@ if ($showEditForm) {
 
     ?>
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 function validateImageForm()
 {
@@ -616,7 +616,7 @@ if ($rowcnt == 0) {
 if ($curuser == $userid) {
     ?>
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 function validateImageForm()
 {

--- a/www/stylepics
+++ b/www/stylepics
@@ -368,7 +368,7 @@ if ($userid == $curuser
 
     // verify access
     list($result, $mainErrMsg, $oldfname, $olddesc, $imgpic) =
-        verify_write_access(get_req_data('oldfname', "edit"));
+        verify_write_access(get_req_data('oldfname'), "edit");
 
     // get the new field values from the request parameters
     $fname = mysql_real_escape_string(get_req_data('newfname'), $db);
@@ -445,7 +445,7 @@ function validateImageForm()
         alert("The server filename you entered is too long.");
         return false;
     }
-    if (fn.search(/[][{}:\/\\*?"'%& \t]/) >= 0)
+    if (fn.search(/[\[\]{}:\/\\*?"'%& \t]/) >= 0)
     {
         alert("The server filename contains invalid characters.");
         return false;

--- a/www/t3join
+++ b/www/t3join
@@ -225,7 +225,7 @@ if ($userid)
         . "Start the game</a><br>";
 
     ?>
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 function launchClick()
 {
     var codeWord = document.getElementById("sessionCodeWord");
@@ -312,7 +312,7 @@ else
 pageFooter();
 
 ?>
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 function playWithoutLogin()
 {
     var mp = document.getElementById("sessionCodeWord").value;

--- a/www/t3join
+++ b/www/t3join
@@ -221,7 +221,8 @@ if ($userid)
 
     // show the launch link
     echo "<br><br>"
-        . "<a href=\"#\" onclick=\"javascript:launchClick();return false;\">"
+        . "<a href=\"#\">"
+        . addEventListener('click', "launchClick();return false;")
         . "Start the game</a><br>";
 
     ?>
@@ -284,8 +285,8 @@ else
         .   "><label for=\"ckPersist\"> Remember me</label>"
         .   "</label></td>"
         . "</tr><tr><td>&nbsp;</td><td style=\"padding-top: 1.5ex;\">"
-        .   "<input type=\"submit\" name=\"login\" value=\"Log In to IFDB\" "
-        .     "onclick=\"javascript:return clickLogInButton();\">"
+        .   "<input type=\"submit\" name=\"login\" value=\"Log In to IFDB\">"
+        .     addSiblingEventListeners([["click", "return clickLogInButton();"]])
         . "</td></tr></table>"
         . "<input type=\"hidden\" name=\"id\" value=\"$sid\">"
         . "<input type=\"hidden\" name=\"storyfile\" value=\""
@@ -297,8 +298,8 @@ else
         . "</td>"
 
         . "<td style=\"border-left: 1px dotted #4040ff; padding-left: 2em;\">"
-        . "<a href=\"#\" "
-        .    "onclick=\"javascript:playWithoutLogin();return false;\">"
+        . "<a href=\"#\">"
+        .    addEventListener("click", "playWithoutLogin();return false;")
         . "Play without logging in</a><br>"
         . "<div class=details style=\"margin-top: 1em;\">"
         . "If you choose this option, the game won't be able to "

--- a/www/t3run
+++ b/www/t3run
@@ -165,8 +165,8 @@ if ($userid)
 
     // add the multi-user option
     echo "<br>"
-        . "<label><input type=\"checkbox\" id=\"ckMulti\" "
-        .    "onclick=\"javascript:ckMultiChange();\">"
+        . "<label><input type=\"checkbox\" id=\"ckMulti\">"
+        .    addSiblingEventListeners([["click", "ckMultiChange();"]])
         . "<label for=\"ckMulti\">"
         .   " Enable multi-user play"
         . "</label></label>"
@@ -195,8 +195,8 @@ if ($userid)
     {
         // we have saved games - show a "start a new game" link
         echo "<br><ul class=doublespace>"
-            . "<li><a href=\"#\" "
-            .   "onclick=\"javascript:launchClick();return false;\">"
+            . "<li><a href=\"#\">"
+            .   addEventListener('click', "launchClick();return false;")
             . "Start a new game</a><br>";
 
         // show the saved games
@@ -205,8 +205,9 @@ if ($userid)
             // get the information for this entry
             $fname = $f["name"];
             $links = array(
-                "<a href=\"#\" onclick=\"javascript:launchClick("
-                . "'$fname');return false;\">Restore this game</a>");
+                "<a href=\"#\">"
+                .   addEventListener('click', "launchClick('$fname');return false;")
+                . "Restore this game</a>");
             $desc = getSaveFileDesc(
                 $f, array("Saved game #\$: ", "Saved game: "), $links);
             echo "<li>$desc";
@@ -219,8 +220,8 @@ if ($userid)
     {
         // no saved games - show a simple "Start the game" link
         echo "<br>"
-            . "<a href=\"#\" "
-            .   "onclick=\"javascript:launchClick();return false;\">"
+            . "<a href=\"#\">"
+            .   addEventListener('click', "launchClick();return false;")
             . "Start the game</a><br>";
     }
 

--- a/www/t3run
+++ b/www/t3run
@@ -225,7 +225,7 @@ if ($userid)
     }
 
     ?>
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 function ckMultiChange()
 {
     var ck = document.getElementById("ckMulti");

--- a/www/t3servers
+++ b/www/t3servers
@@ -399,8 +399,8 @@ table.srvedit td.1 {
    // add a Delete button, except for a new entry
    if ($applyID != 'NEW')
    {
-       echo "<input type=\"submit\" name=\"ApplyDelete\" value=\"Delete\" "
-           . "onclick=\"javascript:return confirmDeleteRow();\"> "
+       echo "<input type=\"submit\" name=\"ApplyDelete\" value=\"Delete\"> "
+           .   addSiblingEventListeners([['click', "return confirmDeleteRow();"]])
            . "&nbsp; ";
 
 ?>

--- a/www/t3servers
+++ b/www/t3servers
@@ -404,7 +404,7 @@ table.srvedit td.1 {
            . "&nbsp; ";
 
 ?>
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 function confirmDeleteRow()
 {
     return confirm("Are you sure you want to permanently delete this "

--- a/www/useractivation.php
+++ b/www/useractivation.php
@@ -35,13 +35,13 @@ function genNewUserAdminLinks($verbose, $actcode, $salt)
         . ($verbose ? "<b>Approve</b> - " : "")
         . "Send activation email</a>"
         . "$br<a href=\"" . get_root_url() . "userconfirm?"
-        . "a=$actcode&s=$salt&c=flush\" "
-        . "onclick='javascript:return confirm(\"Do you really want to delete this user?\");' >"
+        . "a=$actcode&s=$salt&c=flush\">"
+        . addEventListener('click', "return confirm(\"Do you really want to delete this user?\");")
         . ($verbose ? "<b>Delete</b> - " : "")
         . "Delete user completely</a>"
         . "$br<a href=\"" . get_root_url() . "userconfirm?"
-        . "a=$actcode&s=$salt&c=ban\" "
-        . "onclick='javascript:return confirm(\"Do you really want to ban this user?\");' >"
+        . "a=$actcode&s=$salt&c=ban\">"
+        . addEventListener('click', "return confirm(\"Do you really want to ban this user?\");")
         . ($verbose ? "<b>Ban</b> - " : "")
         . "Forbid login; hide reviews, comments, and profile</a>";
 }

--- a/www/util.php
+++ b/www/util.php
@@ -937,10 +937,11 @@ function spoilerWarningClose()
 function spoilerWarningScript()
 {
     static $didSpoilerScript = 0;
+    global $nonce;
     if ($didSpoilerScript++ != 0)
         return "";
     else
-        return "\n<script type=\"text/javascript\">\n"
+        return "\n<script type=\"text/javascript\" nonce=\"$nonce\">\n"
             . "<!--\n"
             . "function showSpoiler(id) { "
             . "document.getElementById(\"a_spoiler\" + id).style.display = "

--- a/www/util.php
+++ b/www/util.php
@@ -909,12 +909,9 @@ function spoilerWarningOpen($label = "Spoiler - click to show")
     static $spoilerNum = 0;
 
     // set up the text
-    $ret = "<span class=\"spoilerButton\" "
+    $ret = "<span class=\"spoilerButton\""
            . "id=\"a_spoiler$spoilerNum\">("
-           . "<a href=\"#\">"
-           . addEventListener("click", "showSpoiler('$spoilerNum'); return false;")
-           . "$label"
-           . "</a>)</span>"
+           . "<a href=\"#\" x-num='$spoilerNum'>$label</a>)</span>"
            . "<span class=\"hiddenSpoiler\" "
            . "id=\"s_spoiler$spoilerNum\">";
 
@@ -948,6 +945,12 @@ function spoilerWarningScript()
             . "document.getElementById(\"s_spoiler\" + id).style.display = "
             . "\"inline\";"
             . "}\n"
+            . "document.querySelectorAll('.spoilerButton a').forEach(function (link) {\n"
+            . "  link.addEventListener('click', function (event) {\n"
+            . "    event.preventDefault();\n"
+            . "    showSpoiler(event.target.getAttribute('x-num'));\n"
+            . "  });"
+            . "});"
             . "//-->\n"
             . "</script>";
 }
@@ -1378,7 +1381,7 @@ function fixDesc($desc, $specials = 0)
     // if we found a spoiler tag, add the necessary script if we haven't
     // already done so
     if ($foundSpoiler)
-        $desc = spoilerWarningScript() . $desc;
+        $desc .= spoilerWarningScript();
 
     // return the result
     return output_encode($desc);

--- a/www/util.php
+++ b/www/util.php
@@ -855,9 +855,8 @@ function showSortingControls($formName, $dropName, $sortMap, $curSortBy,
         . "class=\"sortingControls\">";
 
     // add the drop-down list
-    echo "<select name=\"$dropName\" "
-        . "onchange=\"javascript:document.getElementById("
-        . "'sort-go-button-$idSerial').click();\">";
+    echo "<select name=\"$dropName\">"
+        . addEventListener("change", "document.getElementById('sort-go-button-$idSerial').click();");
 
     // add the option values for the list
     foreach ($sortMap as $key => $val) {
@@ -912,9 +911,9 @@ function spoilerWarningOpen($label = "Spoiler - click to show")
     // set up the text
     $ret = "<span class=\"spoilerButton\" "
            . "id=\"a_spoiler$spoilerNum\">("
-           . "<a href=\"#\" onclick=\"javascript:"
-           . "showSpoiler('$spoilerNum');"
-           . "return false;\">$label"
+           . "<a href=\"#\">"
+           . addEventListener("click", "showSpoiler('$spoilerNum'); return false;")
+           . "$label"
            . "</a>)</span>"
            . "<span class=\"hiddenSpoiler\" "
            . "id=\"s_spoiler$spoilerNum\">";

--- a/www/viewgame
+++ b/www/viewgame
@@ -1829,13 +1829,11 @@ if ($embargoCnt > 0)
                <?php if (!isEmpty($system))
                    echo "Development System: <a href=\"search?searchfor=system:" . urlencodeFromHTML($system) . "\">$system</a><br>" ?>
                <?php if (!isEmpty($forgiveness))
-                   echo "<a class=silent " . helpWinHRef("help-forgiveness")
-                       . " title=\"What does this mean?\">"
-                       . "Forgiveness Rating</a>: $forgiveness<br>" ?>
+                   echo helpWinLink("help-forgiveness", "Forgiveness Rating")
+                       . ": $forgiveness<br>" ?>
                <?php if(!isEmpty($bafsid))
-                   echo "<a class=silent " . helpWinHRef("help-bafs")
-                       . " title=\"What's a Baf's Guide ID?\">
-                        Baf's Guide ID</a>:
+                   echo helpWinLink("help-bafs", "Baf's Guide ID")
+                       . ":
                      <a class=silent
                       href=\"https://web.archive.org/web/20110100000000/http://www.wurb.com/if/game/$bafsid\"
                         title=\"Go to the Baf's Guide listing for this game\">
@@ -1845,8 +1843,7 @@ if ($embargoCnt > 0)
             </span>
             <?php
 
-$caption = "<a class=silent " . helpWinHRef("help-ifid")
-           . " title=\"What's an IFID?\">IFID</a>";
+$caption = helpWinLink("help-ifid", "IFID");
 
 if (count($ifids) == 0 || isEmpty($ifids[0]))
     echo "<span class=notes>$caption: <i>Unknown</i></span><br>";
@@ -1862,8 +1859,8 @@ else {
 }
             ?>
             <span class=notes>
-              <a class=silent <?php echo helpWinHRef("help-tuid");
-                 ?> title="What's a TUID?">TUID</a>:
+              <?php echo helpWinLink("help-tuid", "TUID");
+                 ?>:
                  <?php echo htmlspecialcharx($id) ?>
             </span><br>
 

--- a/www/viewgame
+++ b/www/viewgame
@@ -720,8 +720,6 @@ if (is_null(getID()) && get_req_data('ifid') != "") {
 
     <p>IFDB doesn't have a listing matching the <?php
 echo helpWinLink("help-ifid", "IFID");
-//    <a href="needjs"
-//     onclick="javascript:helpWin('help-ifid');return false;">IFID</a>
     ?>
     "<?php echo htmlspecialcharx(get_req_data('ifid')) ?>."  This
     could mean one of several things:
@@ -1306,8 +1304,8 @@ function updateUnwishList(id, stat)
                       "updateRating", "mouseOutRating")
         . " <span id=\"ratingSaveMsg\" class=xmlstatmsg></span><br>"
         . ($currentUserReview != "" ? "" :
-           "<span id=\"clearRatingSpan\"><a href=\"needjs\" "
-           . "onclick=\"javascript:clearRating();return false\">"
+           "<span id=\"clearRatingSpan\"><a href=\"needjs\">"
+           . addEventListener("click", "clearRating();return false")
            . "Remove rating</a><br></span>")
         . "<a href=\"review?id=$id&userid=$curuser\">"
         . ($currentUserReview != "" ? "Revise my review" : "Review it")
@@ -1832,8 +1830,6 @@ if ($embargoCnt > 0)
                    echo "Development System: <a href=\"search?searchfor=system:" . urlencodeFromHTML($system) . "\">$system</a><br>" ?>
                <?php if (!isEmpty($forgiveness))
                    echo "<a class=silent " . helpWinHRef("help-forgiveness")
-//                       href=\"needjs\"
-//                     onclick=\"javascript:helpWin('help-forgiveness');return false;\"
                        . " title=\"What does this mean?\">"
                        . "Forgiveness Rating</a>: $forgiveness<br>" ?>
                <?php if(!isEmpty($bafsid))
@@ -1850,8 +1846,6 @@ if ($embargoCnt > 0)
             <?php
 
 $caption = "<a class=silent " . helpWinHRef("help-ifid")
-//              href=\"needjs\"
-//              onclick=\"javascript:helpWin('help-ifid');return false;\"
            . " title=\"What's an IFID?\">IFID</a>";
 
 if (count($ifids) == 0 || isEmpty($ifids[0]))
@@ -1869,8 +1863,6 @@ else {
             ?>
             <span class=notes>
               <a class=silent <?php echo helpWinHRef("help-tuid");
-//                 href="needjs"
-//                 onclick="javascript:helpWin('help-tuid');return false;"
                  ?> title="What's a TUID?">TUID</a>:
                  <?php echo htmlspecialcharx($id) ?>
             </span><br>
@@ -2364,9 +2356,6 @@ if (count($inrefs) != 0 && !$historyView) {
         <span class=details style="margin-left: 1ex;">
            - <a href="showtags?limit=50">View the most common tags</a>
            (<?php echo helpWinLink("help-tags", "What's a tag?")
-     //<a href="needjs"
-//           onclick="javascript:helpWin('help-tags');return false;"
-//           >What's a tag?</a>
            ?>)
         </span></p>
         <table id="tagTable" border=0 class=tags></table>
@@ -2376,11 +2365,19 @@ if (count($inrefs) != 0 && !$historyView) {
             <span class=details>
                <b>Your tags:</b>
                <span id="myTagList" style="margin-right:1ex;"></span> -
-               <a href="needjs" onclick="javascript:editTags();return false;"
-                  >Edit</a>
+               <a href="needjs"><script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
+                  document.currentScript.parentElement.addEventListener('click', function (event) {
+                    event.preventDefault();
+                    editTags();
+                  })
+                </script>Edit</a>
             <?php if ($adminPriv) { ?>
-               <a href="needjs" onclick="javascript:deleteTags();return false;"
-                  >Delete</a>
+               <a href="needjs"><script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
+                  document.currentScript.parentElement.addEventListener('click', function (event) {
+                    event.preventDefault();
+                    deleteTags();
+                  })
+                </script>Delete</a>
             <?php } ?>
 
                <span class="xmlstatmsg" style="margin-left:1ex;"
@@ -2405,13 +2402,23 @@ if (count($inrefs) != 0 && !$historyView) {
                  </div>
                  <div style="position:absolute;top:2px;right:0px;
                     text-align:right;">
-                    <a href="needjs" onclick="javascript:closeTags('tagEditor');
-                       return false;">Cancel<img src="img/blank.gif"
+                    <a href="needjs"><script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
+                        document.currentScript.parentElement.addEventListener('click', function (event) {
+                            event.preventDefault();
+                            closeTags();
+                        })
+                    </script>Cancel<img src="img/blank.gif"
                           class="popup-close-button"></a>
                  </div>
               </div>
-              <form name="tagForm" onsubmit="javascript:addTags();return false;"
+              <form name="tagForm"
                  style="padding:1ex 1ex 0.5ex 1ex; margin:0 0 0 0;">
+                 <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
+                  document.currentScript.parentElement.addEventListener('submit', function (event) {
+                    event.preventDefault();
+                    addTags();
+                  })
+                </script>
                  <span class=details>Tags you added are shown below with
                     checkmarks.  To remove one of your tags, simply
                     un-check it.
@@ -2427,12 +2434,23 @@ if (count($inrefs) != 0 && !$historyView) {
                     style="vertical-align:middle;">
                  <input type=image src="img/blank.gif" class="add-button"
                     id="viewgame-add-tags-button"
-                    name="addTags" style="vertical-align:middle;"
-                    onclick="javascript:addTags();return false;"><br>
+                    name="addTags" style="vertical-align:middle;">
+                    <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
+                        document.getElementById('viewgame-add-tags-button').addEventListener('click', function (event) {
+                            event.preventDefault();
+                            addTags();
+                        })
+                    </script>
+                <br>
                  <input type=image src="img/blank.gif" class="save-button"
                     id="viewgame-save-tags-button"
-                    name="saveTags" style="margin-top:1ex;"
-                    onclick="javascript:saveTags();return false;">
+                    name="saveTags" style="margin-top:1ex;">
+                    <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
+                        document.getElementById('viewgame-save-tags-button').addEventListener('click', function (event) {
+                            event.preventDefault();
+                            saveTags();
+                        })
+                    </script>
               </form>
            </div>
         </div>
@@ -2448,21 +2466,36 @@ if (count($inrefs) != 0 && !$historyView) {
            </div>
            <div style="position:absolute;top:2px;right:0px;
               text-align:right;">
-              <a href="needjs" onclick="javascript:closeTags('tagDeletor');
-                 return false;">Cancel<img src="img/blank.gif"
+              <a href="needjs"><script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
+                  document.currentScript.parentElement.addEventListener('click', function (event) {
+                    event.preventDefault();
+                    closeTags('tagDeletor');
+                  })
+                </script>Cancel<img src="img/blank.gif"
                     class="popup-close-button"></a>
            </div>
         </div>
-        <form name="tagForm" onsubmit="javascript:addTags();return false;"
+        <form name="tagForm"
            style="padding:1ex 1ex 0.5ex 1ex; margin:0 0 0 0;">
+           <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
+                document.currentScript.parentElement.addEventListener('submit', function (event) {
+                    event.preventDefault();
+                    addTags();
+                })
+            </script>
            <span class=details></span>
            <table id="deleteTagTable" border=0 class=tags
               style="font-size:85%;">
            </table>
            <input type=image src="img/blank.gif" class="save-button"
-              id="viewgame-save-tags-button"
-              name="saveTags" style="margin-top:1ex;"
-              onclick="javascript:saveTagsDelete();return false;">
+              id="viewgame-save-tags-button-delete"
+              name="saveTags" style="margin-top:1ex;">
+              <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
+                document.getElementById('viewgame-save-tags-button-delete').addEventListener('click', function (event) {
+                    event.preventDefault();
+                    saveTagsDelete();
+                })
+            </script>
         </form>
      </div>
   </div>
@@ -2537,19 +2570,10 @@ function dispTagTable(tableID, lst, editor, deleteTags)
 
 
             if (!deleteTags) {
-                s = "<span class=\"cklabel\" onmouseover=\"javascript:"
-                    + "ckboxOver('"+ck+"',false);return true;\" "
-                    + "onmouseout=\"javascript:ckboxLeave('"+ck+"',false);"
-                    + "return true;\" onclick=\"javascript:ckboxClick('"+ck
-                    + "',false,doTagCkBox);return false;\">"
+                s = "<span class=\"cklabel\" x-ck='"+i+"'>"
                     + "<img align=absmiddle border=0 id=\"ckImg"+ck+"\"> "
             } else {
-               s = "<span class=\"cklabel\" onmouseover=\"javascript:"
-                + "ckboxOver('"+ck+"',false);return true;\" "
-                + "onmouseout=\"javascript:ckboxLeave('"+ck+"',false);"
-                + "return true;\" onclick=\"javascript:deleteTag('"
-                + t.replace(/'/g,"\\'")
-                + "');return false;\">"
+               s = "<span class=\"cklabel\" x-ck='"+i+"'>"
                     + "<input type=image align=absmiddle border=0 id=\"ckImg"+ck+"\""
                     + "src='img/delrow.gif' >";
 
@@ -2584,6 +2608,24 @@ function dispTagTable(tableID, lst, editor, deleteTags)
             }
         }
         cell.innerHTML = s;
+        cell.querySelectorAll('.cklabel').forEach(function (cklabel) {
+            var ck = "tagCk" + cklabel.getAttribute('x-ck');
+            cklabel.addEventListener('mouseover', function (event) {
+                ckboxOver(ck, false);
+            });
+            cklabel.addEventListener('mouseout', function (event) {
+                ckboxLeave(ck, false);
+            });
+            cklabel.addEventListener('click', function (event) {
+                event.preventDefault();
+                if (deleteTags) {
+                    var tag = lst[cklabel.getAttribute('x-ck')].tag;
+                    deleteTag(tag);
+                } else {
+                    ckboxClick(ck, false, doTagCkBox);
+                }
+            });
+        })
 
         if (editor)
             ckboxCheck(ck, false, m);

--- a/www/viewgame
+++ b/www/viewgame
@@ -1230,7 +1230,7 @@ if ($curuser) {
         where userid='$curuser' and gameid='$qid'", $db);
     $unwishlist = mysql_num_rows($result) > 0;
             ?>
-            <script type="text/javascript">
+            <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
             <!--
 function updateRating(rating)
 {
@@ -1335,7 +1335,7 @@ function updateUnwishList(id, stat)
         . "</span><br></div></div>";
 
     ?>
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 mouseOutRating(<?php echo $currentUserRating ?>);
 //-->
@@ -1376,7 +1376,7 @@ mouseOutRating(<?php echo $currentUserRating ?>);
       </tr>
    </table>
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 function updatePlaylistCount(n)
 {
@@ -2467,7 +2467,7 @@ if (count($inrefs) != 0 && !$historyView) {
      </div>
   </div>
 
-<script type="text/javascript">
+<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 var dbTagList = [
 <?php
@@ -3123,7 +3123,7 @@ dispTags();
                     ." at <a href=\"https://www.ifwiki.org/index.php\">IF Wiki</a></div>";
                 $jifid = htmlspecialcharx(str_replace("\"", "&#34;", $ifids[0]));
                 ?>
-                <script>
+                <script nonce="<?php global $nonce; echo $nonce; ?>">
                     xmlSend("ifwiki-check?ifid=<?php echo $jifid ?>", null,
                         function(doc) {
                             if (xmlChildText(doc, "exists") == "yes") {


### PR DESCRIPTION
In this PR, I'm attempting to add a Content Security Policy, to provide broad, general defense against XSS attacks.

https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP

XSS security issues occur when an attacker constructs a special link to IFDB, like this:

<https://ifdb.org/allreviews?id=40ru852yszsizxsv&ratings=yes&pg=all&sortby=%3C/script%3E%27%22%3E%3Cimg%20src=x%20onError=prompt(1)%3E>

`sortby` is supposed to be a single word, like `new` to sort by "Newest First", but the code foolishly assumes that we can insert any text from the URL directly into the web page.

The attacker can then write their own JavaScript code that runs on our server, logged in with the current user's credentials. In this example, the attacker just runs `prompt(1)`, as a proof of concept, but if the user is an admin, the code could just as easily delete users, promote themselves to an administrator, or do anything else than an administrator can do.

Fixing XSS issues can be a game of whack-a-mole, trying to catch every case of these, but the better fix is to add a Content Security Policy that forbids this entire kind of bug.

As I write this, there are 44 commits in this PR. 😳

I start by adding a very basic CSP header, allowing too much:

```
header("Content-Security-Policy: default-src 'self' ifdb.org 'nonce-$nonce' 'unsafe-eval';
style-src 'self' 'unsafe-inline';
script-src-attr 'unsafe-inline';");
```

This header blocks all `<script>` tags from working unless they have a valid `nonce` attribute. https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/nonce

…so then I went through and added nonces to as many `<script>` tags as I could find. I think I got them all.

That then left three bugs to fix:

- [x] `unsafe-eval`: Removed all calls to `eval()` https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/eval
- [x] `script-src-attr 'unsafe-inline'`: To fix this, I had to remove all `onclick` attributes from the entire site, replacing them with nonce-enabled `<script>` tags. I did over the course of 39 other commits. 😖 (This fixed the XSS issue above.)
- [ ] `style-src 'unsafe-inline'`: To fix this, I'll have to remove all `style=` attributes, of which there are 235 in the code base, and remove (or add nonces) to all `<style>` elements, of which there are only 9 in the code base.

… so, uh, yeah, a lot of work still to do. But I wanted to get some of this code off of my machine so people could begin reviewing it.