### PR TITLE
Don't collapse reviews unless calling page specifically requests it

### DIFF
--- a/www/reviews.php
+++ b/www/reviews.php
@@ -249,6 +249,7 @@ define("SHOWREVIEW_NOVOTECTLS", 0x0001);
 define("SHOWREVIEW_NOCOMMENTCTLS", 0x0002);
 define("SHOWREVIEW_COMMENTCTLSADDONLY", 0x0004);
 define("SHOWREVIEW_ADMINREVIEWVOTESLINK", 0x0008);
+define("SHOWREVIEW_COLLAPSELONG", 0x0010);
 
 function showReview($db, $gameid, $rec, $specialNames, $optionFlags = 0)
 {
@@ -259,6 +260,7 @@ function showReview($db, $gameid, $rec, $specialNames, $optionFlags = 0)
     $showCommentCtls = !($optionFlags & SHOWREVIEW_NOCOMMENTCTLS);
     $addCommentOnly = ($optionFlags & SHOWREVIEW_COMMENTCTLSADDONLY);
     $adminReviewVotes = ($optionFlags & SHOWREVIEW_ADMINREVIEWVOTESLINK);
+    $collapseLong = ($optionFlags & SHOWREVIEW_COLLAPSELONG);
 
     // get the current user, if we're logged in
     checkPersistentLogin();
@@ -406,10 +408,14 @@ function showReview($db, $gameid, $rec, $specialNames, $optionFlags = 0)
     }
 
     // show the review body
-    global $nonce;
-    echo "<style nonce='$nonce'>.review__body { max-width: 60ch; }</style>"
-        ."<div class=\"readMore review__body\" ><p>$review</p>"
-        .'<div class="expand"><button>Read More</button></div></div>';
+    if ($collapseLong) {
+        global $nonce;
+        echo "<style nonce='$nonce'>.review__body { max-width: 60ch; }</style>"
+            ."<div class=\"readMore review__body\" ><p>$review</p>"
+            .'<div class="expand"><button>Read More</button></div></div>';
+    } else {
+        echo "<div class=\"review__body\" ><p>$review</p></div>";
+    }
 
     // set up the comment controls, if applicable
     $commentCtls = $barCommentCtl = "";

--- a/www/viewgame
+++ b/www/viewgame
@@ -1990,7 +1990,7 @@ mouseOutRating(<?php echo $currentUserRating ?>);
             // show the reviews
             for ($i = 0 ; $i < mysql_num_rows($result) ; $i++)
                 showReview($db, $id, mysql_fetch_array($result, MYSQL_ASSOC),
-                           $specialNames, 0 | ($adminPriv ? SHOWREVIEW_ADMINREVIEWVOTESLINK : 0));
+                           $specialNames, SHOWREVIEW_COLLAPSELONG | ($adminPriv ? SHOWREVIEW_ADMINREVIEWVOTESLINK : 0));
         }
 
         // end the indented division if we started one
@@ -2031,7 +2031,7 @@ mouseOutRating(<?php echo $currentUserRating ?>);
                 $reviewRec = mysql_fetch_array($result, MYSQL_ASSOC);
 
                 // show it
-                showReview($db, $id, $reviewRec, $specialNames, 0 | ($adminPriv ? SHOWREVIEW_ADMINREVIEWVOTESLINK : 0));
+                showReview($db, $id, $reviewRec, $specialNames, SHOWREVIEW_COLLAPSELONG | ($adminPriv ? SHOWREVIEW_ADMINREVIEWVOTESLINK : 0));
             }
 
             // show the link to the full list of reviews, if there are more


### PR DESCRIPTION
Fixes https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/470

When adding "Read More" collapsed reviews on the `/viewgame` page, we caused reviews to be collapsed on all pages, including the single-review page, the "all reviews" page for a game, the "all reviews" page for a user, etc. etc.

Now, we only collapse reviews when the calling page requests it.

(Currently, the calling page is responsible for displaying and wiring up the Read More buttons in `<script>` in `$extraHead`. That seems fine to me, because I don't anticipate using this feature much, but we can move that code down into `reviews.php` if/when we decide to make it reusable on other pages.)