### PR TITLE
Cache busting

### DIFF
--- a/www/allreviews
+++ b/www/allreviews
@@ -64,7 +64,7 @@ if (mysql_num_rows($result) == 0) {
     $pageTitle .= " by ". htmlspecialcharx($username);
 }
 
-pageHeader($pageTitle, false, false, "<script src=\"xmlreq.js\"></script>");
+pageHeader($pageTitle, false, false, scriptSrc('/xmlreq.js'));
 initReviewVote();
 
 if ($errMsg) {

--- a/www/captcha.php
+++ b/www/captcha.php
@@ -14,7 +14,7 @@ include_once "dbconnect.php";
 //   1. Include this file in your php file
 //
 //   2. In your pageHeader() extra header text, include
-//       "<script src=\"xmlreq.js\"></script>"
+//       scriptSrc('/xmlreq.js')
 //
 //   3. Generate a "key" for the captcha session (see below).  This is
 //      a unique key for the $_SESSION array to identify this captcha

--- a/www/club
+++ b/www/club
@@ -889,7 +889,7 @@ if (isset($_REQUEST['members']))
 // --------------------------- Standard View --------------------------------
 
 $pageTitle = "$name - Club Details";
-pageHeader($pageTitle, false, false, "<script src=\"xmlreq.js\"></script>");
+pageHeader($pageTitle, false, false, scriptSrc('/xmlreq.js'));
 echo "<h1>$name</h1>"
    . $desc;
 

--- a/www/comment.php
+++ b/www/comment.php
@@ -483,7 +483,7 @@ if ($succMsg) {
 }
 
 pageHeader($title, "commentForm.commentField", false,
-           "<script src=\"xmlreq.js\"></script>");
+           scriptSrc('/xmlreq.js'));
 captchaSupportScripts($captchaKey);
 
 if (!$submit || $errMsg || !$captchaOK) {

--- a/www/contact
+++ b/www/contact
@@ -5,7 +5,7 @@ include_once "util.php";
 include_once "captcha.php";
 
 varPageHeader("Contacting Us", false, get_req_data('helpwin'),
-              false, "<script src=\"xmlreq.js\"></script>");
+              false, scriptSrc('/xmlreq.js'));
 
 $capkey = "contact";
 captchaSupportScripts($capkey);

--- a/www/delgame
+++ b/www/delgame
@@ -332,7 +332,7 @@ if ($createFwd)
         mysql_query("unlock tables", $db);
 
         pageHeader("$title - Delete Listing", "fwdgame.fwdid",
-                   false, "<script src='xmlreq.js'></script>");
+                   false, scriptSrc('/xmlreq.js'));
 
         gameSearchPopupSupportFuncs();
         gameSearchPopupDiv();

--- a/www/editclub
+++ b/www/editclub
@@ -353,7 +353,7 @@ $membersPublic = ($membersPublic == 'Y');
 // start the page
 $pageTitle = ($qid == "new" ? "Create a Club Listing" : "$name - Edit Club");
 pageHeader("Edit Club", "clubform.name", false,
-           "<script src=\"xmlreq.js\"></script>");
+           scriptSrc('/xmlreq.js'));
 echo "<h1>$pageTitle</h1>";
 
 // add profile link support

--- a/www/editcomp
+++ b/www/editcomp
@@ -1036,8 +1036,8 @@ if ($show == "divform") {
     // showing the division editor form
     pageHeader($pageTitle, false,
                "gfGenForm('divModel');",
-               "<script src=\"gridform.js\"></script>"
-               . "<script src=\"xmlreq.js\"></script>",
+               scriptSrc('/gridform.js')
+               . scriptSrc('/xmlreq.js'),
                false, false);
 
 }
