### PR TITLE
ifdb-recommends: Add a "More like this" link to search results

### DIFF
--- a/www/components/ifdb-recommends.php
+++ b/www/components/ifdb-recommends.php
@@ -365,7 +365,9 @@ if (count($recs) >= 2) {
     $_SESSION['ifdb_recommendations_source'] = $recsrc;
 
     // start the section
-    echo "<div class=headline>IFDB Recommends...</div><div>";
+    echo "<div class=headline>IFDB Recommends..."
+      .($overloaded ? "<span class='headlineRss'><a href='/search?searchbar=played%3Ano+willplay%3Ano+wontplay%3Ano+reviewed%3Ano+rated%3Ano'>More like this</a></span>" : "")
+      ."</div><div>";
     global $nonce;
     echo "<style nonce='$nonce'>\n"
         . ".ifdb-recommends__artLink { margin-right: 1em; }\n"


### PR DESCRIPTION
The "IFDB Recommends" section on the home page currently just returns high-rated games that you haven't played, so we can add a "More like this" link to search results.

We used to have another algorithm that tried to do review clustering to try to find people similar to you and games they liked. (This is the `rating_space` algorithm, earlier in the file.) We have a hard-coded variable, `$overloaded`, which disables the `rating_space` algorithm, in favor of the "highly rated games you haven't played" algorithm we're using now.

We probably never want to turn the old `rating_space` algorithm back on again, but there is some ongoing work to try to replace it, so I don't want to delete it quite yet.

https://intfiction.org/t/replacement-ifdb-recommendation-algorithm/71225
https://intfiction.org/t/magic-8-ball-for-game-recommendations/71260