### PR TITLE
Remove LIKE clauses from fulltext search, to reactivate fulltext index

### DIFF
--- a/sql/patch-schema-2.sql
+++ b/sql/patch-schema-2.sql
@@ -117,3 +117,8 @@ call refresh_gameRatingsSandbox0_mv(NEW.gameid);
 CREATE TRIGGER reviews_delete
 AFTER DELETE ON reviews FOR EACH ROW
 call refresh_gameRatingsSandbox0_mv(OLD.gameid);
+
+alter table ifids
+    add column lower_ifid varchar(64) COLLATE latin1_german2_ci as (lower(ifid)) VIRTUAL,
+    add key lower_ifid (`lower_ifid`)
+;

--- a/www/editgame-util.php
+++ b/www/editgame-util.php
@@ -453,7 +453,7 @@ function saveUpdates($db, $adminPriv, $apiMode,
 
                 // make sure this IFIDs isn't used by any other game
                 $result = mysqli_execute_query($db, "select gameid from ifids
-                    where ifid = ?", [strtolower($ifid)]);
+                    where lower_ifid = ?", [strtolower($ifid)]);
                 if ($result && mysql_num_rows($result) > 0) {
                     $otherid = mysql_result($result, 0, "gameid");
                     if ($id != $otherid) {

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -444,7 +444,7 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
         $likeExpr .= ")";
 
         // build the full expression
-        $expr = "($matchMode ($matchExpr or $likeExpr))";
+        $expr = "$matchMode $matchExpr";
 
         // add the exact matches for &#xxxx; phrases
         if ($exacts) {

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -574,7 +574,7 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
                 // match to the given IFID, but ignoring case
                 $txt = mysql_real_escape_string($txt, $db);
                 if ($txt != "")
-                    $expr = "lower(ifids.ifid) = lower('$txt')";
+                    $expr = "lower_ifid = lower('$txt')";
                 else
                     $expr = "ifids.ifid is null";
                 break;

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -296,7 +296,7 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
             $tableList = "games
                           left join ".getGameRatingsView($db)." on games.id = gameid";
         }
-        $matchCols = "games.id, title, author, `desc`, tags";
+        $matchCols = "title, author, `desc`, tags";
         $likeCol = "title";
         $summaryDesc = "Games";
     }


### PR DESCRIPTION
Fixes https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/404

My naive implementation of implicit TUID search caused a performance issue, and it was never working with implicit IFID searches anyway, https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/300

Now we're using a fast mechanism for implicitly searching by TUID and IFID for one-word searches, and letting the `match` query match exactly.

Intuitively, it really seems like this ought to have broken something… but, as far as I can tell, all the searches seem to behave exactly the same as before. I'm not sure I understand why yet.

I explained my approach here: https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/404#issuecomment-1874844579

> Starting with the `game-ratings-materialized-view` branch, I tried a simple search for Zork `http://localhost:8080/search?searchbar=Zork`.
> 
> It ran this query:
> 
> ```sql
> select
>     games.id as id,
>     games.title as title,
>     games.author as author,
>     games.tags as tags,
>     games.moddate as moddate,
>     games.system as devsys,
>     if (time(games.published) = '00:00:00',
>         date_format(games.published, '%Y'),
>         date_format(games.published, '%M %e, %Y'))
>         as pubfmt,
>     if (time(games.published) = '00:00:00',
>         date_format(games.published, '%Y'),
>         date_format(games.published, '%Y-%m-%d'))
>         as published,
>     date_format(games.published, '%Y') as pubyear,
>     (games.coverart is not null) as hasart,
>     avgRating as avgrating,
>     numRatingsInAvg as ratingcnt,
>     stdDevRating as ratingdev,
>     numRatingsTotal,
>     numMemberReviews,
>     games.sort_title as sort_title,
>     games.sort_author as sort_author,
>     ifnull(games.published, '9999-12-31') as sort_pub,
>     games.flags
>     , match (title, author, `desc`, tags) against ('Zork' in boolean mode) as relevance
> from
>     games
>     left join gameRatingsSandbox0_mv on games.id = gameid
> where
>     ( (match (title, author, `desc`, tags) against ('Zork' in boolean mode) or (title like 'Zork'  or ( title like '%Zork%'))))
> 
> order by
>     if(title = 'Zork',0,1),if(title like 'Zork%',0,1),if((title like 'Zork'  or ( title like '%Zork%')),0,1),relevance desc
>     
> limit 0, 20;
> ```
> 
> When I `analyze` that query, it says that it considered using the fulltext indexes, but decided against it.
> 
> ```
> +------+-------------+------------------------+--------+---------------+---------+---------+---------------+-------+----------+----------+------------+----------------------------------------------+
> | id   | select_type | table                  | type   | possible_keys | key     | key_len | ref           | rows  | r_rows   | filtered | r_filtered | Extra                                        |
> +------+-------------+------------------------+--------+---------------+---------+---------+---------------+-------+----------+----------+------------+----------------------------------------------+
> |    1 | SIMPLE      | games                  | ALL    | title_2,title | NULL    | NULL    | NULL          | 13007 | 13007.00 |   100.00 |       0.52 | Using where; Using temporary; Using filesort |
> |    1 | SIMPLE      | gameRatingsSandbox0_mv | eq_ref | PRIMARY       | PRIMARY | 34      | ifdb.games.id | 1     | 0.91     |   100.00 |     100.00 |                                              |
> +------+-------------+------------------------+--------+---------------+---------+---------+---------------+-------+----------+----------+------------+----------------------------------------------+
> ```
> 
> I believe this is happening because of the `LIKE` parts of the `WHERE` clause. When I go to `searchutil.php` and look at line 446:
> 
> ```
> $expr = "($matchMode ($matchExpr or $likeExpr))";
> ```
> 
> … and replace that line with:
> 
> ```
> $expr = "($matchMode ($matchExpr))";
> ```
> 
> It then generates a query without the `LIKE` clauses:
> 
> ```sql
> select
>     games.id as id,
>     games.title as title,
>     games.author as author,
>     games.tags as tags,
>     games.moddate as moddate,
>     games.system as devsys,
>     if (time(games.published) = '00:00:00',
>         date_format(games.published, '%Y'),
>         date_format(games.published, '%M %e, %Y'))
>         as pubfmt,
>     if (time(games.published) = '00:00:00',
>         date_format(games.published, '%Y'),
>         date_format(games.published, '%Y-%m-%d'))
>         as published,
>     date_format(games.published, '%Y') as pubyear,
>     (games.coverart is not null) as hasart,
>     avgRating as avgrating,
>     numRatingsInAvg as ratingcnt,
>     stdDevRating as ratingdev,
>     numRatingsTotal,
>     numMemberReviews,
>     games.sort_title as sort_title,
>     games.sort_author as sort_author,
>     ifnull(games.published, '9999-12-31') as sort_pub,
>     games.flags
>     , match (title, author, `desc`, tags) against ('Zork' in boolean mode) as relevance
> from
>     games
>     left join gameRatingsSandbox0_mv on games.id = gameid
> where
>     ( (match (title, author, `desc`, tags) against ('Zork' in boolean mode)))
> 
> order by
>     if(title = 'Zork',0,1),if(title like 'Zork%',0,1),if((title like 'Zork'  or ( title like '%Zork%')),0,1),relevance desc
>     
> limit 0, 20;
> ```
> 
> … and that query is using the `fulltext` index when I `ANALYZE` it.
> 
> ```
> +------+-------------+------------------------+----------+---------------+---------+---------+---------------+------+--------+----------+------------+----------------------------------------------+
> | id   | select_type | table                  | type     | possible_keys | key     | key_len | ref           | rows | r_rows | filtered | r_filtered | Extra                                        |
> +------+-------------+------------------------+----------+---------------+---------+---------+---------------+------+--------+----------+------------+----------------------------------------------+
> |    1 | SIMPLE      | games                  | fulltext | title         | title   | 0       |               | 1    | 68.00  |   100.00 |     100.00 | Using where; Using temporary; Using filesort |
> |    1 | SIMPLE      | gameRatingsSandbox0_mv | eq_ref   | PRIMARY       | PRIMARY | 34      | ifdb.games.id | 1    | 0.91   |   100.00 |     100.00 |                                              |
> +------+-------------+------------------------+----------+---------------+---------+---------+---------------+------+--------+----------+------------+----------------------------------------------+
> ```
> 
> Now, what's really confusing about that is that I would have therefore expected _different results_ when removing the `LIKE` clause, but, to my surprise, it _didn't_ change anything in the results.
> 
> I thought that maybe a search for `ounterfeit Monkey` without the C would trigger different results, but, no, Counterfeit Monkey returned right at the top; the results seem identical to the results we'd get from including the `LIKE` clause.
