### PR TITLE
Ban tag synonyms

### DIFF
--- a/sql/patch-schema-2.sql
+++ b/sql/patch-schema-2.sql
@@ -3,3 +3,13 @@ USE ifdb;
 -- use this script for pending changes to the production DB schema
 
 
+CREATE TABLE `blockedtagsynonyms` (
+    `blockedtagsynonymid` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+    `blockedtag` varchar(255) COLLATE latin1_german2_ci NOT NULL,
+    `preferredtag` varchar(255) COLLATE latin1_german2_ci NOT NULL,
+    PRIMARY KEY (`blockedtagsynonymid`),
+    UNIQUE KEY `blockedtag` (`blockedtag`)
+) ENGINE = MyISAM DEFAULT CHARSET = latin1 COLLATE = latin1_german2_ci;
+
+insert into blockedtagsynonyms (blockedtag, preferredtag)
+values ('sci-fi', 'science fiction');

--- a/www/adminops
+++ b/www/adminops
@@ -185,6 +185,67 @@ if (isset($_REQUEST['bulkdeletetag'])) {
     exit();
 }
 
+if (isset($_REQUEST['blocktag'])) {
+    $tag = $_POST['blockedtag'] ?? null;
+    $preferredtag = $_POST['preferredtag'] ?? null;
+    $deleteblock = $_POST['deleteblock'] ?? null;
+    pageHeader("Block tag");
+    if ($deleteblock) {
+        $result = mysqli_execute_query($db, 'delete from blockedtagsynonyms where blockedtag = ?', [$tag]);
+        if ($result) {
+            echo "<h1>Unblock tag: ". htmlspecialcharx($tag)."</h1>\n"
+                ."<p>Unblocked '". htmlspecialcharx($tag) . "'.</p>"
+                ."<p><a href='/adminops?blocktag'>Block/unblock another tag</a></p>"
+                ."<p><a href='/adminops'>Return to the System Maintenance Panel</a></p>";
+        } else {
+            error_log("error unblocking tag '$tag': " . mysqli_error($db));
+            echo "<span class=errmsg>There was an error unblocking the tag.</span>";
+        }
+    } else if (!$tag || !$preferredtag) {
+            $result = mysqli_query($db, 'select blockedtag, preferredtag from blockedtagsynonyms order by blockedtag');
+            $rows = mysqli_fetch_all($result, MYSQLI_NUM);
+        ?>
+        <h1>Block tag</h1>
+        <p><form method=post>Block tag: <input type=hidden name=blocktag value=''><input name=blockedtag required>
+        <p>Preferred Tag: <input name=preferredtag required>
+        <button>Block tag</button></form></p>
+        
+        <table border=1>
+            <tr><th>Blocked Tag</th><th>Preferred Tag</th><th>Unblock?</th></tr>
+            <?php
+            foreach ($rows as [$blockedtag, $preferredtag]) {
+                echo "<tr><td>".htmlspecialcharx($blockedtag)."</td><td>".htmlspecialcharx($preferredtag)."</td><td>"
+                    . "<form method=post><input type=hidden name=deleteblock value=1>"
+                    . "<input type=hidden name=blockedtag value='".htmlspecialcharx($blockedtag)."'><button>Unblock</button></form></td></tr>\n";
+            }
+            ?>
+        </table>
+        <?php
+    } else {
+        $result = mysqli_execute_query($db, 'select distinct(id), title from games join gametags on games.id=gameid where tag = ? order by title', [$tag]);
+        $rows = mysqli_fetch_all($result, MYSQLI_NUM);
+        if (count($rows)) {
+            echo "<h1>Block tag: ". htmlspecialcharx($tag)."</h1>\n"
+                ."<p><span class=errmsg>There are ".count($rows)." games with the tag \"".htmlspecialcharx($tag)."\". <a href='/adminops?bulkdeletetag'>Delete the existing tag</a> before banning it.</span>"
+                ."<p><a href='/adminops?blocktag'>Cancel</a></p>";
+            pageFooter();
+            exit();
+        }
+        $result = mysqli_execute_query($db, "insert into blockedtagsynonyms (blockedtag, preferredtag) values (?, ?)", [$tag, $preferredtag]);
+        if ($result) {
+            echo "<h1>Block tag: ". htmlspecialcharx($tag)."</h1>\n"
+                ."<p>Blocked '". htmlspecialcharx($tag) . "'.</p>"
+                ."<p><a href='/adminops?blocktag'>Block another tag</a></p>"
+                ."<p><a href='/adminops'>Return to the System Maintenance Panel</a></p>";
+        } else {
+            error_log("error blocking tag '$tag': " . mysqli_error($db));
+            echo "<span class=errmsg>There was an error blocking the tag.</span>";
+        }
+    }
+    pageFooter();
+    exit();
+}
+
 if (isset($_REQUEST['burygame'])) {
     $tuid = isset($_REQUEST['id']) ? htmlspecialcharx($_REQUEST['id']) : false;
     if ($tuid === false) {
@@ -2603,6 +2664,7 @@ function cleanutf8($str)
 <a href="adminops?burygame">Bury game</a><br>
 <a href="adminops?bulkaddtag">Bulk add tags</a><br>
 <a href="adminops?bulkdeletetag">Bulk delete tags</a><br>
+<a href="adminops?blocktag">Block tag</a><br>
 <a href="adminops?userSelfComments">User self-comments</a><br>
 <a href="adminops?reaper=30">Persistent session reaper</a><br>
 <a href="adminops?fixsortkeys">

--- a/www/taggame
+++ b/www/taggame
@@ -120,6 +120,16 @@ if (mysql_num_rows($result) == 0)
                  "This tag request refers to a non-existent game.",
                  false, false);
 
+foreach ($tags as $t) {
+    $result = mysqli_execute_query($db, "select preferredtag from blockedtagsynonyms where blockedtag=?", [$t]);
+    if (mysql_num_rows($result)) {
+        [$preferred_tag] = mysqli_fetch_array($result, MYSQLI_NUM);
+        sendResponse("400 Bad Request", "Not Saved",
+            "To help keep IFDB's tags tidy, please use the existing tag \"$preferred_tag\" instead of \"$t\".", false, false);
+    }
+}
+
+
 // delete any old tags set by this user
 mysql_query(
     "delete from gametags where userid = '$userid' and gameid='$qid'", $db);

--- a/www/viewgame
+++ b/www/viewgame
@@ -2739,7 +2739,7 @@ function saveTags()
     }
     dispTags();
     closeTags("tagEditor");
