### PR TITLE
viewcomp: Add a link to search for games by competition ID

### DIFF
--- a/www/viewcomp
+++ b/www/viewcomp
@@ -407,7 +407,8 @@ newsSummary($db, "C", $compID, 3,
             "</div>");
 
 // show the games, by division
-echo "<h2>Games and Awards</h2><div class=indented>";
+echo "<style nonce='$nonce'>.compgames { display: inline-block; } </style><h2 class=compgames>Games and Awards</h2>
+    <span class='details'><a href='/search?searchbar=competitionid:$compID'>Search for games</a></span> <div class=indented>";
 
 $divs = $rec["divisions"];
 $games = $rec["games"];


### PR DESCRIPTION
Moved out of #340.

@salty-horse wrote: https://github.com/iftechfoundation/ifdb/pull/340#discussion_r1778027751

> I don't like the label "Search for games". It's a "List all participating games" that happens to use the site's search functionality.
> 
> More accurately, it's a list of all the participating games that are on IFDB - maybe that should be clarified somewhere?
> 
> A bigger question: Perhaps the competition page needs a proper section with the list of all games (and if it's too long, lead to the search page)

I replied:

> Not sure what you mean by this. The existing "Games and Awards" does show all of the competition's entrants already. But it shows the games in a hardcoded order, without cover art or ratings info, and there's no way to sort or filter the competition results.
> 
> You want to see a list of IFComp 2024 games sorted by Highest Rating? You want to exclude Twine games? You want to search for that IFComp game about "aliens" but you can't remember the name? Today, the only way to do any of that is to click through on a random game in IFComp 2024, then scroll down and click on the "IFComp 2024" tag, and then filter your search within that.
> 
> By linking to a search for `competitionid:4lxgmwam7owmbb9h`, we make it more obvious how to do all the rest of the search stuff.
> 
> In light of that, is "Search for games" still not the right answer here? Is there something better we can think of? I think it's more than just "List all participating games," especially since the list is already right there…?