### PR TITLE
Add links to the tag table and the tag cloud from "Browse tags"

### DIFF
--- a/www/search
+++ b/www/search
@@ -1370,6 +1370,14 @@ else if ($term || $browse)
                 . "</div>";
         }
 
+        // if this is a tag search, show the list tip box
+        if ($searchType == "tag") {
+            echo "<div class=tipbox>"
+                . "<h1>View all the game tags</h1>"
+                . "You can <a href=\"showtags\">see all the tags in a table</a> or in a <a href=\"showtags?cloud=1\">tag cloud</a>."
+                . "</div>";
+        }
+
         // show the sorting controls
         $hids = array("searchfor" => $term);
         if ($browse)

--- a/www/search
+++ b/www/search
@@ -1370,7 +1370,7 @@ else if ($term || $browse)
                 . "</div>";
         }
 
-        // if this is a tag search, show the list tip box
+        // if this is a tag search, show the tag tip box
         if ($searchType == "tag") {
             echo "<div class=tipbox>"
                 . "<h1>View all the game tags</h1>"


### PR DESCRIPTION
Right now, when users browse tags in the "Tags" tab of the search page, there is no indication that the tag cloud/table exists.

This PR adds a tip box there, linking to the tag table and the tag cloud.

Fixes https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/274