### PR TITLE
Rename Downloads to External Links

### DIFF
--- a/www/api/putific
+++ b/www/api/putific
@@ -182,10 +182,10 @@ required.
 <p><b>ifiction</b>: the iFiction XML file upload.  Use content-type
 text/xml.  The file name and suffix aren't important; the server
 ignores these and always tries to parse this file as XML regardless of
-the filename.  See the <a href="#links">download links</a> section
+the filename.  See the <a href="#links">external links</a> section
 for details on the XML format.  File upload parameter; required.
 
-<p><b>links</b>: the downloadable file link list.  This is an XML
+<p><b>links</b>: the external link list.  This is an XML
 attachment, like the iFiction file.  Use content-type text/xml.  The
 file name and suffix are ignored; this is always treated as an
 XML file.  File upload parameter; optional.
@@ -338,21 +338,21 @@ overridden with the <b>requireIFID</b> parameter, though, as described
 above.)  All other items are optional.
 
 
-<h2><a name="links">Download links</h2>
+<h2><a name="links">External links</h2>
 
-<p>The request can optionally provide a list of downloadable files to
+<p>The request can optionally provide a list of external links (including downloadable files) to
 add to the game listing.  You will usually want to include at least a
 link to the downloadable story file, but you can also include any
 desired supplemental files (such as hints, maps, instructions,
 walk-throughs, or "feelies").  These are listed on the game's IFDB
-page in the "Downloads" section.
+page in the "External Links" section.
 
 <p>Note that IFDB doesn't host game downloads.  It only links to them.
-The download section is simply a list of URLs to files on other
+The External Links section is simply a list of URLs to files on other
 servers; you don't attach any of the actual game files to the request,
 just pointers to them.
 
-<p>The download list is specified via an XML file, attached to the
+<p>The external links list is specified via an XML file, attached to the
 request via the <b>links</b> parameter.  The XML content is formatted
 as follows:
 
@@ -562,23 +562,23 @@ existing listing.  The restriction is simply that all IFIDs in the
 iFiction record that already exist on IFDB must all point to the same
 listing.
 
-<p>The download links specified through the API are purely additive.
-When the API is used to update an existing listing, the download links
-in the request are merged with the download links from the existing
+<p>The external links specified through the API are purely additive.
+When the API is used to update an existing listing, the external links
+in the request are merged with the external links from the existing
 record.  The merging is by URL:
 
 <p>
 <ul>
 
