### PR TITLE
Improve visibility of the text in the "Edit Tags" box in dark mode

### DIFF
--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -2260,7 +2260,6 @@ span.sfl-save-autodesc {
     font-style: italic;
     padding-left: 1em;
 }
-
 @media (prefers-color-scheme: dark) {
     body {
         background: #000000;
@@ -2404,6 +2403,15 @@ span.sfl-save-autodesc {
     form.stylepicform {
         background: #101030;
         color: #ffffff;
+    }
+    form.edittagsform {
+        background-color: #000000;
+    }
+    form.edittagsform span.details {
+        color: #ffffff;
+    }
+    form.edittagsform span.cklabel {
+        color: #9090ff;
     }
     input, select{
         background-color: #000000;

--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -2407,9 +2407,6 @@ span.sfl-save-autodesc {
     form.edittagsform {
         background-color: #000000;
     }
-    form.edittagsform span.details {
-        color: #ffffff;
-    }
     form.edittagsform span.cklabel {
         color: #9090ff;
     }

--- a/www/viewgame
+++ b/www/viewgame
@@ -2408,7 +2408,7 @@ if ($embargoCnt > 0)
                           class="popup-close-button"></a>
                  </div>
               </div>
-              <form name="tagForm">
+              <form name="tagForm" class="edittagsform">
                  <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
                   document.currentScript.parentElement.addEventListener('submit', function (event) {
                     event.preventDefault();


### PR DESCRIPTION
In the dark mode version of the Edit Tags box, change the background color to black and lighten the text color of the tags so that the text is visible.

Fixes https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/512