### PR TITLE
Send TUID to IF Archive

### DIFF
--- a/www/editgame
+++ b/www/editgame
@@ -1480,17 +1480,15 @@ foreach ($linkfmts as $lf) {
 
 function uploadWindow()
 {
-    var title = document.getElementById("title").value;
-    var devsys = document.getElementById("system").value;
-    var license = document.getElementById("license").value;
-    var author = document.getElementById("eAuthor").value;
-    var version = document.getElementById("version").value;
-    window.open("ifarchive-upload?"
-                + "title=" + encodeURIComponent(title)
-                + "&system=" + encodeURIComponent(devsys)
-                + "&license=" + encodeURIComponent(license)
-                + "&author=" + encodeURIComponent(author)
-                + "&version=" + encodeURIComponent(version));
+    var tuid = new URLSearchParams(window.location.search).get('id');
+    var params = new URLSearchParams();
+    params.set("title", document.getElementById("title").value);
+    params.set("system", document.getElementById("system").value);
+    params.set("license", document.getElementById("license").value);
+    params.set("author", document.getElementById("eAuthor").value);
+    params.set("version", document.getElementById("version").value);
+    if (tuid) params.set("tuid", tuid);
+    window.open("ifarchive-upload?" + params.toString());
 }
 
 function submitUpload(id, fname, fmtid, osid, compression, pri)

--- a/www/ifarchive-upload
+++ b/www/ifarchive-upload
@@ -210,6 +210,14 @@ uploadForm.addEventListener('submit', function (event) {
 </script>
 
  <input type="hidden" name="ifdbid" value="<?php echo $uploadID ?>"/>
+ <?php
+ $tuid = $_GET['tuid'] ?? null;
+ if ($tuid && $tuid != "new") {
+    ?>
+    <input type="hidden" name="tuid" value="<?= htmlspecialcharx($tuid) ?>"/>
+    <?php
+ }
+ ?>
 
 <table border="0" cellspacing="5">
   <tr><td align=right>Filename:</td><td>&nbsp;</td>


### PR DESCRIPTION
Fixes https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/449

Now, if possible, we'll add a `tuid` parameter to the request to https://upload.ifarchive.org/cgi-bin/upload.py

There are some catches.

1. If you navigate directly to https://ifdb.org/ifarchive-upload then we won't send a `tuid` parameter. We will send an `ifdbid` "temp ID" parameter. (But it's almost certainly going to be useless, because it won't be associated with a pending link.)

2. Similarly, if you're creating a new game at <https://ifdb.org/editgame?id=new>, as opposed to editing a game, we won't send a TUID in that case, either. Hopefully the user will save the game listing, including the `ifarchive-pending` link, and the "Notify IFDB" button will work anyway.