### PR TITLE
Clean up polls sampler

### DIFF
--- a/www/components/poll-sampler.php
+++ b/www/components/poll-sampler.php
@@ -32,8 +32,14 @@ $recently_created = mysqli_fetch_all($result);
 
 // add the most recently active polls (i.e., latest vote)
 $result = mysqli_execute_query($db,
-    "$baseQuery order by max(v.votedate) desc limit 0, 5", [$sandbox]);
+    "$baseQuery order by max(v.votedate) desc limit 0, 10", [$sandbox]);
 $recently_voted = mysqli_fetch_all($result);
+
+// don't show recently created polls in the "recently voted" section
+$recently_created_ids = array_fill_keys(array_map(function($row) { return $row[0]; }, $recently_created), 1);
+$recently_voted = array_slice(array_filter($recently_voted, function($row) use ($recently_created_ids) {
+    return !isset($recently_created_ids[$row[0]]);
+}), 0, 5);
 
 echo "<div class=\"block\"><div class=\"headline\">Vote!</div>"
     . "<p>Help other IFDB members find the games they're looking for "


### PR DESCRIPTION
I had a look at the polls sampler code responsible for list of polls in the homepage, and it didn't make sense to me, so I cleaned it up a bit to work closer to what the comments appear to intend.

It fetches the top 5 most recently-created polls, top 5 recently-active polls, and top 5 most popular polls.

Then it does this:
```
$allRows = array_merge($rows1, $rows2, $rows3);
$rows = array();
addPollRows($rows, $rows1, $allRows);
addPollRows($rows, $rows1, $allRows);
addPollRows($rows, $rows2, $allRows);
addPollRows($rows, $rows2, $allRows);
addPollRows($rows, $rows3, $allRows);
```

You'd think it takes 2 from the first group, 2 from the second group, and 1 from the third. But `addPollRows` actually adds two items, so the final result ends up having 10 items.

The comment above `addPollRows` says "pick the top 2 of each, skipping duplicates", which I think is intended to describe what the snippet pasted above does (even though it only takes 1 item from the third group).

`addPollRows` itself has these comments:

> Add the next element of src not in dst. If that failed, fall back to the master list

But that is not what it's doing. It's taking an item from `src` AND another item from the "master list" of all 3 groups.

I changed it to explicitly take 4 from each of the first two groups, and 2 from the last. But since this is just juggling 15 items, it ends up being the same as the original. Now it also removes items as it scans them, so it doesn't loop over the same items again and again.

So this change is mostly to ease the mind of anyone reading the code, while allowing easy changes in the future.