### PR TITLE
Fix poll news on home page

### DIFF
--- a/www/newitems.php
+++ b/www/newitems.php
@@ -109,7 +109,7 @@ function getNewItems($db, $limit)
            left outer join pollvotes as v on v.pollid = p.pollid
            join users as u on u.id = p.userid
          where
-           users.sandbox in $sandbox
+           u.sandbox in $sandbox
            $anp
          group by
            p.pollid


### PR DESCRIPTION
The home page is supposed to list new polls in the "New on IFDB" section, but the query always failed, because the `users` table is aliased as `u`.