### PR TITLE
Change default users.acctstatus to A (Active)

### DIFF
--- a/sql/patch-schema.sql
+++ b/sql/patch-schema.sql
@@ -34,7 +34,7 @@ ALTER TABLE `users`
     ADD COLUMN `password` varchar(40) CHARACTER SET latin1 COLLATE latin1_bin NOT NULL DEFAULT '',
     ADD COLUMN `pswsalt` varchar(32) COLLATE latin1_german2_ci NOT NULL DEFAULT '',
     ADD COLUMN `activationcode` varchar(40) COLLATE latin1_german2_ci DEFAULT NULL,
-    ADD COLUMN `acctstatus` char(1) COLLATE latin1_german2_ci NOT NULL DEFAULT '0',
+    ADD COLUMN `acctstatus` char(1) COLLATE latin1_german2_ci NOT NULL DEFAULT 'A',
     ADD COLUMN `lastlogin` datetime DEFAULT NULL,
     ADD COLUMN `privileges` varchar(32) COLLATE latin1_german2_ci NOT NULL DEFAULT '''''',
     ADD COLUMN `defaultos` int(11) unsigned DEFAULT NULL,


### PR DESCRIPTION
Fixes #888. In the dev environment, this makes all of the imported users active by default; without that, member search doesn't work.

I verified that when I create a new user, the user still gets created with `acctstatus=D` ("Pending Activation") so this should have no effect on new user rows.

I also checked the production DB. The default `acctstatus` in production is also 0, and I think that's a bug, too, and we should fix it. `0` is not a valid `acctstatus`; it's always supposed to be a letter.

```
MariaDB [ifdb]> describe users;
+-----------------+------------------+------+-----+---------+-------+
| Field           | Type             | Null | Key | Default | Extra |
+-----------------+------------------+------+-----+---------+-------+
| id              | varchar(32)      | NO   | PRI |         |       |
| email           | varchar(255)     | NO   | UNI |         |       |
| name            | varchar(128)     | NO   | UNI |         |       |
| gender          | char(1)          | YES  |     | NULL    |       |
| publicemail     | varchar(255)     | YES  |     | NULL    |       |
| emailflags      | tinyint(2)       | NO   |     | 3       |       |
| location        | varchar(128)     | NO   |     |         |       |
| profile         | text             | YES  |     | NULL    |       |
| profilestatus   | varchar(1)       | YES  |     | NULL    |       |
| picture         | varchar(64)      | YES  |     | NULL    |       |
| password        | varchar(40)      | NO   |     |         |       |
| pswsalt         | varchar(32)      | NO   |     |         |       |
| activationcode  | varchar(40)      | YES  |     | NULL    |       |
| acctstatus      | char(1)          | NO   |     | 0       |       |
| created         | datetime         | YES  |     | NULL    |       |
| lastlogin       | datetime         | YES  |     | NULL    |       |
| privileges      | varchar(32)      | NO   |     | ''      |       |
| defaultos       | int(11) unsigned | YES  |     | NULL    |       |
| defaultosvsn    | int(11) unsigned | YES  |     | NULL    |       |
| noexedownloads  | tinyint(1)       | NO   |     | 0       |       |
| publiclists     | varchar(10)      | YES  |     | NULL    |       |
| mirrorid        | int(11) unsigned | NO   |     | 100     |       |
| stylesheetid    | bigint(20)       | YES  |     | NULL    |       |
| offsite_display | char(1)          | NO   |     | A       |       |
| accessibility   | tinyint(1)       | YES  |     | NULL    |       |
| caughtupdate    | datetime         | YES  |     | NULL    |       |
| remarks         | mediumtext       | YES  |     | NULL    |       |
| tosversion      | int(11)          | NO   |     | 1       |       |
| Sandbox         | int(11)          | NO   |     | 0       |       |
| welcomeopen     | tinyint(1)       | NO   |     | 1       |       |
+-----------------+------------------+------+-----+---------+-------+
30 rows in set (0.052 sec)

MariaDB [ifdb]> select count(id), acctstatus from users group by acctstatus;
+-----------+------------+
| count(id) | acctstatus |
+-----------+------------+
|     18024 | A          |
|      1532 | B          |
|      1528 | D          |
|       293 | R          |
|        11 | X          |
+-----------+------------+
5 rows in set (0.019 sec)
```
