### PR TITLE
Add a maximum password length to prevent DoS attacks

### DIFF
--- a/www/changepsw
+++ b/www/changepsw
@@ -68,6 +68,11 @@ function verify() {
                 six characters long.";
             return true;
         }
+        $max_password_length = MAX_PASSWORD_LENGTH;
+        if (strlen($psw) > $max_password_length) {
+            $errFlagged = "Your password is too long - please use no more than $max_password_length characters.";
+            return true;
+        }
         if (strcmp($psw, $psw2) != 0) {
             $errFlagged = "Password mismatch - you must enter the
                 <b>identical</b> password two times to ensure that you

--- a/www/login-check.php
+++ b/www/login-check.php
@@ -96,6 +96,11 @@ function redirect_to_login_page()
 //
 function doLogin($db, $username, $password)
 {
+    if (strlen($password) > MAX_PASSWORD_LENGTH) {
+        return array(false, "incorrect username or password",
+            "The password is too long. If this is your password, please reset it by using the \"Lost Password\" page.");
+    }
+
     // set up a quoted version of the user ID
     $quid = mysql_real_escape_string($username, $db);
 

--- a/www/newuser
+++ b/www/newuser
@@ -323,6 +323,13 @@ function handlePost()
         return true;
     }
 
+    $max_password_length = MAX_PASSWORD_LENGTH;
+
+    if (strlen($psw) > $max_password_length) {
+        $errFlagged = "Your password is too long - please use no more than $max_password_length characters.";
+        return true;
+    }
+
     // set up the database connection
     $db = dbConnect();
     if ($db == false)

--- a/www/resetpsw
+++ b/www/resetpsw
@@ -83,6 +83,11 @@ function verify() {
                 six characters long.";
             return true;
         }
+        $max_password_length = MAX_PASSWORD_LENGTH;
+        if (strlen($psw) > $max_password_length) {
+            $errFlagged = "Your password is too long - please use no more than $max_password_length characters.";
+            return true;
+        }
         if (strcmp($psw, $psw2) != 0) {
             $errFlagged = "Password mismatch - you must enter the
                 <b>identical</b> password two times to ensure that you

--- a/www/util.php
+++ b/www/util.php
@@ -88,6 +88,11 @@ function mysqli_execute_query(mysqli $mysqli, string $sql, array $params = null)
 }
 }
 
+// https://cheatsheetseries.owasp.org/cheatsheets/Authentication_Cheat_Sheet.html#implement-proper-password-strength-controls
+// "It is important to set a maximum password length to prevent long password Denial of Service attacks."
+// https://www.acunetix.com/vulnerabilities/web/long-password-denial-of-service/
+define("MAX_PASSWORD_LENGTH", 1024);
+
 // --------------------------------------------------------------------------
 //
 // Terms of Service version number


### PR DESCRIPTION
We received a report via email that we're vulnerable to a long-password Denial of Service attack.

https://www.acunetix.com/vulnerabilities/web/long-password-denial-of-service/

The idea is: you can try to login with a _huge_ password, forcing us to waste our CPU trying to hash that password. (In a long-password DoS attack, you don't even have to successfully submit the long password; it wastes our memory and CPU just to hash a long password, to check if it matches the hash we keep in the database.)

The reporter was able to submit a password 84 kilobytes long, which honestly probably isn't that bad, especially considering that we still need to fix this https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/11 but it doesn't hurt to address this now.

Note that if there are any users who currently legitimately have a password longer than 1024 characters, their password will be "falsely" rejected, but they'll be able to fix the problem by using the "Lost Password" page to reset their password.