### PR TITLE
Fix tag negation search

### DIFF
--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -551,7 +551,13 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
             break;
         case 5:
             // tags
-            $tagsToMatch[] = $txt;
+            if ($negate) {
+                $expr = "tags rlike '[[:<:]]"
+                    . mysql_real_escape_string(quoteSqlRLike($txt), $db)
+                    . "[[:>:]]'";
+            } else {
+                $tagsToMatch[] = $txt;
+            }
             break;
         case 99:
             // special-case handling


### PR DESCRIPTION
Fixes https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/426

The problem happened at line 814:

```php
if ($negate)
        $expr = " NOT ($expr)";
```

But when using tag search, we would forgo setting `$expr`, instead populating a join. For positive tag search, this would add a harmless `AND 1` to the query, but for negative tag search, this would add `AND NOT(1)` which never matches anything.

I want to fix this fast, so I'm just rolling back to handling this query the old-fashioned way for now.