### PR TITLE
Return tag synonyms in game tag search results

### DIFF
--- a/sql/patch-schema-2.sql
+++ b/sql/patch-schema-2.sql
@@ -3,3 +3,13 @@ USE ifdb;
 -- use this script for pending changes to the production DB schema
 
 
+CREATE TABLE `tagsynonyms` (
+    `tagsynonymid` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+    `fromtag` varchar(255) COLLATE latin1_german2_ci NOT NULL,
+    `totag` varchar(255) COLLATE latin1_german2_ci NOT NULL,
+    PRIMARY KEY (`tagsynonymid`),
+    KEY `fromtag` (`fromtag`),
+    UNIQUE KEY `from_to` (`fromtag`, `totag`)
+) ENGINE = MyISAM DEFAULT CHARSET = latin1 COLLATE = latin1_german2_ci;
+
+insert into tagsynonyms (fromtag, totag) values ('science fiction', 'sci-fi');

--- a/www/search
+++ b/www/search
@@ -1458,11 +1458,16 @@ else if ($term || $browse)
                     $tagsMatched = array();
                     foreach ($specials as $s) {
                         if ($s[0][0] == "tags") {
+                            $result = mysqli_execute_query($db, 'select totag from tagsynonyms where fromtag = ?', [$s[1]]);
+                            $synonyms = array_merge(...mysqli_fetch_all($result, MYSQLI_NUM));
+                            $matchables = array_merge([$s[1]], $synonyms);
                             foreach ($tags as $t) {
-                                if (strpos(strtolower($t),
-                                           strtolower($s[1])) !== false) {
-                                    $tagsMatched[$t] = true;
-                                    break;
+                                foreach ($matchables as $m) {
+                                    if (strpos(strtolower($t),
+                                               strtolower($m)) !== false) {
+                                        $tagsMatched[$t] = true;
+                                        break;
+                                    }
                                 }
                             }
                         }


### PR DESCRIPTION
Fixes https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/73

For example, as I write this, [Zeppelin Adventure](https://ifdb.org/viewgame?id=op5a8ug80gwyoagl) is tagged "sci-fi" but not "science fiction". When I search for "[adventure tag:science fiction](https://ifdb.org/search?searchbar=adventure+tag%3Ascience+fiction)" on ifdb.org, Zeppelin Adventure doesn't show up, but in this branch, it _does_ show up, and in search results, it says: "tags matched: sci-fi"

<img width="325" alt="image" src="https://github.com/user-attachments/assets/aa28b6ba-3e85-4863-9203-22516861764e">

There's no UI to edit tag synonyms, but that can come later, assuming I've got the schema right.

Am I right in thinking we want to allow synonyms to be asymmetrical? So searches for tag X return games tagged X or Y, but searches for tag Y don't necessarily return games tagged X? (That's why my `tagsynonyms` table has a `fromtag` and `totag` column.)