### PR TITLE
Fixes for warnings on "add comment" page

### DIFF
--- a/www/comment.php
+++ b/www/comment.php
@@ -604,7 +604,7 @@ echo helpWinLink("help-formatting?comment#spoilertags", "&lt;SPOILER&gt; tag")
             . "(this is required because "
             . "your user account was created recently; it's to discourage "
             . "spammers from creating new accounts just to post spam "
-            . "comments)</span><br>";
+            . "comments)</i></span><br>";
         captchaSubForm($captchaKey, $captchaErrMsg, "Verify Code");
     }
 

--- a/www/comment.php
+++ b/www/comment.php
@@ -70,8 +70,7 @@ $srcpage = get_req_data('src');
 if (!$srcpage)
     $srcpage = get_req_data('httpreferer');
 if (!$srcpage)
-    $srcpage = $_SERVER['HTTP_REFERER'];
-$srcpageParam = urlencode($srcpage);
+    $srcpage = $_SERVER['HTTP_REFERER'] ?? '';
 
 $errMsg = false;
 $captchaOK = true;
@@ -82,6 +81,10 @@ $succMsg = false;
 // query the reference record
 list($refRec, $refOwner, $refOwnerName, $errFatal, $errMsg) =
     getCommentReference($db, $srcID);
+
+if (!$srcpage)
+    $srcpage = getCommentReferencePage($srcID, $refRec);
+$srcpageParam = urlencode($srcpage);
 
 // if we're replying, fetch the parent
 $parentRow = false;

--- a/www/listcomment
+++ b/www/listcomment
@@ -37,7 +37,7 @@ function getCommentReference($db, $listID)
 
     // return the record, and the list owner ID
     $rec = mysql_fetch_row($result);
-    return array($rec, $rec[3], $rec[4]);
+    return [$rec, $rec[3], $rec[4], false, false];
 }
 
 function showCommentReference($db, $rec)

--- a/www/listcomment
+++ b/www/listcomment
@@ -15,6 +15,10 @@ $srcParamName = "list";
 
 include "comment.php";
 
+function getCommentReferencePage($listID) {
+    return "/viewlist?id=$listID";
+}
+
 function getCommentReference($db, $listID)
 {
     // query the review

--- a/www/pollcomment
+++ b/www/pollcomment
@@ -35,7 +35,7 @@ function getCommentReference($db, $pollID)
 
     // return the full record, plus the poll owner's user ID
     $rec = mysql_fetch_row($result);
-    return array($rec, $rec[3], $rec[4]);
+    return [$rec, $rec[3], $rec[4], false, false];
 }
 
 function showCommentReference($db, $rec)

--- a/www/pollcomment
+++ b/www/pollcomment
@@ -14,6 +14,10 @@ $srcParamName = "poll";
 
 include "comment.php";
 
+function getCommentReferencePage($pollID) {
+    return "/poll?id=$pollID";
+}
+
 function getCommentReference($db, $pollID)
 {
     // query the review

--- a/www/reviewcomment
+++ b/www/reviewcomment
@@ -16,6 +16,11 @@ $srcParamName = "review";
 
 include "comment.php";
 
+function getCommentReferencePage($srcID, $rec) {
+    $gameID = $rec['gameid'];
+    return "/viewgame?id=$gameID&review=$srcID";
+}
+
 function getCommentReference($db, $srcID)
 {
     // query the review

--- a/www/reviewcomment
+++ b/www/reviewcomment
@@ -32,7 +32,7 @@ function getCommentReference($db, $srcID)
 
     // return the record
     $rec = mysql_fetch_array($result, MYSQL_ASSOC);
-    return array($rec, $rec['userid'], $rec['username']);
+    return [$rec, $rec['userid'], $rec['username'], false, false];
 }
 
 function showCommentReference($db, $rec)

--- a/www/usercomment
+++ b/www/usercomment
@@ -27,7 +27,7 @@ function getCommentReference($db, $srcID)
                      "The specified user isn't in the database.");
 
     $rec = mysql_fetch_row($result);
-    return array($rec, $rec[0], $rec[1]);
+    return [$rec, $rec[0], $rec[1], false, false];
 }
 
 function showCommentReference($db, $rec)

--- a/www/usercomment
+++ b/www/usercomment
@@ -14,6 +14,10 @@ $srcParamName = "user";
 
 include "comment.php";
 
+function getCommentReferencePage($srcID) {
+    return "/showuser?id=$srcID";
+}
+
 function getCommentReference($db, $srcID)
 {
     $quid = mysql_real_escape_string($srcID, $db);


### PR DESCRIPTION
1. There was a warning about the return value of `getCommentReference`, since it sometimes returned an array with 3 values (no error), or 5 values (error). Now it always returns 5.
2. When the "add comment" page was loaded by URL, instead of by browsing from another page, it malfunctioned. It uses the referrer page to fill various "Return to previous page" links. When there was no referrer, those links were empty `href=""`. Now it returns the user to the canonical page of the item they are commenting on.
3. Added missing `</i>`.