### PR TITLE
Hide sandboxed poll votes on /viewgame and /allpolls

### DIFF
--- a/www/allpolls
+++ b/www/allpolls
@@ -47,7 +47,7 @@ if ($gameid) {
 
     // search the database for polls that include this game
     $extraCols = ", sum(v.gameid = '$qgameid') as gameVoteCount";
-    $whereList = "1";
+    $whereList = "not uv.sandbox";
     $having = "having gameVoteCount > 0";
 
 } else {
@@ -117,6 +117,7 @@ if ($errMsg) {
             polls as p
             left outer join pollvotes as v on v.pollid = p.pollid
             join users as u on u.id = p.userid
+            join users as uv on uv.id = v.userid
         where $whereList
         group by p.pollid
         $having

--- a/www/viewgame
+++ b/www/viewgame
@@ -1042,8 +1042,10 @@ if (!isEmpty($genre)) {
                polls as p
                join pollvotes as v on v.pollid = p.pollid
                join users as u on u.id = p.userid
+               join users as uv on uv.id = v.userid
              where
                v.gameid = ?
+               and not uv.sandbox
              group by
                p.pollid
              order by


### PR DESCRIPTION
Poll pages already hide votes from sandboxed users (see PR #175: Sandbox polls). However, game pages still list polls on the basis of these hidden votes. This pull request adds code to check voters' sandbox status before counting their votes on `/viewgame` and `/allpolls`.

(Tested by sandboxing the test user, since actual sandboxed users don't seem to exist in the backup database. To test on the actual site, visit https://ifdb.org/allpolls?game=xf5y04yekcrqtnc — you should see 17 rather than 20 polls, and should not see the polls [Misunderstood Games](https://ifdb.org/poll?id=3ikdo4u713yn7v4y), [For Your Consideration - XYZZY-eligible writing of 2015 - an IFDB Poll](https://ifdb.org/poll?id=6kzcn5on2kkxh73t), or [For Your Consideration - XYZZY-eligible implementations of 2015 - an IFDB Poll](https://ifdb.org/poll?id=rkbr78f45acqnzv2).)