### PR TITLE
Add 'direct link' to reviews authored by logged in user

### DIFF
--- a/www/reviews.php
+++ b/www/reviews.php
@@ -458,7 +458,7 @@ function showReview($db, $gameid, $rec, $specialNames, $optionFlags = 0)
         echo "<div class=smallfoot><span class=details>
                <i>You wrote this review -
                <a href=\"review?id=$gameid&userid=$userid\">Revise it</a></i>
-               $barCommentCtls</span></div>";
+               | <a href=\"viewgame?id=$gameid&review=$reviewid\">Direct link</a> $barCommentCtls</span></div>";
 
     } else if ($specialCode == 'external') {
 

--- a/www/showuser
+++ b/www/showuser
@@ -895,7 +895,7 @@ if ($admin)
 
 
     // add the admin links
-    echo "<a href=\"{$adminUrl}\">Administer user acccount</a><br>";
+    echo "<a href=\"{$adminUrl}\">Administer user account</a><br>";
 }
 
 pageFooter();


### PR DESCRIPTION
Fixes iftechfoundation/ifdb-suggestion-tracker#395.

When a user viewed their own reviews, the "More options" that include some flagging options is removed, but with it is gone the option to get a direct link to the review.

This change adds a "Direct link" where the "More options" would have been.

Note that if there are comments on the view, then the "Direct link" link is right next to a "View comments" link, which leads to the same place (with a `#comments` anchor). Not ideal, but not terrible.