### PR TITLE
Allow fulltext searches for small words.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   db:
     image: mariadb:10
-    command: mysqld --sql_mode="" --ft_stopword_file=""
+    command: mysqld --sql_mode="" --ft_stopword_file="" --ft_min_word_len=1
     volumes:
       - ./initdb:/docker-entrypoint-initdb.d
     environment:


### PR DESCRIPTION
Fixes https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/446

You'll probably have to `./prepare_dev_environment.sh && docker compose down && docker compose up --build` to force Docker to notice this and start working.

Searches for "six" work now, as well list searches for "top 100"