@@ -1046,8 +1046,8 @@ else if ($show == "form") {
     // showing the form - set up the form page
     pageHeader($pageTitle, "editcomp.title",
                "initGrids();\ndocument.body.addEventListener('mousedown', function (event) { checkClosePopup(event, true); });",
-               "<script src=\"gridform.js\"></script>"
-               . "<script src=\"xmlreq.js\"></script>",
+               scriptSrc('/gridform.js')
+               . scriptSrc('/xmlreq.js'),
                false);
 
 

--- a/www/editgame
+++ b/www/editgame
@@ -516,8 +516,8 @@ if ($errMsg) {
                    "gfGenForm('linkModel');gfGenForm('reviewModel');"
                    . "gfGenForm('xrefModel');"
                    . "\ndocument.body.addEventListener('mousedown', function (event) { checkClosePopup(event, true); });",
-                   "<script src=\"gridform.js\"></script>"
-                   . "<script src=\"xmlreq.js\"></script>",
+                   scriptSrc('/gridform.js')
+                   . scriptSrc('/xmlreq.js'),
                    false);
 
         initStarControls();

--- a/www/editlist
+++ b/www/editlist
@@ -725,8 +725,8 @@ for ($i = 0 ; $i < count($listItems) ; $i++) {
 
 pageHeader($pagetitle, $errMsg ? false : "editlist.title",
            "gfGenForm('listModel');",
-           "<script src=\"gridform.js\"></script>"
-          . "<script src=\"xmlreq.js\"></script>");
+           scriptSrc('/gridform.js')
+          . scriptSrc('/xmlreq.js'));
 echo "<h1>$pagetitle</h1>";
 
 gameSearchPopupSupportFuncs();

--- a/www/editprofile
+++ b/www/editprofile
@@ -395,7 +395,7 @@ function saveChanges()
 
             // we need the captcha form step
             pageHeader("Update Profile", false, false,
-                       "<script src='xmlreq.js'></script>");
+                       scriptSrc('/xmlreq.js'));
             captchaSupportScripts($captchaKey);
 
             ?>
@@ -619,7 +619,7 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST'
 
 // start the page
 pageHeader("Update Settings", "editprofile.email", false,
-           "<script src='xmlreq.js'></script>");
+           scriptSrc('/xmlreq.js'));
 imageUploadScripts();
 captchaSupportScripts($captchaKey);
 

--- a/www/gamesearchpopup.php
+++ b/www/gamesearchpopup.php
@@ -8,7 +8,7 @@
 //   1. Include this file in your php script.
 //
 //   2. In the pageHeader() extra headers, include
-//      "<script src='xmlreq.js'></script>"
+//      scriptSrc('/xmlreq.js')
 //
 //   2. Somewhere in the HTML body, call gameSearchPopupSupportFuncs() to
 //      generate the javascript support functions.  This generates an

--- a/www/ifarchive-upload
+++ b/www/ifarchive-upload
@@ -15,7 +15,7 @@ if (!logged_in())
 $userid = $_SESSION['logged_in_as'];
 
 pageHeader("IF Archive File Upload", false, false,
-           "<script src=\"xmlreq.js\"></script>");
+           scriptSrc('/xmlreq.js'));
 
 include_once "captcha.php";
 $capkey = "archive-upload";

--- a/www/lostact
+++ b/www/lostact
@@ -27,7 +27,7 @@ if (!$showForm)
 // Main form display
 //
 pageHeader("Missing Activation Email", "lostact.userid", false,
-           "<script src=\"xmlreq.js\"></script>");
+           scriptSrc('/xmlreq.js'));
 
 ?>
 

--- a/www/lostpass
+++ b/www/lostpass
@@ -27,7 +27,7 @@ if (!$showForm)
 // Main form display
 //
 pageHeader("Lost Password", "lostpass.userid", false,
-           "<script src=\"xmlreq.js\"></script>");
+           scriptSrc('/xmlreq.js'));
 
 ?>
 

--- a/www/newuser
+++ b/www/newuser
@@ -29,7 +29,7 @@ if (!$showForm)
 //
 
 pageHeader("New User Registration", "newuser.userid", false,
-           "<script src=\"xmlreq.js\"></script>");
+           scriptSrc('/xmlreq.js') . scriptSrc('/passwords.js'));
 ?>
 
 <h1>New User Registration</h1>
@@ -114,7 +114,6 @@ if ($errFlagged != false) {
             onPassConfChange(event.target);
         });
     </script>
-<script type="text/javascript" src="passwords.js">
 </script>
 
 <p>

--- a/www/opsys
+++ b/www/opsys
@@ -497,7 +497,7 @@ if ($geticon) {
         // we can edit it - show the editing form
         pageHeader("Edit OS/Interpreter", "editos.osname",
                    "gfGenForm('vsnGridModel');",
-                   "<script src=\"gridform.js\"></script>");
+                   scriptSrc('/gridform.js'));
 
         imageUploadScripts();
 

