### PR TITLE
In dark mode, lighten the borders of the search bars to make them easier to see

### DIFF
--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -2301,8 +2301,8 @@ span.sfl-save-autodesc {
     .menu-toggle-button {
         filter: invert(1);
     }
-    .searchbar-wrapper {
-        border: 2px solid black;
+    .searchbar-wrapper { 
+        border: 1px solid #696991;
     }
     #topbar-search-go-button {
         filter: invert(1);
@@ -2433,7 +2433,7 @@ span.sfl-save-autodesc {
     input, select{
         background-color: #000000;
         color: #FFFFFF;
-        border: 1px solid #323245;
+        border: 1px solid #696991;
     }
     div.tipbox {
         background: #101030;


### PR DESCRIPTION
In dark mode, when the search bars are not in focus, the text input fields are somewhat difficult to see.

This PR lightens the borders of the main search bar ("Search for games...") as well as the "Search for (tags, etc.)..." search bar so that the typing area is easier to see.

Before:
![text input field in dark mode](https://github.com/user-attachments/assets/c768e470-8e20-431c-aa37-b20a0f72abea)

After:
![border color 696991](https://github.com/user-attachments/assets/b6dc6bb4-fd5a-4eda-8954-528ef4bcc654)

Fixes #365.

Discussion here: https://intfiction.org/t/dark-mode-on-ifdb-thoughts-about-the-color-and-border-of-text-input-fields/71543/1
