### PR TITLE
Don't try to insert a blank IFID

### DIFF
--- a/www/editgame-util.php
+++ b/www/editgame-util.php
@@ -1551,6 +1551,7 @@ function saveOldGame($db, $adminPriv, $apiMode,
         $ifids = $changesNew['ifids'];
         for ($i = 0 ; $i < count($ifids) ; $i++) {
             if ($result) {
+                if ($ifids[$i] == '') continue;
                 $progress = "IIF070F.$i";
                 $ifid = mysql_real_escape_string(strtoupper($ifids[$i]), $db);
                 $result = mysql_query("insert into ifids


### PR DESCRIPTION
Fixes https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/442

(When deploying, I'll also need to manually remove the blank IFID from the production database.)

```
delete from ifids where ifid='';
```