### PR TITLE
Fix float-clearing bug

### DIFF
--- a/www/viewgame
+++ b/www/viewgame
@@ -873,7 +873,7 @@ echo helpWinLink("help-ifid", "IFID");
 
 ?>
 <style nonce="<?php global $nonce; echo $nonce; ?>">
-    .viewgame__mainSummary { margin: 0; padding: 0; order: -1; }
+    .viewgame__mainSummary { margin: 0; padding: 0; order: -1; display: flow-root; }
     @media (max-width: 60rem) {
         #viewgame-body {
             display: flex;

--- a/www/viewgame
+++ b/www/viewgame
@@ -1472,18 +1472,18 @@ if (!isEmpty($genre)) {
                                 if ($playOnlineButton) {
                                     echo "<div class=\"viewgame__externalLinksDiv\"><span class='viewgame__externalLinksAnchor'>$playOnlineButton | </span>"
                                         . "<a href=\"".htmlspecialcharx($website)."\">Web Site</a>"
-                                        . "<span class='viewgame__externalLinksAnchor'> | <a href='#externalLinksTable'>External Links</span></div>";
+                                        . "<span class='viewgame__externalLinksAnchor'> | <a href='#externalLinksTable'>External Links</a></span></div>";
                                 } else {
-                                    echo "<div class=\"viewgame__externalLinksDiv\"><a href=\"".htmlspecialcharx($website)."\">Web Site</a><span class='viewgame__externalLinksAnchor'> | <a href='#externalLinksTable'>External Links</span></div>";
+                                    echo "<div class=\"viewgame__externalLinksDiv\"><a href=\"".htmlspecialcharx($website)."\">Web Site</a><span class='viewgame__externalLinksAnchor'> | <a href='#externalLinksTable'>External Links</a></span></div>";
                                 }
                             } else if (!isEmpty($website)) {
                                 echo "<div><a href=\"".htmlspecialcharx($website)."\">Web Site</a></div>";
                             } else {
                                 if ($playOnlineButton) {
                                     echo "<div class='viewgame__externalLinksAnchor viewgame__externalLinksDiv'>$playOnlineButton | "
-                                        . "<a href='#externalLinksTable'>External Links</div>";
+                                        . "<a href='#externalLinksTable'>External Links</a></div>";
                                 } else {
-                                    echo "<a class='viewgame__externalLinksAnchor viewgame__externalLinksDiv' href='#externalLinksTable'>External Links</div>";
+                                    echo "<a class='viewgame__externalLinksAnchor viewgame__externalLinksDiv' href='#externalLinksTable'>External Links</a></div>";
                                 }
                             }                        }
                      ?>


### PR DESCRIPTION
Fixes https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/491

In #331, I removed what I _thought_ was an "unnecessary" table, with just one row and one cell.

But the table _did_ serve a purpose that I didn't realize at the time: it created a [block formatting context](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_flow_layout/Introduction_to_formatting_contexts).

When the `externalLinksDiv` went to `clear: both`, when the table was there, it would only clear the `coverart`, but when we removed the table, it would also attempt to clear the External Links div, which could be arbitrarily long, creating a huge empty space on the page.

Adding `display: flow-root` to the `mainSummary` fixes the issue.

I've tested this on Counterfeit Monkey, Anchorhead, Uninteractive Fiction, and [Cold Iron](https://ifdb.org/viewgame?id=x8ohk12d1a6f12ge).

I missed this in #331 because I'd only tested Uninteractive Fiction and Counterfeit Monkey, but CM doesn't have a Website and so it didn't have an `externalLinksDiv` on desktop screen sizes, so it didn't trigger this bug. Anchorhead does, and so does Cold Iron (which is the case where the bug was first reported to me).

This bug is so bad that I think I'm going to merge the fix without review, but I invite you to take a look after the fact!