-   <li>For an existing download link with a URL matching a
-   download link in the API request, the data from the request (title,
+   <li>For an existing external link with a URL matching an
+   external link in the API request, the data from the request (title,
    description, etc) replaces the existing data.
 
    <li>For an existing link with a URL that <i>doesn't</i> match any
    link in the API request, the existing link is kept with no changes.
 
    <li>For a link in the API request that doesn't match any URL in
-   the existing download links, the API request link is added to the
+   the existing external links, the API request link is added to the
    list, after all of the existing links.
 
 </ul>
@@ -597,7 +597,7 @@ existing link to the old game in the interim, so that users viewing
 the page will find something to download, even if it's not necessarily
 fully up to date yet.
 
-<p>The reason that the download links are additive is that the links
+<p>The reason that the external links are additive is that the links
 presented through the request API are presumably the files published
 directly by the author of the game, but existing links might refer to
 other "unofficial" files created by third parties, such as hints or
@@ -605,7 +605,7 @@ walk-throughs.  We don't want to delete those third-party files just
 because the author is updating her published files.  So, we simply
 retain any existing links without changes when they're not mentioned
 in the request.  In the simplest case, when the request doesn't
-include any download links, this means that we make no changes
+include any external links, this means that we make no changes
 at all to the existing links.
 
 

--- a/www/contact
+++ b/www/contact
@@ -40,9 +40,9 @@ link at the bottom of the game's main page.  To add a game, click
 the "Add a new game listing" link on the IFDB home page.
 
 
-<h3>Reporting broken download links</h3>
+<h3>Reporting broken links</h3>
 
-<p>A broken link in the "Download" section of a game listing should be
+<p>A broken link in the "External Links" section of a game listing should be
 treated like any other listing error: you can correct it yourself by
 editing the page containing the bad link.  To edit a game's page,
 click the "Edit this page" link at the bottom of the page.

--- a/www/cssthumb
+++ b/www/cssthumb
@@ -56,11 +56,11 @@ echo "<style nonce='$nonce'>\n"
                <table width="100%" border=0 cellpadding=0 cellspacing=0>
                   <tr>
                      <td valign=top>
-                        <h3>Download</h3>
+                        <h3>External Links</h3>
                      </td>
                   </tr>
                </table>
-               <i>This is where the download information goes.</i>
+               <i>This is where the external link information goes.</i>
                <table class=downloadlist>
                   <tr valign=top>
                      <td>

--- a/www/editgame
+++ b/www/editgame
@@ -1142,7 +1142,7 @@ for ($i = 0 ; $i < count($fields) ; $i++) {
 // ---------------  time for the download link section ---------------------
 //echo "<tr><td>&nbsp;<br></td></tr>";
 echo "<tr valign=top>
-   <td align=right><b>Download Links:&nbsp;&nbsp;</b></td><td>";
+   <td align=right><b>External Links:&nbsp;&nbsp;</b></td><td>";
 
 global $nonce;
 echo "<style nonce='$nonce'>\n"
@@ -1244,9 +1244,9 @@ function echoGridField($link, $fld, $isFirst = false)
                             linkurl.addEventListener('input', function() {updateFormatUI();})
                         </script>
 
-                        The full URL, linking directly to the downloadable
-                        file. For IF Archive links, use the <b>main</b> Archive
-                        only (http://www.ifarchive.org/if-archive/...) -
+                        The full URL. When linking to a downloadable file, link directly to the downloadable
+                        file, if possible. For IF Archive links, use the <b>main</b> Archive
+                        only (https://ifarchive.org/if-archive/...) -
                         <b>don't</b> link to mirrors.
                      </span>
                   </td>
@@ -1280,7 +1280,7 @@ function echoGridField($link, $fld, $isFirst = false)
                      <textarea name="linkdesc" id="linkdesc"
                                rows=3 cols=60></textarea><br>
                      <span class=details>
-                        A brief description to display in the Download box.
+                        A brief description to display in the External Links box.
                         Optional.
                      </span>
                   </td>
@@ -1631,7 +1631,7 @@ var linkVals = [
 
             <div id="linkGridDiv">
                <noscript>
-                  <i>JavaScript must be enabled to edit the download links.</i>
+                  <i>JavaScript must be enabled to edit the external links.</i>
                </noscript>
             </div>
          </td>

--- a/www/game-rss.php
+++ b/www/game-rss.php
@@ -173,7 +173,7 @@ function getGameRssItems($db, $id, $feedType, $gameTitle, $links, $extFeed)
                 $ldescs = implode("; ", $ldescs);
 
                 // for an external listing, add the game title
-                $ttl = ($extFeed ? "$gameTitle downloads " : $ltitles);
+                $ttl = ($extFeed ? "$gameTitle external links " : $ltitles);
 
                 // build the item XML
                 $item = "<item>"

--- a/www/help-link-policy
+++ b/www/help-link-policy
@@ -2,10 +2,10 @@
 include_once "session-start.php";
 include_once "util.php";
 include_once "pagetpl.php";
-helpPageHeader("Policy for Download Links");
+helpPageHeader("Policy for External Links");
 ?>
 
-<h1>Policy for Download Links</h1>
+<h1>Policy for External Links</h1>
 
 <p>Please link only to <b>legal</b> downloads.  This means that
 the copyright owner must explicitly allow the download.

--- a/www/help-links
+++ b/www/help-links
@@ -6,18 +6,18 @@ include_once "pagetpl.php";
 include_once "dbconnect.php";
 $db = dbConnect();
 
-helpPageHeader("Download Links");
+helpPageHeader("External Links");
 ?>
 
-<h1>Download Links</h1>
+<h1>External Links</h1>
 
-<p><b>URL:</b> Enter the full URL to the downloadable file.
+<p><b>URL:</b> Enter the full URL.
 
 <ul>
 
-   <li>Link directly to the file, rather than to a separate "gateway"
-page.  The "Play Online" button assumes that links lead directly to
-downloadable files.
+   <li>When linking to a downloadable file, link directly to the file,
+rather than to a separate "gateway" page.  The "Play Online" button
+assumes that links lead directly to downloadable files.
 
    <li>If the game's author doesn't allow you to link directly to the
 file, don't add it as a download link; instead, link to the author's
@@ -32,15 +32,15 @@ to the main IF Archive URL.
 </ul>
 
 <p><b>Title:</b> Enter a short title for the link, for display in
-the Download box on the game's page.
+the External Links box on the game's page.
 
 <p><b>Description:</b> If the file's purpose isn't obvious enough
 from the title, you can add a brief description here.
 This is optional.  <b>Don't</b> use this to describe the game itself,
 since that belongs in the main game description.
 
-<p><b>"This is a playable game file":</b> This tells the Download
-Adviser and other tools whether or not this file contains the actual
+<p><b>"This is a playable game file":</b> This tells the "Play Online"
+button and other tools whether or not this file contains the actual
 game program.
 
 <ul>

--- a/www/help-pending-link
+++ b/www/help-pending-link
@@ -2,12 +2,12 @@
 include_once "session-start.php";
 include_once "util.php";
 include_once "pagetpl.php";
-helpPageHeader("Pending Download Links");
+helpPageHeader("Pending External Links");
 ?>
 
-<h1>Pending Download Links</h1>
+<h1>Pending External Links</h1>
 
-<p>The "pending" checkbox for a game download link tells IFDB that the
+<p>The "pending" checkbox for an external link tells IFDB that the
 file isn't available for download yet, but will be soon.  If you check
 this box, IFDB will do two things:
 

--- a/www/home
+++ b/www/home
@@ -78,7 +78,7 @@ if ($debugflag) echo "debug mode enabled...<br>";
 
          <div id="download-advisor-aside" class="column col-sidebar">
             <div class="headline">New to IF?</div>
-            <p>IFDB can help get you up and running with the games you find on IFDB. Just click <img src="img/playonlinebtn.gif" align="absmiddle" alt='The "Play On-line" button'> in any game's Download box to play the game right in your browser.</p>
+            <p>IFDB can help get you up and running with the games you find on IFDB. Just click <img src="img/playonlinebtn.gif" align="absmiddle" alt='The "Play On-line" button'> in any game's External Links box to play the game right in your browser.</p>
          </div>
       </div>
 

--- a/www/viewgame
+++ b/www/viewgame
@@ -835,7 +835,7 @@ echo helpWinLink("help-ifid", "IFID");
               <table width="100%" border=0 cellpadding=0 cellspacing=0>
                  <tr>
                     <td valign=top>
-                       <h3>Download</h3>
+                       <h3>External Links</h3>
                        <?php
 //                           if ($version != "")
 //                               echo "<span class=notes>Version
@@ -1357,7 +1357,7 @@ echo "updatePlaylistCount($playlistCnt); updateWishlistCount($wishlistCnt);"
             <a href="viewgame?id=<?php echo $id ?>&reviews&rss">
                <img src="img/blank.gif" class="rss-icon">New member reviews</a>
             <br><a href="viewgame?id=<?php echo $id ?>&downloads&rss">
-               <img src="img/blank.gif" class="rss-icon">Updates to downloadable files</a>
+               <img src="img/blank.gif" class="rss-icon">Updates to external links</a>
             <br><a href="viewgame?id=<?php echo $id ?>&news&rss">
                <img src="img/blank.gif" class="rss-icon">All updates to this page</a>
          </td>


### PR DESCRIPTION
@brirush84 suggested that we rename the "Downloads" box on IFDB game listings to "External Links."

> Right now, it does kind of look like IFDB is hosting games, because the downloads section looks just like an itch or steam page.
>
> But all links are external anyways, and nowadays a lot of them aren’t for downloads anyway (like steam pages or online walkthroughs).

This PR renames Downloads to External Links.

<img width="1012" alt="image" src="https://github.com/iftechfoundation/ifdb/assets/96150/5d72fa08-ef65-485d-8ed9-4204bb25fcb8">


Changes:

* The `viewgame` box (this is the most important change)
* The `editgame` form (for consistency)
* Help/documentation
    * `/home` says that "Play Online" is in the "External Links" box, not the "Downloads" box"
    * `/contact` Contact Us page, which explains how to fix broken <s>downloads</s> external links
    * `/api/putific` API docs
    * `/help-link-policy`
    * `/help-links`
    * `/help-pending-link`

Not changed:

* The putific API still has a `<downloads>` section; this isn't worth breaking an API over
* There are still (dead?) references to Download Advisor, which we removed in Feb 2022.
* We still have a "Download Notes" section, which affects the "External Links" box. 🤷‍♂️