### PR TITLE
Enable bfcache on session pages

### DIFF
--- a/www/session-start.php
+++ b/www/session-start.php
@@ -21,6 +21,11 @@ session_set_cookie_params([
     'samesite' => 'Lax'
 ]);
 
+// session_start automatically sets a cache-control header by default; disable that
+session_cache_limiter('');
+
+header('Cache-Control: private, no-cache');
+
 @session_start();
 
 ?>


### PR DESCRIPTION
`session_start()` automatically tosses in a `session.cache_limiter` setting, "nocache" that sets "Cache-Control: no-store, no-cache, must-revalidate"

https://www.php.net/manual/en/session.configuration.php#ini.session.cache-limiter
https://www.php.net/manual/en/function.session-cache-limiter.php

That's normally excessive, but harmless. `private, no-cache` would be sufficient to force revalidation.

But, it turns out, `no-store` breaks bfcache. https://web.dev/articles/bfcache#minimize-no-store

So, here, we're disabling the `cache_limiter` and setting an explicit `Cache-Control: private, no-cache`. This enables bfcache, which is especially snappy when you do a search, click on a game, and click the back button.