### PR TITLE
Allow moderators to add/delete tags in bulk

### DIFF
--- a/www/adminops
+++ b/www/adminops
@@ -75,6 +75,57 @@ if (isset($_REQUEST['adminemail'])) {
     exit();
 }
 
+if (isset($_REQUEST['bulkdeletetag'])) {
+    $tag = $_POST['tag'] ?? null;
+    $confirm = $_POST['confirm'] ?? null;
+    pageHeader("Bulk delete tag");
+    if (!$tag) {
+        ?>
+        <h1>Bulk delete tag</h1>
+        <p><form method=post>Delete Tag: <input type=hidden name=bulkdeletetag value=''><input name=tag><button>Search</button></form></p>
+        <?php
+    } else if (!$confirm) {
+        $result = mysqli_execute_query($db, 'select distinct(id), title from games join gametags on games.id=gameid where tag = ? order by title', [$tag]);
+        $rows = mysqli_fetch_all($result, MYSQLI_NUM);
+        if (!count($rows)) {
+            echo "<h1>Bulk delete tag: ". htmlspecialcharx($tag)."</h1>\n"
+                ."<p><span class=errmsg>There are no games with the tag \"".htmlspecialcharx($tag)."\".</span>"
+                ."<p><form method=post>Delete Tag: <input type=hidden name=bulkdeletetag value=''><input name=tag><button>Search</button></form></p>";
+            pageFooter();
+            exit();
+        }
+        echo "<h1>Bulk delete tag: ". htmlspecialcharx($tag)."</h1>\n"
+            ."<p>" . count($rows) . " game(s):</p>";
+        global $nonce;
+        echo "<style nonce='$nonce'>#games { display: grid; grid-template-columns: repeat(auto-fill, 20ch);</style><div id=games>\n";
+        foreach ($rows as [$tuid, $title]) {
+            echo "<div><a href='/viewgame?id=$tuid'>".htmlspecialcharx($title)."</a></div>\n";
+        }
+        ?>
+        </div>
+        <p><form method=post>
+            <input type=hidden name=bulkdeletetag value=''>
+            <input type=hidden name=tag value='<?= htmlspecialcharx($tag); ?>'>
+            <input type=hidden name=confirm value=1>
+            <button>Confirm Delete</button></form></p>
+        <?php
+    } else {
+        $result = mysqli_query($db, "delete from gametags where tag = '" . mysqli_real_escape_string($db, $tag). "'");
+        if ($result) {
+            $count = mysqli_affected_rows($db);
+            echo "<h1>Bulk delete tag: ". htmlspecialcharx($tag)."</h1>\n"
+                ."<p> Deleted '". htmlspecialcharx($tag) . "' from $count game(s).</p>"
+                ."<p><form method=post>Delete Tag: <input type=hidden name=bulkdeletetag value=''><input name=tag><button>Search</button></form></p>"
+                ."<p><a href='/adminops'>Return to the System Maintenance Panel</a></p>";
+        } else {
+            error_log("error deleting tag '$tag': " . mysqli_error($db));
+            echo "<span class=errmsg>There was an error deleting the tag.</span>";
+        }
+    }
+    pageFooter();
+    exit();
+}
+
 if (isset($_REQUEST['burygame'])) {
     $tuid = isset($_REQUEST['id']) ? htmlspecialcharx($_REQUEST['id']) : false;
     if ($tuid === false) {
@@ -2491,6 +2542,7 @@ function cleanutf8($str)
 <a href="adminops?finduser">User search</a><br>
 <a href="adminops?adminemail">Send admin email</a><br>
 <a href="adminops?burygame">Bury game</a><br>
+<a href="adminops?bulkdeletetag">Bulk delete tags</a><br>
 <a href="adminops?userSelfComments">User self-comments</a><br>
 <a href="adminops?reaper=30">Persistent session reaper</a><br>
 <a href="adminops?fixsortkeys">

--- a/www/adminops
+++ b/www/adminops
@@ -75,6 +75,65 @@ if (isset($_REQUEST['adminemail'])) {
     exit();
 }
 
+if (isset($_REQUEST['bulkaddtag'])) {
+    $tag = $_POST['tag'] ?? null;
+    $tag2 = $_POST['tag2'] ?? null;
+    $confirm = $_POST['confirm'] ?? null;
+    pageHeader("Bulk add tag");
+    if (!$tag || !$tag2) {
+        ?>
+        <h1>Bulk add tag</h1>
+        <p><form method=post>Add this tag: <input type=hidden name=bulkaddtag value=''><input name=tag2 required>
+        <br>to all games that have this tag: <input name=tag required>
+        <button>Search</button></form></p>
+        <?php
+    } else if (!$confirm) {
+        $result = mysqli_execute_query($db, 'SELECT distinct(id), title from games
+            join gametags g1 on games.id=g1.gameid
+            left outer join gametags g2 on games.id=g2.gameid and g2.tag = ?
+            where g1.tag = ? and g2.tag is null order by title', [$tag2, $tag]);
+        $rows = mysqli_fetch_all($result, MYSQLI_NUM);
+        if (!count($rows)) {
+            echo "<h1>Bulk add tag: ". htmlspecialcharx($tag)."</h1>\n"
+                ."<p><span class=errmsg>There are no games with the tag \"".htmlspecialcharx($tag)."\" that don't have the tag \"".htmlspecialcharx($tag2)."\".</span></p>"
+                ."<p><a href='/adminops?bulkaddtag'>Add another</p>";
+            pageFooter();
+            exit();
+        }
+        echo "<h1>Bulk add tag: ". htmlspecialcharx($tag2)."</h1>\n"
+            ."<p>You're about to add the tag \"".htmlspecialcharx($tag2)."\" to ". count($rows) . " game(s) with the tag \"".htmlspecialcharx($tag)."\" that don't already have the tag \"".htmlspecialcharx($tag2)."\":</p>";
+        global $nonce;
+        echo "<style nonce='$nonce'>#games { display: grid; grid-template-columns: repeat(auto-fill, 20ch);</style><div id=games>\n";
+        foreach ($rows as [$tuid, $title]) {
+            echo "<div><a href='/viewgame?id=$tuid'>".htmlspecialcharx($title)."</a></div>\n";
+        }
+        ?>
+        </div>
+        <p><form method=post>
+            <input type=hidden name=bulkaddtag value=''>
+            <input type=hidden name=tag value='<?= htmlspecialcharx($tag); ?>'>
+            <input type=hidden name=tag2 value='<?= htmlspecialcharx($tag2); ?>'>
+            <input type=hidden name=confirm value=1>
+            <button>Confirm Add Tag "<?= htmlspecialcharx($tag2); ?>"</button></form></p>
+        <?php
+    } else {
+        $result = mysqli_execute_query($db, 'SELECT distinct(id) from games
+            join gametags g1 on games.id=g1.gameid
+            left outer join gametags g2 on games.id=g2.gameid and g2.tag = ?
+            where g1.tag = ? and g2.tag is null', [$tag2, $tag]);
+        $tuids = array_merge(...mysqli_fetch_all($result, MYSQLI_NUM));
+        foreach ($tuids as $tuid) {
+            mysqli_execute_query($db, "INSERT into gametags (gameid, userid, tag, moddate) values (?, ?, ?, now())", [$tuid, $userid, $tag2]);
+        }
+        echo "<h1>Bulk added tag: ". htmlspecialcharx($tag2)."</h1>\n"
+            ."<p> Added '". htmlspecialcharx($tag2) . "' to ".count($tuids)." game(s).</p>"
+            ."<p><a href='/adminops?bulkaddtag'>Add another</p>"
+            ."<p><a href='/adminops'>Return to the System Maintenance Panel</a></p>";
+    }
+    pageFooter();
+    exit();
+}
+
 if (isset($_REQUEST['bulkdeletetag'])) {
     $tag = $_POST['tag'] ?? null;
     $confirm = $_POST['confirm'] ?? null;
@@ -2542,6 +2601,7 @@ function cleanutf8($str)
 <a href="adminops?finduser">User search</a><br>
 <a href="adminops?adminemail">Send admin email</a><br>
 <a href="adminops?burygame">Bury game</a><br>
+<a href="adminops?bulkaddtag">Bulk add tags</a><br>
 <a href="adminops?bulkdeletetag">Bulk delete tags</a><br>
 <a href="adminops?userSelfComments">User self-comments</a><br>
 <a href="adminops?reaper=30">Persistent session reaper</a><br>


### PR DESCRIPTION
Bulk adding tags probably shouldn't be restricted to moderators; anyone can already add as many tags as they want, and can even write code to do it using the IFDB API. (But I don't really know where I'd put a feature like that. I don't think I'd want to link to it right off the `viewgame` page. Maybe a secret URL?)

Fixes https://github.com/iftechfoundation/ifdb-suggestion-tracker/issues/514