### PR TITLE
Convert ifarchive URLs to HTTPS

### DIFF
--- a/www/api/index
+++ b/www/api/index
@@ -47,9 +47,9 @@ requests to throttle the rate.
 <p>If the application you have in mind doesn't need live data, note
 that full exports of the IFDB SQL database (minus users' personal
 information) are available on the
-<a href="http://www.ifarchive.org/">IF Archive</a> in the
+<a href="https://www.ifarchive.org/">IF Archive</a> in the
 <a
-href="http://ifarchive.org/indexes/if-archiveXinfoXifdb.html">info/ifdb</a>
+href="https://ifarchive.org/indexes/if-archiveXinfoXifdb.html">info/ifdb</a>
 directory.  You can use these exports to create local copies of the
 database for more computation-intensive analysis, without using any network
 bandwidth and without creating any load on the IFDB servers.  The

--- a/www/api/putific
+++ b/www/api/putific
@@ -28,7 +28,7 @@ update the IFDB listing for the game.  This would save the user the
 trouble of re-entering the project metadata via the IFDB web form.
 
 <p>The metadata format used in the putific API is iFiction, the XML
-format defined by the <a href="http://babel.ifarchive.org/">Treaty of
+format defined by the <a href="https://babel.ifarchive.org/">Treaty of
 Babel</a> specification.  iFiction is the obvious format for our
 purposes here, since it was was specifically designed for metadata
 interchange among sites like IFDB and the IF Archive, tools such as an

--- a/www/api/viewgame
+++ b/www/api/viewgame
@@ -8,7 +8,7 @@ apiPageHeader("viewgame");
 ?>
 
 <p>The viewgame API lets applications retrieve IFDB's listing data for
-a game in the <a href="http://babel.ifarchive.org/">Treaty of
+a game in the <a href="https://babel.ifarchive.org/">Treaty of
 Babel</a>'s iFiction XML format.
 
 <h2>Identifying a game</h2>

--- a/www/help-formatting
+++ b/www/help-formatting
@@ -34,7 +34,7 @@ reader clicks a button saying they want to see it.
 <p><b>&lt;P&gt;</b> - paragraph break: shows a blank line between the paragraphs.
 
 <p><b>&lt;BR/&gt;</b> - paragraph break (this is provided so that you can
-   copy text from an <a href="http://babel.ifarchive.org">iFiction</a>
+   copy text from an <a href="https://babel.ifarchive.org">iFiction</a>
    XML file - the iFiction format uses &lt;BR/&gt; for paragraph breaks)
 
 <p><b>&lt;A GAME="<i>tuid</i>"&gt; ... &lt;/A&gt;</b> - hyperlink the text

--- a/www/help-ifid
+++ b/www/help-ifid
@@ -12,7 +12,7 @@ serial number that's assigned to each work of Interactive Fiction.
 Each work has its own unique IFID, giving players, authors, and
 archivists a universal, unambiguous way to refer to a given game.
 It's the same idea as the ISBN system for books.  The IFID system is
-defined by the <a href="http://babel.ifarchive.org">Treaty of
+defined by the <a href="https://babel.ifarchive.org">Treaty of
 Babel</a>, which was created in 2006.
 
 <h2>How do I determine a game's IFID?</h2>
@@ -25,7 +25,7 @@ the technical details.
 
 <p>If you're not the author, there are software tools that can find
 the IFID for a given story file.  The
