### PR TITLE
Add `reviewed:yes` and `rated:yes` filters

### DIFF
--- a/www/search
+++ b/www/search
@@ -983,6 +983,14 @@ else {  // ...default is searching games
             you have/haven't put on your "won't play" list (i.e. "I'm not interested").
             Only works if you are logged in with a user account.
 
+        <p><b>reviewed:<i>yes</i>|<i>no</i></b> lists games that
+            you have/haven't reviewed (with a written review).
+            Only works if you are logged in with a user account.
+
+       <p><b>rated:<i>yes</i>|<i>no</i></b> lists games that
+            you have/haven't rated (with a star rating).
+            Only works if you are logged in with a user account.
+
        </div>
 
        <?php echo $commonPostInstructions ?>

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -254,6 +254,8 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
             "played:" => array("played", 99),
             "willplay:" => array("willplay", 99),
             "wontplay:" => array("wontplay", 99),
+            "reviewed:" => array("reviewed", 99),
+            "rated:" => array("rated", 99),
             "license:" => array("license", 0),
             "format:" => array("/gameformat/", 99));
 
@@ -656,6 +658,42 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
                     // we need yes=not-null/no=null game ids
                     $op = (preg_match("/^y.*/i", $txt) ? "is not" : "is");
                     $expr = "ul.gameid $op null";
+                }
+                break;
+
+            case 'reviewed':
+                // Only use this query when the user is logged in
+                if ($curuser) {
+                    // need to join the reviews table to do this query
+                    if (!isset($extraJoins[$col])) {
+                        $extraJoins[$col] = true;
+                        $tableList .= " left join reviews as reviewed "
+                                      . "on games.id = reviewed.gameid "
+                                      . "and reviewed.review is not null "
+                                      . "and reviewed.userid = '$curuser'";
+                    }
+
+                    // we need yes=not-null/no=null game ids
+                    $op = (preg_match("/^y.*/i", $txt) ? "is not" : "is");
+                    $expr = "reviewed.gameid $op null";
+                }
+                break;
+
+            case 'rated':
+                // Only use this query when the user is logged in
+                if ($curuser) {
+                    // need to join the reviews table to do this query
+                    if (!isset($extraJoins[$col])) {
+                        $extraJoins[$col] = true;
+                        $tableList .= " left join reviews as rated "
+                                      . "on games.id = rated.gameid "
+                                      . "and rated.rating is not null "
+                                      . "and rated.userid = '$curuser'";
+                    }
+
+                    // we need yes=not-null/no=null game ids
+                    $op = (preg_match("/^y.*/i", $txt) ? "is not" : "is");
+                    $expr = "rated.gameid $op null";
                 }
                 break;
 

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -612,89 +612,94 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
 
             case 'played':
                 // Only use this query when the user is logged in
