### PR TITLE
Add "search all tags" and "view all tags" link to the "Edit Tags" dialog

### DIFF
--- a/www/viewgame
+++ b/www/viewgame
@@ -2349,7 +2349,7 @@ if ($embargoCnt > 0)
 
         <p><span id="tagPre" class=details></span>
         <span class='details viewgame__commonTags'>
-           - <a href="showtags?limit=50">View the most common tags</a>
+           - <a href="/showtags?cloud=1&limit=100">View the most common tags</a>
            (<?php echo helpWinLink("help-tags", "What's a tag?")
            ?>)
         </span></p>
@@ -2415,6 +2415,10 @@ if ($embargoCnt > 0)
                     addTags();
                   })
                 </script>
+                <span class=details>
+                 <a href="/search?tag" target="_blank">Search all tags on IFDB</a> | <a href="/showtags" target="_blank">View all tags on IFDB</a>
+                </span>
+                <br><br>
                  <span class=details>Tags you added are shown below with
                     checkmarks.  To remove one of your tags, simply
                     un-check it.


### PR DESCRIPTION
Add a "search all tags" link to the "Edit Tags" dialog, as that's currently the closest thing we have to tag suggestions.

Also add a "view all tags" link to the "Edit Tags" dialog, so that the user can have the list of tags open while deciding which tags to add.

Both links open in a new tab/window so that they can be open at the same time that the user is adding tags in the "Edit Tags" window.

Change the existing "view the most common tags" link to point to the tag cloud (as before), so it will be different enough from the "view all tags" link in the dialog not to be redundant. (I think there is value in having a link that's outside of the "Edit Tags" dialog, for users who are just browsing and want to explore tags, but who aren't actually adding any tags.)

I changed it to point to the top 100 tag cloud instead of the top 50 tag cloud, just because I thought it might give a slightly better representation of the variety of tags used.

Addresses https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/510

Also addresses https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/511