### PR TITLE
Add visible message about accessibility option

### DIFF
--- a/www/starctl.php
+++ b/www/starctl.php
@@ -51,6 +51,7 @@ function setStarCtlValue(id, val)
         // with automatic mouse rollover highlighting.
 
         ?>
+<span class=fmtnotes>To turn on accessible controls, please visit the <a href="https://www.ifdb.org/editprofile">settings page</a>.</span>
 <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 var starRatings = {};

--- a/www/starctl.php
+++ b/www/starctl.php
@@ -51,7 +51,7 @@ function setStarCtlValue(id, val)
         // with automatic mouse rollover highlighting.
 
         ?>
-<span class=fmtnotes>To turn on accessible controls, please visit the <a href="https://www.ifdb.org/editprofile">settings page</a>.</span>
+<span class=fmtnotes>To turn on accessible controls for star ratings, please visit the <a href="/editprofile">settings page</a>.</span><br>
 <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 <!--
 var starRatings = {};


### PR DESCRIPTION
This is another way to approach https://github.com/iftechfoundation/ifdb/issues/370

This would be a visible message, and would be temporary until the star rating controls are redone.

I am not sure how to test this in the dev environment, because it requires being logged in, and I have not been able to activate a new user in the dev environment in order to log in.