--- a/www/pagetpl.php
+++ b/www/pagetpl.php
@@ -4,6 +4,17 @@ include_once "csp-nonce.php";
 include_once "util.php";
 include_once "login-persist.php";
 
+function srcCacheBust($filename)
+{
+    $mtime = filemtime($_SERVER['DOCUMENT_ROOT'] . $filename);
+    return "$filename?t=$mtime";
+}
+
+function scriptSrc($filename)
+{
+    return "<script src=\"" . srcCacheBust($filename) . "\"></script>";
+}
+
 function basePageHeader($title, $focusCtl, $extraOnLoad, $extraHead,
                         $ckbox, $bodyAttrs)
 {
@@ -34,7 +45,7 @@ function basePageHeader($title, $focusCtl, $extraOnLoad, $extraHead,
    <link rel="search" type="application/opensearchdescription+xml"
          title="IFDB Search Plugin"
          href="<?php echo get_root_url() ?>plugins/ifdb-opensearchdesc.xml">
-   <script src="/ifdbutil.js"></script>
+   <script src="<?php echo srcCacheBust('/ifdbutil.js')?>"></script>
    <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1">
    <meta name="description" content="IFDB is a game catalog and recommendation engine for Interactive Fiction, also known as Text Adventures. IFDB is a collaborative, wiki-style community project.  Members can contribute game listings, reviews, recommendations, and more.">
    <title><?php echo $title ?></title>

--- a/www/profilelink.php
+++ b/www/profilelink.php
@@ -8,7 +8,7 @@
 //
 //  1. Include this file
 //
-//  2. In the pageHeader call, include "<script src='xmlreq.js'></script>"
+//  2. In the pageHeader call, include scriptSrc('/xmlreq.js')
 //     in the extra header text.
 //
 //  3. Somewhere in the file, call profileLinkSupportFuncs() to generate

--- a/www/reviews.php
+++ b/www/reviews.php
@@ -5,7 +5,7 @@
 // include_once "pagetpl.php";
 //
 // put the following extra text in the <HEAD> section:
-//    <script src="xmlreg.js"></script>
+//    scriptSrc('/xmlreq.js')
 //
 // call initReviewVote() somewhere in the <BODY> section, to insert the
 // javascript code for review voting

--- a/www/search
+++ b/www/search
@@ -360,7 +360,7 @@ if (!$xml) {
     pageHeader($term == "" && $browse ? "Browse $searchTypeName"
                                       : "Search for $searchTypeName",
                false, false,
-               "<script src=\"xmlreq.js\"></script>");
+               scriptSrc('/xmlreq.js'));
 
     $commonInstructions =
         "<p><b>+<i>word</i></b> makes <i>word</i> mandatory - only items

--- a/www/showuser
+++ b/www/showuser
@@ -232,7 +232,7 @@ if ($rss == 'gamenews')
     exit();
 }
 
-pageHeader($pageTitle, false, false, "<script src=\"xmlreq.js\"></script>");
+pageHeader($pageTitle, false, false, scriptSrc('/xmlreq.js'));
 
 $captchaKey = "showuser.$uid";
 captchaSupportScripts($captchaKey);

--- a/www/viewgame
+++ b/www/viewgame
@@ -661,7 +661,7 @@ if (isset($_REQUEST['ifiction']))
 }
 
 // start the page
-$extraHead = "<script src=\"xmlreq.js\"></script>";
+$extraHead = scriptSrc('/xmlreq.js');
 if ($should_hide) {
     $extraHead .= "<meta name=\"robots\" content=\"noindex\">";
 }


### PR DESCRIPTION
In https://intfiction.org/t/security-updates-live-on-ifdb/63315/2?u=dfabulich JTN reports a bunch of strange issues that I can't reproduce. I hypothesize that JTN has cached an old version of some of our JS, causing an issue.

In this PR, I'm adding a cache busting URL parameter https://developer.mozilla.org/en-US/docs/Web/HTTP/Caching#cache_busting 

So instead of 

```
<script src="/ifdbutil.js"></script>
```

We'll request

```
<script src="/ifdbutil.js?t=1653965576"></script>
```

Where `t` is the last modified time of the file on disk.

I also incorporated this for user styles, based on the `modified` date in the database.

Thus the CSS for Midnight styles now looks like this:

```
<link rel="stylesheet" href="/users/oyrrw74upu8n2dds/css/48.css?t=1615448743">
```