### PR TITLE
On showtags page, change tag frequency to exclude redundant tags

### DIFF
--- a/www/showtags
+++ b/www/showtags
@@ -28,7 +28,7 @@ else {
 // get the top (most frequently used) $limit tags
 $result = mysqli_execute_query($db,
     "select
-       tag, count(tag) as freq,
+       tag, count(distinct gameid) as freq,
        (unix_timestamp(now()) - unix_timestamp(max(moddate))) as age
      from gametags
      group by tag

--- a/www/showtags
+++ b/www/showtags
@@ -208,7 +208,6 @@ if (count($tags) == 0) {
         foreach ($tags as $t) {
             $freq = $t['freq'];
             $tag = $t['tag'];
-            $age = $t['age'];
             $td = htmlspecialcharx($tag);
             $tu = urlencode($tag);
             echo "<div>"


### PR DESCRIPTION
Fixes #882

Previously, the tag frequency (shown in parentheses in the table view) showed how many times that tag has been used in total, even redundantly. (The same tag can be applied to the same game more than once by different users.)

With this PR, the tag frequency instead shows how many distinct games a tag has been applied to, excluding redundant tags. The frequency on the showtags page should now be consistent with number of games that show up in search results when you click the tag.

I also removed an unnecessary line left over from a previous change.

Before:
![tag_count_before](https://github.com/user-attachments/assets/2c20ca3d-57f2-4df6-a1b3-ec1f9b80f384)



After:
![tag_count_after](https://github.com/user-attachments/assets/326760c2-5a0f-419e-9607-c357e5d6c222)
