### PR TITLE
PHP 8 fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7-apache
+FROM php:8-apache
 
 RUN docker-php-ext-install mysqli
 RUN apt-get update -y && apt-get install -y zlib1g-dev libpng-dev libjpeg-dev


### PR DESCRIPTION
Initial work on iftechfoundation/ifdb#468.

The site seems to work - I didn't test all features, but browsing around I didn't encounter any problems.

Based on the SQL error, I assume MySQL was also upgraded, so there might be errors in the some of the commands I didn't run.

I ran `php -l` on all the files and fixed the warnings. Some of these commits can be applied to the main (php7) branch as well, if you wish.

Since there's no test suite, is it possible to deploy this on to a test site with some coverage analysis? Or is that too resource-consuming on a live site?