### PR TITLE
Ifarchive-tuid-report: normalize urls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ www/local-credentials.php
 **/ifdb-archive.zip
 **/ifdb-archive-*.zip
 initdb
+www/vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,20 @@
-FROM php:7-apache
+FROM composer:2 as builder
+WORKDIR /app
+COPY composer.json composer.lock ./
+RUN composer install --no-dev --optimize-autoloader --no-interaction
+
+FROM php:7-apache as web
 
 RUN docker-php-ext-install mysqli
 RUN apt-get update -y && apt-get install -y zlib1g-dev libpng-dev libjpeg-dev
 RUN docker-php-ext-configure gd --with-jpeg
 RUN docker-php-ext-install gd
 RUN a2enmod rewrite headers
+COPY --from=builder /app/vendor /opt/vendor
 RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+
+CMD ["apache2-foreground"]

--- a/README.md
+++ b/README.md
@@ -32,6 +32,15 @@ docker compose up --build
 
 All of your database changes should now be available.
 
+# Updating PHP dependencies
+
+Our PHP dependencies are checked into `composer.json` and `composer.lock`. To update those files, you'll need to run `composer` inside the Docker container, using the `docker-php-composer.sh` script, like this:
+
+```
+docker-php-composer.sh update
+docker-php-composer.sh install whatever/dependency
+```
+
 ## Known Issues with the Development Environment
 
 * Sending email doesn't work. That's unfortunate, because if you want to create a user, you'll need to login with an activation code. After you try to create a new user, you should be able to see the email text in the Docker logs. Search for `EMAIL: NOT SENDING EMAIL IN LOCAL DEVELOPMENT MODE`.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "glenscott/url-normalizer": "^1.4"
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,60 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "5d2ff3627508b7f98794b355aedc2d22",
+    "packages": [
+        {
+            "name": "glenscott/url-normalizer",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/glenscott/url-normalizer.git",
+                "reference": "b8e79d3360a1bd7182398c9956bd74d219ad1b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/glenscott/url-normalizer/zipball/b8e79d3360a1bd7182398c9956bd74d219ad1b3c",
+                "reference": "b8e79d3360a1bd7182398c9956bd74d219ad1b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "URL\\": "src/URL"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Glen Scott",
+                    "email": "glen@glenscott.co.uk"
+                }
+            ],
+            "description": "Syntax based normalization of URL's",
+            "support": {
+                "issues": "https://github.com/glenscott/url-normalizer/issues",
+                "source": "https://github.com/glenscott/url-normalizer/tree/master"
+            },
+            "time": "2015-06-11T16:06:02+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
+}

--- a/docker-php-composer.sh
+++ b/docker-php-composer.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -ex
+docker run --rm -v "$(pwd):/app" builder composer "$@"
+rm -rf vendor

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/sh -e
+
+APP_ROOT=/var/www/html
+VENDOR_IMAGE_SRC=/opt/vendor
+VENDOR_LINK_TARGET=${APP_ROOT}/vendor
+
+# Check if the target vendor path exists AND is not already the symlink we want.
+# This prevents errors if the container restarts
+if [ ! -L "${VENDOR_LINK_TARGET}" ] || [ "$(readlink -f ${VENDOR_LINK_TARGET})" != "${VENDOR_IMAGE_SRC}" ]; then
+
+  if [ -e "${VENDOR_LINK_TARGET}" ]; then
+    echo "Warning: Removing existing file/directory at ${VENDOR_LINK_TARGET} to create vendor symlink."
+    rm -rf "${VENDOR_LINK_TARGET}"
+  fi
+
+  echo "Creating symlink: ${VENDOR_LINK_TARGET} -> ${VENDOR_IMAGE_SRC}"
+  ln -s "${VENDOR_IMAGE_SRC}" "${VENDOR_LINK_TARGET}"
+else
+  echo "Vendor symlink already exists and is correct."
+fi
+
+# Execute the original command passed to the container (e.g., apache2-foreground)
+exec "$@"

--- a/www/ifarchive-tuid-report
+++ b/www/ifarchive-tuid-report
@@ -3,6 +3,7 @@
 include_once "util.php";
 include_once "pagetpl.php";
 include_once "dbconnect.php";
+require_once 'vendor/autoload.php';
 
 $json = $_GET['json'] ?? false;
 $refresh = $_GET['refresh'] ?? false;
@@ -87,9 +88,21 @@ $db = dbConnect();
 
 $output = [];
 foreach($tuids as $tuid => $path) {
-    $result = mysqli_execute_query($db, "select url from gamelinks where gameid = ? and url like ?", [$tuid, "%$path"]);
-    $row = mysqli_fetch_row($result);
-    if (!$row) {
+    // normalize the path using URL normalizer. First we make it an absolute URL, normalize it, then we strip the absolute part off
+    $ifarchive_host = "https://ifarchive.org/";
+    $path = substr((new URL\Normalizer($ifarchive_host . $path))->normalize(), strlen($ifarchive_host));
+    $result = mysqli_execute_query($db, "select url from gamelinks where gameid = ?", [$tuid]);
+    $found = false;
+    foreach ($result->fetch_all(MYSQLI_NUM) as [$url]) {
+        $url = (new URL\Normalizer($url))->normalize();
+        // check whether the $url ends with $path
+        if (substr_compare($url, $path, -strlen($path)) === 0) {
+            $found = true;
+            break;
+        }
+    }
+
+    if (!$found) {
         [$title] = mysqli_fetch_row(mysqli_execute_query($db, "select title from games where id = ?", [$tuid]));
         $output[]= [
             "tuid" => $tuid,


### PR DESCRIPTION
This required me to add composer support, but I struggled with it mightily. I'm not at all sure I'm handling that the "right way."

In the previous draft iteration of this PR, I checked in the entire `vendor` directory, which doesn't seem to be the "right way."

Now, I'm using a Docker multi-stage build in the `Dockerfile` to run `composer install` as the image is built. I've also added a new `docker-php-composer.sh` script that you can run to update `composer.json` and `composer.lock` and install new dependencies.

I think this PR is much cleaner than the previous version; it should be ready to merge.