### PR TITLE
Remove donation ad from IFDB home page

### DIFF
--- a/www/home
+++ b/www/home
@@ -45,20 +45,6 @@ if ($debugflag) echo "debug mode enabled...<br>";
 
          <p>The Interactive Fiction Database is an IF game catalog and recommendation engine. IFDB is a Wiki-style community project: members can add new game listings, write reviews, exchange game recommendations, and more. <span class=details><a href="tips">Tips & More Info</a></span><p>
 
-         <div class="iftf-donation details">
-            <div>
-               <a href="http://iftechfoundation.org/"><img class="iftf invert" alt="Interactive Fiction technology Foundation" src="/img/iftf-logo.svg"></a>
-            </div>
-            <div>
-               IFDB is managed by the <a href="http://iftechfoundation.org/">Interactive Fiction Technology Foundation</a>.
-               It is funded by <a href="http://iftechfoundation.org/give/">the donations of IF supporters like you</a>.
-               All donations go to support the operation of this web site and IFTF's other services.
-               <form action="https://www.paypal.com/donate" method="post" target="_top">
-                  <input type="hidden" name="hosted_button_id" value="2CZJEA3PXM3QS" />
-                  <input class="Donate" type="submit" value="Donate with PayPal">
-               </form>
-            </div>
-         </div>
       </div>
 
       <?php include "components/check-inbox.php"?>


### PR DESCRIPTION
Not sure if we want to do this, but folks are complaining that the donation ad is too prominent on the home page, and this is the easiest way to fix that.

(The donation ad would still appear in the footer on all pages, including the home page.)