### PR TITLE
Add hover styling to donation button

### DIFF
--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -1093,6 +1093,11 @@ div.footer {
     padding: 8px 10px;
     color: white;
     font-weight: bold;
+    cursor: pointer;
+}
+
+.iftf-donation .Donate:hover {
+    background-color: #b45620;
 }
 
 /*


### PR DESCRIPTION
@erkyrath wrote:

>  I’d recommend adding `cursor: pointer;` to the CSS for the button. The link feels unresponsive without that.

… I didn't actually do that, in this case, I just added a darker background to the hover state, but I'm open to discussing it.

I didn't add `cursor: pointer` because this a button, not a link. When you click it, it issues a POST action to PayPal, which you're not supposed to refresh.

By default, HTML buttons don't have `cursor: pointer`. When you hover them, they get a little darker. `cursor: pointer` was designed for underlined links, to make it clear to users that the text is _clickable_. 

<img width="218" src="https://github.com/user-attachments/assets/ab584903-ffda-4191-8aca-1f79b83efc6d">

https://medium.com/simple-human/buttons-shouldnt-have-a-hand-cursor-b11e99ca374b
> Buttons shouldn't have a hand cursor.
