### PR TITLE
Fix minor typo (issue #479)

### DIFF
--- a/www/viewgame
+++ b/www/viewgame
@@ -1783,6 +1783,7 @@ if (!$should_hide) {
         if ($wishlistCnt != 1) {
             echo "s";
         }
+		echo ".";
         echo "</a></div>";
     }
 }


### PR DESCRIPTION
> On a game page, "N members have played this game." ends in a period, and "It's on N wishlists" does not.
> 
> Example: https://ifdb.org/viewgame?id=op0uw1gn1tjqmjt7

Added a period so we can look at the second sentence without twitching. =]