### PR TITLE
ifarchive-commit: Create games_history entry when updating url

### DIFF
--- a/www/ifarchive-commit
+++ b/www/ifarchive-commit
@@ -7,10 +7,13 @@ include_once "dbconnect.php";
 try {
     $db = dbConnect();
 
-    $id = get_req_data("ifdbid");
+    $ifdbid = get_req_data("ifdbid");
     $newPath = get_req_data("path");
-    $oldUrl = "https://ifdb.org/ifarchive-pending?ifdbid=$id";
     $apiKey = get_req_data("key");
+
+    $oldUrl = "https://ifdb.org/ifarchive-pending?ifdbid=$ifdbid";
+
+    $ifarchive_userid = "ix4vb4m6daiyrayh"; // IF Archive Team
 
     // remove any leading '/' in the path
     $newPath = preg_replace("/^\/+/", "", $newPath);
@@ -30,13 +33,58 @@ try {
     if (mysql_num_rows($result) == 0)
         throw new Exception("Error: no link found to this pending URL");
 
+    $rec = mysqli_fetch_array($result, MYSQL_ASSOC);
+    $gameid = $rec['gameid'];
+
+    // gather previous data for games_history
+    $result = mysqli_execute_query($db,
+        "select pagevsn, editedby, moddate from games
+         where id = ?", [$gameid]);
+
+    if (!$result) throw new Exception("Error: database games query failed: " . mysqli_error($db));
+
+    $rec = mysqli_fetch_array($result, MYSQL_ASSOC);
+    if (!$rec) throw new Exception("Error: database games query returned no results: " . mysqli_error($db));
+    $old_pagevsn = $rec['pagevsn'];
+    $old_editedby = $rec['editedby'];
+    $old_moddate = $rec['moddate'];
+
+    // gather old links for games_history
+    $result = mysqli_execute_query($db,
+            "select
+               url, title, `desc`, attrs, fmtid, osid, osvsn,
+               compression, compressedprimary, displayorder
+            from gamelinks
+            where gameid = ?
+            order by displayorder", [$gameid]
+    );
+    if (!$result) throw new Exception("Error: database gamelinks query failed: " . mysqli_error($db));
+    $rows = mysqli_num_rows($result);
+    $links = [];
+    for ($i = 0 ; $i < $rows ; $i++)
+        $links[$i] = mysqli_fetch_array($result, MYSQL_ASSOC);
+    $deltas = ["links" => $links];
+
     $result = mysqli_execute_query($db,
         "update gamelinks
          set attrs = attrs & ~".GAMELINK_PENDING.", url=?
          where url=?", [$newUrl, $oldUrl]
     );
-    
-    if (!$result) throw new Exception("Error: database update failed: " . mysqli_error($db));
+
+    if (!$result) throw new Exception("Error: database gamelinks update failed: " . mysqli_error($db));
+
+    // each history record saves the old values for the columns edited in the *following* version
+    $result = mysqli_execute_query($db,
+        "insert into games_history (id, editedby, moddate, pagevsn, deltas) values (?, ?, ?, ?, ?)",
+        [$gameid, $old_editedby, $old_moddate, $old_pagevsn, serialize($deltas)]);
+
+    if (!$result) throw new Exception("Error: database games_history insert failed: " . mysqli_error($db));
+
+    $result = mysqli_execute_query($db,
+        "update games set pagevsn = ?, editedby = ?, moddate = now() where id = ?",
+        [($old_pagevsn+1), $ifarchive_userid, $gameid]);
+
+    if (!$result) throw new Exception("Error: database games update failed: " . mysqli_error($db));
 
     header("Content-type: text/plain");
     echo "OK";

--- a/www/ifarchive-commit
+++ b/www/ifarchive-commit
@@ -7,8 +7,8 @@ include_once "dbconnect.php";
 try {
     $db = dbConnect();
 
-    $id = mysql_real_escape_string(get_req_data("ifdbid"), $db);
-    $newPath = mysql_real_escape_string(get_req_data("path"), $db);
+    $id = get_req_data("ifdbid");
+    $newPath = get_req_data("path");
     $oldUrl = "https://ifdb.org/ifarchive-pending?ifdbid=$id";
     $apiKey = get_req_data("key");
 
@@ -21,17 +21,20 @@ try {
     if ($apiKey != localIfArchiveKey())
         throw new Exception("Error: invalid API key");
 
-    $result = mysql_query(
+    $result = mysqli_execute_query($db,
         "select gameid from gamelinks
-        where url = '$oldUrl'", $db);
+         where url = ?", [$oldUrl]);
+
+    if (!$result) throw new Exception("Error: database gamelinks url query failed: " . mysqli_error($db));
 
     if (mysql_num_rows($result) == 0)
         throw new Exception("Error: no link found to this pending URL");
 
-    $result = mysql_query(
+    $result = mysqli_execute_query($db,
         "update gamelinks
-        set attrs = attrs & ~".GAMELINK_PENDING.", url='$newUrl'
-        where url='$oldUrl'", $db);
+         set attrs = attrs & ~".GAMELINK_PENDING.", url=?
+         where url=?", [$newUrl, $oldUrl]
+    );
     
     if (!$result) throw new Exception("Error: database update failed: " . mysqli_error($db));
 

--- a/www/ifarchive-commit
+++ b/www/ifarchive-commit
@@ -4,39 +4,44 @@ include_once "util.php";
 include_once "pagetpl.php";
 include_once "dbconnect.php";
 
-header("Content-type: text/plain");
+try {
+    $db = dbConnect();
 
-$db = dbConnect();
+    $id = mysql_real_escape_string(get_req_data("ifdbid"), $db);
+    $newPath = mysql_real_escape_string(get_req_data("path"), $db);
+    $oldUrl = "https://ifdb.org/ifarchive-pending?ifdbid=$id";
+    $apiKey = get_req_data("key");
 
-$id = mysql_real_escape_string(get_req_data("ifdbid"), $db);
-$newPath = mysql_real_escape_string(get_req_data("path"), $db);
-$oldUrl = "https://ifdb.org/ifarchive-pending?ifdbid=$id";
-$apiKey = get_req_data("key");
+    // remove any leading '/' in the path
+    $newPath = preg_replace("/^\/+/", "", $newPath);
 
-// remove any leading '/' in the path
-$newPath = preg_replace("/^\/+/", "", $newPath);
+    // figure the new URL based on the relative path on the Archive
+    $newUrl = "https://www.ifarchive.org/$newPath";
 
-// figure the new URL based on the relative path on the Archive
-$newUrl = "https://www.ifarchive.org/$newPath";
+    if ($apiKey != localIfArchiveKey())
+        throw new Exception("Error: invalid API key");
 
-if ($apiKey != localIfArchiveKey())
-    die("Error: invalid API key");
+    $result = mysql_query(
+        "select gameid from gamelinks
+        where url = '$oldUrl'", $db);
 
-$result = mysql_query(
-    "select gameid from gamelinks
-     where url = '$oldUrl'", $db);
+    if (mysql_num_rows($result) == 0)
+        throw new Exception("Error: no link found to this pending URL");
 
-if (mysql_num_rows($result) == 0)
-    die("Error: no link found to this pending URL");
+    $result = mysql_query(
+        "update gamelinks
+        set attrs = attrs & ~".GAMELINK_PENDING.", url='$newUrl'
+        where url='$oldUrl'", $db);
+    
+    if (!$result) throw new Exception("Error: database update failed: " . mysqli_error($db));
 
-$result = mysql_query(
-    "update gamelinks
-     set attrs = attrs & ~".GAMELINK_PENDING.", url='$newUrl'
-     where url='$oldUrl'", $db);
-
-if ($result)
+    header("Content-type: text/plain");
     echo "OK";
-else
-    die("Error: database update failed: " . mysql_error($db));
+} catch (Exception $e) {
+    error_log($e);
+    http_response_code(500);
+    header("Content-type: text/plain");
+    echo $e->getMessage();
+}
 
 ?>

--- a/www/util.php
+++ b/www/util.php
@@ -84,7 +84,14 @@ function mysqli_execute_query(mysqli $mysqli, string $sql, array $params = null)
     return false;  
   }
 
-  return $stmt->get_result();  
+  $result = $stmt->get_result();
+  // $stmt->get_result() returns false on successful INSERT/UPDATE statements
+  // https://www.php.net/manual/en/mysqli-stmt.get-result.php#refsect1-mysqli-stmt.get-result-returnvalues
+  if ($result === false && !$stmt->errno) {
+    return true;
+  } else {
+    return $result;
+  }
 }
 }
 


### PR DESCRIPTION
Fixes https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/397

I also ported the code to use the `mysqli_execute_query` polyfill (which exposed a bug in the polyfill, which I fixed).

I tested this with TUID 4qfjt6y5pkan2220 (Crystal and Stone, Beetle and Bone).

It has a pending IF Archive link `csbbr4.z8` pointing to `https://ifdb.org/ifarchive-pending?ifdbid=451vzcr3se2vmapo`

So, I was able to locally test it like this:

```
curl "http://localhost:8080/ifarchive-commit?ifdbid=451vzcr3se2vmapo&path=/if-archive/games/zcode/csbb.z8&key="
```

Note that the IF Archive sends us three parameters:

* `ifdbid`: This is the ID of the pending link, _not_ the game's TUID
* `path`: The actual path of the file on the IF Archive
* `key`: A secret key. Using a blank key works for local testing, because the `local-credentials.php.template` uses a blank string for `localIfArchiveKey()`.

See [How IFDB's IF Archive Uploader Works](https://docs.google.com/document/d/1EY4Hs6bPjKg_U-nczs0oP1DqTKv4UPkKnLr0NZ4FqZw/edit) for more details.