-<a href="http://babel.ifarchive.org">Treaty of Babel</a> site has a
+<a href="https://babel.ifarchive.org">Treaty of Babel</a> site has a
 free, portable program that does this.  Some author systems also
 include built-in IFID extraction tools (for example, in TADS Workbench
 on Windows, the <b>Tools &gt; Read IFID From...</b> command can

--- a/www/help-license-type
+++ b/www/help-license-type
@@ -16,7 +16,7 @@ categories:
 allows you to use without charge.  There might be some restrictions;
 for example, users might not be allowed to modify the software.  This
 is the most common license type for games in the <a
-href="http://www.ifarchive.org">IF Archive</a>.
+href="https://www.ifarchive.org">IF Archive</a>.
 
 <p><b>Public Domain:</b> The author has explicitly renounced all
 rights to the software, allowing anyone to use it or modify it in any

--- a/www/help-link-policy
+++ b/www/help-link-policy
@@ -24,7 +24,7 @@ help ensure that the site can continue operating.
 
 <p>It's always acceptable to link to sites that maintain and enforce
 similar policies of diligent copyright compliance, such as the <a
-href="http://www.ifarchive.org">IF Archive</a>.
+href="https://www.ifarchive.org">IF Archive</a>.
 
 <?php
 helpPageFooter();

--- a/www/help-links
+++ b/www/help-links
@@ -24,7 +24,7 @@ file, don't add it as a download link; instead, link to the author's
 site via the Web Site field on the game's main page.
 
    <li>For files stored at the IF Archive, link to the <b>main</b> IF
-Archive site (http://www.ifarchive.org/...), <b>not</b> to a mirror.
+Archive site (https://www.ifarchive.org/...), <b>not</b> to a mirror.
 IFDB will automatically substitute a mirror site based on the user's
 preferences, but it can only do this with links that start off pointing
 to the main IF Archive URL.

--- a/www/ifarchive-pending
+++ b/www/ifarchive-pending
@@ -5,7 +5,7 @@ pageHeader("File Pending Review")
 
 <h1>File Pending Review</h1>
 
-This file has been uploaded to the <a href="http://www.ifarchive.org">IF
+This file has been uploaded to the <a href="https://www.ifarchive.org">IF
 Archive</a> and is still pending review.  Please allow a couple of days
 for the Archive to review the file.  If it's been more than a week or
 so and this file is still showing as "pending", you might want to contact

--- a/www/ifarchive-upload
+++ b/www/ifarchive-upload
@@ -135,7 +135,7 @@ function setArchivePath(fmt, typ)
 <h1>Upload to the IF Archive</h1>
 </div>
 
-<p>This form uploads to the <a target="_blank" href="http://www.ifarchive.org/">IF
+<p>This form uploads to the <a target="_blank" href="https://www.ifarchive.org/">IF
 Archive</a> (ifarchive.org).  IFDB itself doesn't host any uploaded
 game files.  ifarchive.org is the leading repository of current and
 historical IF works, so most authors of new works like to upload their
@@ -147,7 +147,7 @@ games there, to reach players and for historical preservation.</p>
 
    <li>Be aware that your file will be uploaded the ifarchive.org, <b>not</b> IFDB.
 
-   <li>You must read and agree to the <a target="_blank" href="http://ifarchive.org/misc/license.html">IF Archive Terms of Use</a>
+   <li>You must read and agree to the <a target="_blank" href="https://ifarchive.org/misc/license.html">IF Archive Terms of Use</a>
    before uploading.
 
    <li>Your file won't be available for download until an Archive maintainer
@@ -293,7 +293,7 @@ uploadForm.addEventListener('submit', function (event) {
 
   <tr><td align=right>Agreement:</td><td>&nbsp;</td>
      <td><input type="checkbox" name="tos">I agree to the
-        <a target="_blank" href="http://www.ifarchive.org/misc/license.html">IF Archive Terms of Use</a>
+        <a target="_blank" href="https://www.ifarchive.org/misc/license.html">IF Archive Terms of Use</a>
      </td></tr>
 
  <tr><td>&nbsp;</td><td>&nbsp;</td><td>


### PR DESCRIPTION
I did a grep for `"http://.*ifarchive"`

Only two hits remain.

1. an `xmlns` reference in `viewgame`. I believe this is supposed to remain `http` because `xmlns` values only look like URLs; they're unique ID strings, not meant to be clicked on
2. `bafs-file-order`, which I've filed a PR to delete in #297 