### PR TITLE
Replace "what is a wiki" links

### DIFF
--- a/www/contact
+++ b/www/contact
@@ -27,7 +27,7 @@ problems.
 <p>If you catch an error in a game listing (a typo, factual
 inaccuracy, etc), there's no need to send us email.  Instead, please
 take advantage of IFDB's community-edited,
-<a href="http://wiki.org/wiki.cgi?WhatIsWiki">Wiki</a>-like design and
+<a href="https://en.wikipedia.org/wiki/Wiki">Wiki</a>-like design and
 make the correction yourself.  This is the best way to keep IFDB
 accurate and up-to-date, since it avoids the inevitable delay of
 involving a site administrator in every change.

--- a/www/tips
+++ b/www/tips
@@ -9,7 +9,7 @@ pageHeader("Tips on Using IFDB", false);
 
 <p>First, it's a comprehensive catalog of IF, past and present.  IFDB
 is a collaborative, community project - it's a little like a <a
-href="http://wiki.org/wiki.cgi?WhatIsWiki">Wiki</a> for IF
+href="https://en.wikipedia.org/wiki/Wiki">Wiki</a> for IF
 bibliography.  Members can edit the game listings in the catalog, and
 even add new listings, so you never have to wait for the site's
 administrators to get around to adding the latest releases or fixing


### PR DESCRIPTION
The main wiki at http://wiki.org/ isn't online, and I found no news about it, so for now the links can point to Wikipedia's explanation of the term "Wiki".