### PR TITLE
Hide sandboxed users' reclists (fixes #400)

### DIFF
--- a/www/alllists
+++ b/www/alllists
@@ -31,6 +31,16 @@ $sortList = array(
     'nm' => array('l.title', 'By List Name'));
 
 // look up the game or user record
+// Exclude lists from the sandbox
+$sandbox = "not u.sandbox";
+if ($curuser)
+{
+    // get my sandbox
+    $mysandbox = 0;
+    $result = mysql_query("select sandbox from users where id='$curuser'", $db);
+    list($mysandbox) = mysql_fetch_row($result);
+    if ($mysandbox != 0) $sandbox = "1";
+}
 if ($gameid) {
     $result = mysql_query(
         "select title from games where id='$qgameid'", $db);
@@ -86,8 +96,11 @@ if ($errMsg) {
     // count up how many lists we have total
     $result = mysql_query(
         "select count(*) as c
-         from reclists as l $joinList
-         where $whereList", $db);
+         from reclists as l, users as u $joinList
+         where
+            u.id = l.userid
+            and $whereList
+            and $sandbox", $db);
     $lstcnt = mysql_result($result, 0, "c");
 
     if ($pg == 'all') {
@@ -124,6 +137,7 @@ if ($errMsg) {
             reclistitems.listid = l.id
             and u.id = l.userid
             and $whereList
+            and $sandbox
         group by reclistitems.listid
         order by {$ord[0]}
         limit $firstOnPage," . $perPage, $db);

--- a/www/viewgame
+++ b/www/viewgame
@@ -1512,7 +1512,12 @@ if (!isEmpty($genre)) {
         // look for lists containing this game
         $params = [$id];
         $sortMeLast = "";
+        $sandbox = "not users.sandbox";
         if ($curuser) {
+			$mysandbox = 0;
+            $result = mysql_query("select sandbox from users where id='$curuser'", $db);
+            list($mysandbox) = mysql_fetch_row($result);
+            if ($mysandbox != 0) $sandbox = "1";
             $sortMeLast = "if(reclists.userid = ?, 2, 1),";
             $params[] = $curuser;
         }
@@ -1531,6 +1536,7 @@ if (!isEmpty($genre)) {
                 reclistitems.gameid = ?
                 and reclists.id = reclistitems.listid
                 and users.id = reclists.userid
+				and $sandbox
              group by reclistitems.listid
              order by $sortMeLast rand()
              limit 0, 4", $params);


### PR DESCRIPTION
This pull request hides sandboxed users' lists from both /viewgame and /alllists pages, unless logged in as a sandboxed user. (This includes the "All Recommended Lists by [User]" version of /alllists — sandboxed users will appear to have no lists.)

Fixes iftechfoundation/ifdb-suggestion-tracker#400.