### PR TITLE
Ensure browsers (Firefox) don't autocomplete star control on refresh

### DIFF
--- a/www/starctl.php
+++ b/www/starctl.php
@@ -38,7 +38,7 @@ function showStarCtl($id, $init, $clickFunc)
         if ($i == $init) {
             $checked = "checked";
         }
-        $str .= "<input type='radio' name='rating' value='$i' id='{$id}__rating$i' $checked>"
+        $str .= "<input type='radio' name='rating' value='$i' id='{$id}__rating$i' autocomplete='off' $checked>"
             . "<label for='{$id}__rating$i'><span>"
             . ($i === 1 ? "1 star": "$i stars")
             ."</span></label>";


### PR DESCRIPTION
Fixes #906

https://stackoverflow.com/questions/299811/why-does-the-checkbox-stay-checked-when-reloading-the-page

This appears to only affect Firefox for some reason.