### PR TITLE
Cache coverart when version is specified

### DIFF
--- a/www/search
+++ b/www/search
@@ -1449,6 +1449,7 @@ else if ($term || $browse)
                 $art = $row['hasart'];
                 $rcnt = $row['ratingcnt'];
                 $rdev = $row['ratingdev'];
+                $pagevsn = $row['pagevsn'];
                 $xlink = "";
                 if ($extraLinkA) {
                     $xlink = "<span class='details search__xlink'>"
@@ -1512,7 +1513,7 @@ else if ($term || $browse)
                     echo "<table class=grid border=0 cellspacing=0 cellpadding=0>"
                         . "<tr><td>"
                         . "<a href=\"viewgame?id=$id\">"
-                        . coverArtThumbnail($id, 80)
+                        . coverArtThumbnail($id, 80, "&version=$pagevsn")
                         . "</a></td><td>"
                         . "<h3 class=result><a href=\"viewgame?id=$id\">"
                         . "<b>$title</b></a></h3>$xlink<br>"

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -286,6 +286,7 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
                        games.sort_title as sort_title,
                        games.sort_author as sort_author,
                        ifnull(games.published, '9999-12-31') as sort_pub,
+                       games.pagevsn,
                        games.flags";
         $baseWhere = "";
         $groupBy = "";

--- a/www/viewgame
+++ b/www/viewgame
@@ -153,6 +153,10 @@ function sendCoverArt()
     // retrieve the image
     list($imgname, $title, $pagevsn) = mysql_fetch_row($result);
 
+    if (isset($_REQUEST['version'])) {
+        header("Cache-Control: public, max-age=31536000, immutable");
+    }
+
     // get the target version from the request
     $targVsn = (isset($_REQUEST['version'])
                 && (int)$pagevsn != (int)($_REQUEST['version']))
@@ -1383,7 +1387,7 @@ if ($hasart) {
                <td class=coverart>
 
                   <a href="<?php echo $arthref ?>&ldesc">
-                     <?php echo coverArtThumbnail($id, 175, isset($_REQUEST['version']) ? "&version=".$_REQUEST['version'] : ""); ?>
+                     <?php echo coverArtThumbnail($id, 175, isset($_REQUEST['version']) ? "&version=".$_REQUEST['version'] : "&version=$pagevsn"); ?>
                   </a>
                </td>
                <?php


### PR DESCRIPTION
Whenever we update the coverart, we create a new version of the page. So, when the version is specified, we can immutably cache the coverart image.

I've explicitly added a version parameter to the coverart at the top of the viewgame page and to the search results page. There are more spots to catch, but I think this is a very good start.