### PR TITLE
Remove implicit search by IFID

### DIFF
--- a/www/gamesearchpopup.php
+++ b/www/gamesearchpopup.php
@@ -197,8 +197,7 @@ function gameSearchPopupDiv()
           </div>
        </div>
        <div class="edit-popup-win">
-          <p><b>Step 1:</b> Search for a game by title, <?php
-              echo helpWinLink("help-ifid", "IFID") ?>, or <?php
+          <p><b>Step 1:</b> Search for a game by title or <?php
               echo helpWinLink("help-tuid", "TUID") ?>:
           <br>
           <input id="gameSearchPopupSearchBox" type=text size=50>

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -1023,9 +1023,9 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
 
     $logging_level = 0;
 
-    // in game searches, implicitly match by TUID and IFID with an early query
+    // in game searches, implicitly match by TUID with an early query
     if ($searchType == "game" && count($words) == 1 && count($extraJoins) == 0) {
-        $sql = "select games.id as gameid from games where games.id = ? union all select gameid from ifids where lower_ifid=lower(?)";
+        $sql = "select games.id as gameid from games where games.id = ?";
         if ($logging_level) {
             error_log($sql);
             error_log($words[0]);


### PR DESCRIPTION
We added implicit search by IFID in https://github.com/iftechfoundation/ifdb/pull/276 to fix https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/300 ("Can't select game by TUID or IFID when editing Cross-References ")

But this caused https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/439 and https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/433

IMO, implicit search by IFID just isn't worth it, especially when implicit search by TUID works great.

There are a few places that do support implicit search by TUID and IFID still, including polls and "Suggest Similar Games" at  `/crossrec`. They still work fine, and I'm not going to bother to rip anything out there. 

(BTW, note the difference between "cross-recommendations", which is for "similar games", and "cross-references", which is for games that are formally related to each other in an enumerated way: adaptations, ports, sequels, translations, etc.)