### PR TITLE
Add frame-ancestors CSP rule to prevent clickjacking

### DIFF
--- a/www/csp-nonce.php
+++ b/www/csp-nonce.php
@@ -34,4 +34,5 @@ header("Content-Security-Policy: "
     ."default-src 'self' ifdb.org www.google.com 'nonce-$nonce'; "
     ."script-src 'self' ifdb.org www.google.com 'nonce-$nonce'; "
     ."style-src 'self' ifdb.org 'nonce-$nonce'; "
+    ."frame-ancestors 'self'; "
 );

--- a/www/csp-nonce.php
+++ b/www/csp-nonce.php
@@ -30,4 +30,8 @@ global $nonce;
 $nonce = random_str(8);
 
 // default-src should be enough, but Firefox ESR 102 doesn't support `default-src nonce`, only `style-src nonce` and `script-src nonce`.
-header("Content-Security-Policy: default-src 'self' ifdb.org www.google.com 'nonce-$nonce'; script-src 'self' ifdb.org www.google.com 'nonce-$nonce'; style-src 'self' ifdb.org 'nonce-$nonce';");
+header("Content-Security-Policy: "
+    ."default-src 'self' ifdb.org www.google.com 'nonce-$nonce'; "
+    ."script-src 'self' ifdb.org www.google.com 'nonce-$nonce'; "
+    ."style-src 'self' ifdb.org 'nonce-$nonce'; "
+);


### PR DESCRIPTION
We received a report via email that ifdb.org can be accessed as an iframe on third-party sites, and that this could make IFDB vulnerable to a clickjacking attack.

https://owasp.org/www-community/attacks/Clickjacking

No clear demonstration of a harmful clickjack was demonstrated. I think it would actually be rather challenging to pull off a real clickjacking attack, since our login cookies use `SameSite=Lax`.

But since AFAIK we don't intend anyone to put an IFDB page in an iframe, so we should probably just block iframing; adding the extra protection probably won't hurt anything, and it might help.