### PR TITLE
Add a table view (with tag frequency in parentheses) to the showtags page

### DIFF
--- a/www/showtags
+++ b/www/showtags
@@ -133,6 +133,7 @@ if (count($tags) == 0) {
         
     // show the tags
     echo "<table>";
+    $totalcolumns = 3;
     $nextcolumn = 1;
     foreach ($tags as $t) {
         $freq = $t['freq'];
@@ -142,18 +143,18 @@ if (count($tags) == 0) {
         $tu = urlencode($tag);
         $siz = calcDistBin($freq, $freqBins);
         $color = calcDistBin($age, $ageBins);
-        $tagcolumn = $nextcolumn++;
-        if ($nextcolumn == 4) {
+        $currentcolumn = $nextcolumn++;
+        if ($nextcolumn > $totalcolumns) {
             $nextcolumn = 1;
         }
-        if ($tagcolumn == 1) {
+        if ($currentcolumn == 1) {
             echo "<tr>";
         }
         echo "<td>"
             . "<a class=silent href=\"search?searchfor=tag:$tu\">"
             . "<font size=2>"
             . "$td ($freq)</font></a></td>";
-        if ($tagcolumn == 3) {
+        if ($currentcolumn == $totalcolumns) {
                 echo "</tr>";
             }
     }

--- a/www/showtags
+++ b/www/showtags
@@ -130,8 +130,10 @@ if (count($tags) == 0) {
         . ".showtags__tag { margin: 0 1em 0 1em; white-space: nowrap; }\n"
         . "</style>\n";
 
-
+        
     // show the tags
+    echo "<table>";
+    $nextcolumn = 1;
     foreach ($tags as $t) {
         $freq = $t['freq'];
         $tag = $t['tag'];
@@ -140,21 +142,28 @@ if (count($tags) == 0) {
         $tu = urlencode($tag);
         $siz = calcDistBin($freq, $freqBins);
         $color = calcDistBin($age, $ageBins);
-
-        echo "<span class='showtags__tag'>"
+        $tagcolumn = $nextcolumn++;
+        if ($nextcolumn == 4) {
+            $nextcolumn = 1;
+        }
+        if ($tagcolumn == 1) {
+            echo "<tr>";
+        }
+        echo "<td>"
             . "<a class=silent href=\"search?searchfor=tag:$tu\">"
-            . "<font size=$siz><span class=\"tagAge$color\">"
-            . "$td</span></font></a></span> ";
+            . "<font size=2>"
+            . "$td ($freq)</font></a></td>";
+        if ($tagcolumn == 3) {
+                echo "</tr>";
+            }
     }
-
 }
-
+echo "</table>";
 echo "</center></div><p>"
    . "Show <a href=\"showtags?limit=20\">the top 20</a> / "
    . "<a href=\"showtags?limit=50\">the top 50</a> / "
    . "<a href=\"showtags?limit=100\">the top 100</a> / "
    . "<a href=\"showtags\">all</a> game tags.<br>";
-
 
 pageFooter();
 ?>

--- a/www/showtags
+++ b/www/showtags
@@ -119,8 +119,8 @@ if (count($tags) == 0) {
     usort($tags, "sortByTagName");
 
     echo "<h1>$title</h1>"
-        . "<p>Here are of all the tags on IFDB, along with numbers showing how many games have each tag. "
-        . "Click a tag to list the games associated with the tag."
+        . "<p>Here are all of the tags on IFDB, along with numbers showing how many games have each tag. "
+        . "Click on a tag to list the games associated with the tag."
         . "<p><div class=indented><center>";
 
     global $nonce;

--- a/www/showtags
+++ b/www/showtags
@@ -119,10 +119,8 @@ if (count($tags) == 0) {
     usort($tags, "sortByTagName");
 
     echo "<h1>$title</h1>"
-        . "<p>Here are $limitName associated with games in IFDB. "
-        . "Tags that are used more frequently are shown in larger type, and "
-        . "newer tags are in darker colors. "
-        . "Click on a tag to list games associated with the tag."
+        . "<p>Here are of all the tags on IFDB, along with numbers showing how many games have each tag. "
+        . "Click a tag to list the games associated with the tag."
         . "<p><div class=indented><center>";
 
     global $nonce;
@@ -151,9 +149,9 @@ if (count($tags) == 0) {
             echo "<tr>";
         }
         echo "<td>"
-            . "<a class=silent href=\"search?searchfor=tag:$tu\">"
+            . "<a href=\"search?searchfor=tag:$tu\">"
             . "<font size=2>"
-            . "$td ($freq)</font></a></td>";
+            . "$td</a> ($freq)</font></a></td>";
         if ($currentcolumn == $totalcolumns) {
                 echo "</tr>";
             }

--- a/www/showtags
+++ b/www/showtags
@@ -128,7 +128,7 @@ if (count($tags) == 0) {
         . ".showtags__tag { margin: 0 1em 0 1em; white-space: nowrap; }\n"
         . "</style>\n";
 
-        
+    
     // show the tags
     echo "<table>";
     $totalcolumns = 3;
@@ -151,13 +151,13 @@ if (count($tags) == 0) {
         echo "<td>"
             . "<a href=\"search?searchfor=tag:$tu\">"
             . "<font size=2>"
-            . "$td</a> ($freq)</font></a></td>";
+            . "$td</a> ($freq)</font></td>";
         if ($currentcolumn == $totalcolumns) {
-                echo "</tr>";
-            }
+            echo "</tr>";
+        }
     }
-}
 echo "</table>";
+}
 echo "</center></div><p>"
    . "Show <a href=\"showtags?limit=20\">the top 20</a> / "
    . "<a href=\"showtags?limit=50\">the top 50</a> / "


### PR DESCRIPTION
This is definitely not ready to merge. The intention is to add an option for viewing all the tags in a table, with the frequency of each tag in parentheses. The third column is pushed off to the right, I think because of the length of some of the tags which are actually URLs, but I'm not sure how to fix it.

Fixes https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/499