### PR TITLE
Search by TUID

### DIFF
--- a/www/search
+++ b/www/search
@@ -963,6 +963,11 @@ else {  // ...default is searching games
           echo helpWinLink("help-ifid", "What's an IFID?");
        ?>)
 
+       <p><b>tuid:<i>xxx</i></b> searches for a game with the given TUID.
+       (<?php
+          echo helpWinLink("help-tuid", "What's a TUID?");
+       ?>)
+
         <p><b>authorid:<i>id</i></b> lists games by the author with
             the given id.
 

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -249,6 +249,7 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
             "author:" => array("author", 99),
             "authorid:" => array("authorid", 99),
             "ifid:" => array("/ifid/", 99),
+            "tuid:" => array("/tuid/", 99),
             "downloadable:" => array("/downloadable/", 99),
             "played:" => array("played", 99),
             "willplay:" => array("willplay", 99),
@@ -544,6 +545,10 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
         case 99:
             // special-case handling
             switch ($col) {
+            case '/tuid/':
+                $txt = mysql_real_escape_string($txt, $db);
+                $expr = "games.id = lower('$txt')";
+                break;
             case '/ifid/':
                 // we need to join the IFIDS table for this query
                 if (!isset($extraJoins[$col])) {

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -288,7 +288,7 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
         $baseWhere = "";
         $groupBy = "group by games.id";
         $baseOrderBy = "sort_title";
-        $matchCols = "title, author, `desc`, tags";
+        $matchCols = "games.id, title, author, `desc`, tags";
         $likeCol = "title";
         $summaryDesc = "Games";
     }


### PR DESCRIPTION
Fixes https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/300

The pop-up for searching for games was turning around and running a simple search, so if you paste in a TUID, it didn't work. Now, if you do a simple search for a game's TUID, it'll work. I've also added a `tuid:` operator to search, to only search by TUID, which will guarantee accurate results.