-    xmlSend("taggame", "tagStatusSpan", cbSaveTags, c);
+    xmlSend("taggame", "tagStatusSpan", cbSaveTags, c, true);
 }
 
 function saveTagsDelete()
@@ -2764,12 +2764,20 @@ function saveTagsDelete()
 
     dispTags();
     closeTags("tagDeletor");
-    xmlSend("taggamedelete", "tagStatusSpan", cbSaveTags, c);
+    xmlSend("taggamedelete", "tagStatusSpan", cbSaveTags, c, true);
 }
 
 
 function cbSaveTags(resp)
 {
+    if (!resp) {
+        alert("There was an error saving tags.");
+        return;
+    }
+    if (resp.querySelector("error")) {
+        alert(resp.querySelector("error").firstChild.data);
+        return;
+    }
     var tags = resp.getElementsByTagName("tag");
     for (var i = 0 ; i < tags.length ; ++i)
     {

--- a/www/xmlreq.js
+++ b/www/xmlreq.js
@@ -48,7 +48,7 @@ function xmlReqEvent(tracker)
         var msgspan = (tracker.statusSpanID
                        ? document.getElementById(tracker.statusSpanID)
                        : null);
-        var resp = req.responseXML.documentElement;
+        var resp = req.responseXML?.documentElement;
         if (req.status == 200 && resp != null)
         {
             if (msgspan)
@@ -72,7 +72,7 @@ function xmlReqEvent(tracker)
                        + "Please try again later.");
         }
         if (tracker.cbFunc)
-            tracker.cbFunc(req.responseXML.documentElement);
+            tracker.cbFunc(resp);
     }
 }
 


### PR DESCRIPTION
In this PR, we populate a table of `blockedtagsynonyms`. We forbid anyone to tag a game with a tag on this list, and we recommend that the user use a synonymous tag instead, e.g. we'd block "sci-fi" and tell people to use "science fiction" instead.

Along the way, I had to fix https://github.com/iftechfoundation/ifdb/issues/396 so I could show an error message at all.

Notably, when tagging fails, the changes remain visible in the page, as if they'd kinda succeeded, with the red error message "Not Saved."

<img width="614" alt="image" src="https://github.com/user-attachments/assets/0458684b-0b15-4846-a739-7207e8381a6c">

This is because the user might have submitted multiple tags X, Y, and Z, but only tag Y is blocked. If we just revert all the changes, we'd have to discard X and Z. The user can fix the issue by clicking "Edit," unchecking Y, and submitting that, or by refreshing the page, discarding all of the tags they submitted.