### PR TITLE
Fix implicit search by TUID

### DIFF
--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -1086,7 +1086,7 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
             error_log($sql);
             error_log($words[0]);
         }
-        $result = mysqli_execute_query($db, $sql, [$words[0], $words[0]]);
+        $result = mysqli_execute_query($db, $sql, [$words[0]]);
         if ($result) {
             $rows[] = mysql_fetch_array($result, MYSQL_ASSOC);
             if (isset($rows) && isset($rows[0])) {


### PR DESCRIPTION
You're supposed to be able to paste a TUID into IFDB search, with no operator, and have it just work, but we broke it when we removed implicit search by IFID.