### PR TITLE
Revert "Add fulltext index for author search"

### DIFF
--- a/sql/patch-schema-2.sql
+++ b/sql/patch-schema-2.sql
@@ -20,8 +20,6 @@ truncate table userScores_mv;
 insert into userScores_mv select *, now() from userScores;
 unlock tables;
 
-alter table games add fulltext key `author` (`author`);
-
 alter table reviews
     add column `embargopastdate` date DEFAULT NULL,
     add key `embargodate` (`embargodate`),

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -668,9 +668,9 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
                 $or = "";
                 foreach ($nameList as $n) {
                     // look for this exact name embedded in the author field
-                    $expr .= "$or match (author) against ('"
+                    $expr .= "$or author like '%"
                              . mysql_real_escape_string(quoteSqlLike($n), $db)
-                             . "') ";
+                             . "%' ";
 
                     // get the sorting version of the name - LAST, SUFFIX,
                     // FIRST, MIDDLE, and split into an array


### PR DESCRIPTION
This reverts https://github.com/iftechfoundation/ifdb/pull/277, which caused https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/436

With the benefit of hindsight, nobody should have trusted that #277 did what it was supposed to do, because it doesn't include the results of before/after `analyze`. It turns out that it didn't fix https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/406 at all; instead, it just caused https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/436, for no performance benefit.

This fixes https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/436 but does not address https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/168 which is also about author search relevance.

Before reverting:
```sql
select sql_calc_found_rows
    games.id as id,
    games.title as title,
    games.author as author,
    games.tags as tags,
    games.moddate as moddate,
    games.system as devsys,
    if (time(games.published) = '00:00:00',
        date_format(games.published, '%Y'),
        date_format(games.published, '%M %e, %Y'))
        as pubfmt,
    if (time(games.published) = '00:00:00',
        date_format(games.published, '%Y'),
        date_format(games.published, '%Y-%m-%d'))
        as published,
    date_format(games.published, '%Y') as pubyear,
    (games.coverart is not null) as hasart,
    avgRating as avgrating,
    numRatingsInAvg as ratingcnt,
    stdDevRating as ratingdev,
    numRatingsTotal,
    numMemberReviews,
    games.sort_title as sort_title,
    games.sort_author as sort_author,
    ifnull(games.published, '9999-12-31') as sort_pub,
    games.flags
    
from
    games
                left join gameRatingsSandbox0_mv on games.id = gameid
    
where
    ( match (author) against ('Emily Ryan')  or author rlike '[[:<:]]E.*[[:space:]]+Ryan[[:>:]]')
    


order by
    starsort desc
    
limit 0, 20;
```

```
+------+-------------+------------------------+--------+---------------+---------+---------+---------------+-------+----------+----------+------------+----------------------------------------------+
| id   | select_type | table                  | type   | possible_keys | key     | key_len | ref           | rows  | r_rows   | filtered | r_filtered | Extra                                        |
+------+-------------+------------------------+--------+---------------+---------+---------+---------------+-------+----------+----------+------------+----------------------------------------------+
|    1 | SIMPLE      | games                  | ALL    | NULL          | NULL    | NULL    | NULL          | 12987 | 12987.00 |   100.00 |       1.00 | Using where; Using temporary; Using filesort |
|    1 | SIMPLE      | gameRatingsSandbox0_mv | eq_ref | PRIMARY       | PRIMARY | 34      | ifdb.games.id | 1     | 0.91     |   100.00 |     100.00 |                                              |
+------+-------------+------------------------+--------+---------------+---------+---------+---------------+-------+----------+----------+------------+----------------------------------------------+
```

After reverting, the query says:
```sql
select sql_calc_found_rows
    games.id as id,
    games.title as title,
    games.author as author,
    games.tags as tags,
    games.moddate as moddate,
    games.system as devsys,
    if (time(games.published) = '00:00:00',
        date_format(games.published, '%Y'),
        date_format(games.published, '%M %e, %Y'))
        as pubfmt,
    if (time(games.published) = '00:00:00',
        date_format(games.published, '%Y'),
        date_format(games.published, '%Y-%m-%d'))
        as published,
    date_format(games.published, '%Y') as pubyear,
    (games.coverart is not null) as hasart,
    avgRating as avgrating,
    numRatingsInAvg as ratingcnt,
    stdDevRating as ratingdev,
    numRatingsTotal,
    numMemberReviews,
    games.sort_title as sort_title,
    games.sort_author as sort_author,
    ifnull(games.published, '9999-12-31') as sort_pub,
    games.flags
    
from
    games
                left join gameRatingsSandbox0_mv on games.id = gameid
    
where
    ( author like '%Emily Ryan%'  or author rlike '[[:<:]]E.*[[:space:]]+Ryan[[:>:]]')
    


order by
    starsort desc
    
limit 0, 20;
```

```
+------+-------------+------------------------+--------+---------------+---------+---------+---------------+-------+----------+----------+------------+----------------------------------------------+
| id   | select_type | table                  | type   | possible_keys | key     | key_len | ref           | rows  | r_rows   | filtered | r_filtered | Extra                                        |
+------+-------------+------------------------+--------+---------------+---------+---------+---------------+-------+----------+----------+------------+----------------------------------------------+
|    1 | SIMPLE      | games                  | ALL    | NULL          | NULL    | NULL    | NULL          | 12987 | 12987.00 |   100.00 |       0.01 | Using where; Using temporary; Using filesort |
|    1 | SIMPLE      | gameRatingsSandbox0_mv | eq_ref | PRIMARY       | PRIMARY | 34      | ifdb.games.id | 1     | 1.00     |   100.00 |     100.00 |                                              |
+------+-------------+------------------------+--------+---------------+---------+---------+---------------+-------+----------+----------+------------+----------------------------------------------+
```

So we can see that the performance is no better or worse, but https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/436 is fixed, so that's good enough for me.