-                if ($curuser) {
-                    // need to join the playedgames table to do this query
-                    if (!isset($extraJoins[$col])) {
-                        $extraJoins[$col] = true;
-                        $tableList .= " left join playedgames as pg "
-                                      . "on games.id = pg.gameid "
-                                      . "and pg.userid = '$curuser'";
-                    }
-
-                    // we need yes=not-null/no=null game ids
-                    $op = (preg_match("/^y.*/i", $txt) ? "is not" : "is");
-                    $expr = "pg.gameid $op null";
+                if (!$curuser) {
+                    break;
                 }
+                // need to join the playedgames table to do this query
+                if (!isset($extraJoins[$col])) {
+                    $extraJoins[$col] = true;
+                    $tableList .= " left join playedgames as pg "
+                                    . "on games.id = pg.gameid "
+                                    . "and pg.userid = '$curuser'";
+                }
+
+                // we need yes=not-null/no=null game ids
+                $op = (preg_match("/^y.*/i", $txt) ? "is not" : "is");
+                $expr = "pg.gameid $op null";
                 break;
 
             case 'willplay':
                 // Only use this query when the user is logged in
-                if ($curuser) {
-                    // need to join the wishlists table to do this query
-                    if (!isset($extraJoins[$col])) {
-                        $extraJoins[$col] = true;
-                        $tableList .= " left join wishlists as wl "
-                                      . "on games.id = wl.gameid "
-                                      . "and wl.userid = '$curuser'";
-                    }
-
-                    // we need yes=not-null/no=null game ids
-                    $op = (preg_match("/^y.*/i", $txt) ? "is not" : "is");
-                    $expr = "wl.gameid $op null";
+                if (!$curuser) {
+                    break;
                 }
+                // need to join the wishlists table to do this query
+                if (!isset($extraJoins[$col])) {
+                    $extraJoins[$col] = true;
+                    $tableList .= " left join wishlists as wl "
+                                  . "on games.id = wl.gameid "
+                                  . "and wl.userid = '$curuser'";
+                }
+
+                // we need yes=not-null/no=null game ids
+                $op = (preg_match("/^y.*/i", $txt) ? "is not" : "is");
+                $expr = "wl.gameid $op null";
                 break;
 
             case 'wontplay':
                 // Only use this query when the user is logged in
-                if ($curuser) {
-                    // need to join the unwishlists table to do this query
-                    if (!isset($extraJoins[$col])) {
-                        $extraJoins[$col] = true;
-                        $tableList .= " left join unwishlists as ul "
-                                      . "on games.id = ul.gameid "
-                                      . "and ul.userid = '$curuser'";
-                    }
-
-                    // we need yes=not-null/no=null game ids
-                    $op = (preg_match("/^y.*/i", $txt) ? "is not" : "is");
-                    $expr = "ul.gameid $op null";
+                if (!$curuser) {
+                    break;
                 }
+                // need to join the unwishlists table to do this query
+                if (!isset($extraJoins[$col])) {
+                    $extraJoins[$col] = true;
+                    $tableList .= " left join unwishlists as ul "
+                                  . "on games.id = ul.gameid "
+                                  . "and ul.userid = '$curuser'";
+                }
+
+                // we need yes=not-null/no=null game ids
+                $op = (preg_match("/^y.*/i", $txt) ? "is not" : "is");
+                $expr = "ul.gameid $op null";
                 break;
 
             case 'reviewed':
                 // Only use this query when the user is logged in
-                if ($curuser) {
-                    // need to join the reviews table to do this query
-                    if (!isset($extraJoins[$col])) {
-                        $extraJoins[$col] = true;
-                        $tableList .= " left join reviews as reviewed "
-                                      . "on games.id = reviewed.gameid "
-                                      . "and reviewed.review is not null "
-                                      . "and reviewed.userid = '$curuser'";
-                    }
-
-                    // we need yes=not-null/no=null game ids
-                    $op = (preg_match("/^y.*/i", $txt) ? "is not" : "is");
-                    $expr = "reviewed.gameid $op null";
+                if (!$curuser) {
+                    break;
                 }
+                // need to join the reviews table to do this query
+                if (!isset($extraJoins[$col])) {
+                    $extraJoins[$col] = true;
+                    $tableList .= " left join reviews as reviewed "
+                                  . "on games.id = reviewed.gameid "
+                                  . "and reviewed.review is not null "
+                                  . "and reviewed.userid = '$curuser'";
+                }
+
+                // we need yes=not-null/no=null game ids
+                $op = (preg_match("/^y.*/i", $txt) ? "is not" : "is");
+                $expr = "reviewed.gameid $op null";
                 break;
 
             case 'rated':
                 // Only use this query when the user is logged in
-                if ($curuser) {
-                    // need to join the reviews table to do this query
-                    if (!isset($extraJoins[$col])) {
-                        $extraJoins[$col] = true;
-                        $tableList .= " left join reviews as rated "
-                                      . "on games.id = rated.gameid "
-                                      . "and rated.rating is not null "
-                                      . "and rated.userid = '$curuser'";
-                    }
-
-                    // we need yes=not-null/no=null game ids
-                    $op = (preg_match("/^y.*/i", $txt) ? "is not" : "is");
-                    $expr = "rated.gameid $op null";
+                if (!$curuser) {
+                    break;
                 }
+                // need to join the reviews table to do this query
+                if (!isset($extraJoins[$col])) {
+                    $extraJoins[$col] = true;
+                    $tableList .= " left join reviews as rated "
+                                  . "on games.id = rated.gameid "
+                                  . "and rated.rating is not null "
+                                  . "and rated.userid = '$curuser'";
+                }
+
+                // we need yes=not-null/no=null game ids
+                $op = (preg_match("/^y.*/i", $txt) ? "is not" : "is");
+                $expr = "rated.gameid $op null";
                 break;
 
             case 'author':


### PR DESCRIPTION
Fixes https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/495

Apropos #334, it's not totally clear that #334 is the right approach, and it's not clear that we'll get to a consensus quickly. But adding search filters is uncontroversial, and this alone allows users to get the search I _actually_ care about, which is `played:no willplay:no wontplay:no reviewed:no rated:no`, a search filter for games that are "new to you."

If we decide to merge #334, then `played:no` will effectively mean `played:no reviewed:no rated:no`. Alternately, if we automagically mark games as "I've played it" when you review or rated it, `played:no` will, similarly, effectively mean `played:no reviewed:no rated:no` because everything you've rated or reviewed will be added to your "I've played it" list.

But it also means that you'll be able to use `played:yes reviewed:no rated:no` to find games that you've played but not reviewed or rated, which could be useful in its own right.

