### PR TITLE
Cache CSS & JS immutably when cache busting

### DIFF
--- a/www/.htaccess
+++ b/www/.htaccess
@@ -11,8 +11,14 @@ ErrorDocument 503 /error503
   Deny from All
 </FilesMatch>
 
+# Cache immutable when t parameter is present, else no-cache
+RewriteCond %{QUERY_STRING} (^|&)t= [NC]
+RewriteRule \.(css|js)$ - [E=CACHE_CONTROL:immutable]
 <FilesMatch "\.(css|js)$">
-  Header set Cache-Control "no-cache"
+  Header set Cache-Control "public, max-age=31536000, immutable" env=CACHE_CONTROL
+</FilesMatch>
+<FilesMatch "\.(css|js)$">
+  Header set Cache-Control "public, no-cache" env=!CACHE_CONTROL
 </FilesMatch>
 
 RewriteEngine on

--- a/www/.htaccess
+++ b/www/.htaccess
@@ -16,9 +16,13 @@ RewriteCond %{QUERY_STRING} (^|&)t= [NC]
 RewriteRule \.(css|js)$ - [E=CACHE_CONTROL:immutable]
 <FilesMatch "\.(css|js)$">
   Header set Cache-Control "public, max-age=31536000, immutable" env=CACHE_CONTROL
+  # When using mod_deflate, Apache refuses to send 304s with ETags
+  # https://scarff.id.au/blog/2009/apache-304-and-mod_deflate-revisited/
+  FileEtag None
 </FilesMatch>
 <FilesMatch "\.(css|js)$">
   Header set Cache-Control "public, no-cache" env=!CACHE_CONTROL
+  FileETag None
 </FilesMatch>
 
 RewriteEngine on


### PR DESCRIPTION
We make an effort to request all CSS and JS files with a t= parameter, busting the cache.

But sometimes we can't do that, e.g. when users use a custom stylesheet (e.g. Midnight starts with `@import url("/ifdb.css"); `).

With these settings, when the URL contains a "t=" parameter, we set the file to be publicly cached immutably. When the t parameter is missing, we set it to no-cache, forcing the browser to revalidate its cache on every request.