### PR TITLE
Add message about the "Use Accessible Controls" setting

### DIFF
--- a/www/starctl.php
+++ b/www/starctl.php
@@ -51,6 +51,7 @@ function setStarCtlValue(id, val)
         // with automatic mouse rollover highlighting.
 
         ?>
+<span style="position:absolute;width:1px;left:-10000px;">To rate games using a keyboard, please visit the settings page and turn on the "Use Accessible Controls" setting.</span>
 <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 var starRatings = {};

--- a/www/starctl.php
+++ b/www/starctl.php
@@ -51,7 +51,7 @@ function setStarCtlValue(id, val)
         // with automatic mouse rollover highlighting.
 
         ?>
-<span style="position:absolute;width:1px;left:-10000px;">To rate games using a keyboard, please visit the settings page and turn on the "Use Accessible Controls" setting.</span>
+<span style="position:absolute;left:-10000px;">To rate games using a keyboard, please visit the settings page and turn on the "Use Accessible Controls" setting.</span>
 <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 var starRatings = {};


### PR DESCRIPTION
People who might like to use the "Use accessible controls" setting on the settings page may not know it exists. This message is meant to make users aware of that setting, in text that is read by a screen reader but is not visible on the screen.

I have not been able to test it, but it is modeled after the following code. An IFDB user confirmed that the "Yip yip yip" text in the code below is read aloud by a screen reader, even though it is not visible on the screen:

```
<h1>Woof!</h1>
<span style="position:absolute;width:1px;left:-10000px;">Yip yip yip</span>
```