### PR TITLE
Add games with no ratings/reviews to gameRatingsSandbox0 view

### DIFF
--- a/sql/patch-schema.sql
+++ b/sql/patch-schema.sql
@@ -429,12 +429,13 @@ from (
         from (
             select count(`ifdb`.`reviews`.`id`) AS `count`,
               `ifdb`.`reviews`.`rating` AS `rating`,
-              `ifdb`.`reviews`.`gameid` AS `gameid`,
+              `ifdb`.`games`.`id` AS `gameid`,
               ifnull(`ifdb`.`reviews`.`RFlags`, 0) & 2 AS `omitted`,
               `ifdb`.`reviews`.`review` is not null AS `hasReview`
             from (
-                `ifdb`.`reviews`
-                left join `ifdb`.`users` on(`ifdb`.`reviews`.`userid` = `ifdb`.`users`.`id`)
+                `ifdb`.`games`
+                left outer join `ifdb`.`reviews` on (`ifdb`.`games`.`id` = `ifdb`.`reviews`.`gameid`)
+                left outer join `ifdb`.`users` on(`ifdb`.`reviews`.`userid` = `ifdb`.`users`.`id`)
               )
             where ifnull(`ifdb`.`users`.`Sandbox`, 0) = 0
               and ifnull(
@@ -443,7 +444,7 @@ from (
               )
               and `ifdb`.`reviews`.`special` is null
             group by `ifdb`.`reviews`.`rating`,
-              `ifdb`.`reviews`.`gameid`,
+              `ifdb`.`games`.`id`,
               ifnull(`ifdb`.`reviews`.`RFlags`, 0) & 2,
               ifnull(
                 `ifdb`.`reviews`.`special`,
@@ -595,12 +596,13 @@ from (
         from (
             select count(`ifdb`.`reviews`.`id`) AS `count`,
               `ifdb`.`reviews`.`rating` AS `rating`,
-              `ifdb`.`reviews`.`gameid` AS `gameid`,
+              `ifdb`.`games`.`id` AS `gameid`,
               ifnull(`ifdb`.`reviews`.`RFlags`, 0) & 2 AS `omitted`,
               `ifdb`.`reviews`.`review` is not null AS `hasReview`
             from (
-                `ifdb`.`reviews`
-                left join `ifdb`.`users` on(`ifdb`.`reviews`.`userid` = `ifdb`.`users`.`id`)
+                `ifdb`.`games`
+                left outer join `ifdb`.`reviews` on (`ifdb`.`games`.`id` = `ifdb`.`reviews`.`gameid`)
+                left outer join `ifdb`.`users` on(`ifdb`.`reviews`.`userid` = `ifdb`.`users`.`id`)
               )
             where ifnull(`ifdb`.`users`.`Sandbox`, 0) in (0, 1)
               and ifnull(
@@ -609,7 +611,7 @@ from (
               )
               and `ifdb`.`reviews`.`special` is null
             group by `ifdb`.`reviews`.`rating`,
-              `ifdb`.`reviews`.`gameid`,
+              `ifdb`.`games`.`id`,
               ifnull(`ifdb`.`reviews`.`RFlags`, 0) & 2,
               ifnull(
                 `ifdb`.`reviews`.`special`,


### PR DESCRIPTION
Searches for `#reviews:N` are powered by the `gameRatingsSandbox0` view, but it was being populated based on the `reviews` table, so it omitted all games with no rows in the `reviews` table.

(Technically the `gameRatingsSandbox0` view is what we use to generate the `gameRatingsSandbox0_mv` materialized view, which is refreshed based on a trigger. We use `gameRatingsSandbox0_mv` for actual user searches.)

The updated query starts with the `games` table and does an outer join to `reviews`, so games with no reviews will show up in the results as 0 `numMemberReviews` and 0 `numRatingsTotal`.

```
MariaDB [ifdb]> select * from gameRatingsSandbox0_mv where gameid='twh3dc70ff2o6wdk' \G
*************************** 1. row ***************************
          gameid: twh3dc70ff2o6wdk
          rated1: 0
          rated2: 0
          rated3: 0
          rated4: 0
          rated5: 0
 numRatingsInAvg: 0
 numRatingsTotal: 0
numMemberReviews: 0
       avgRating: NULL
    stdDevRating: NULL
        starsort: 2.0473720558371173
         updated: 2024-09-24
1 row in set (0.001 sec)
```

Fixes https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/294