### PR TITLE
Giant search pages

### DIFF
--- a/www/search
+++ b/www/search
@@ -248,7 +248,7 @@ else {
 
 $pg = isset($_REQUEST['pg']) ? $_REQUEST['pg'] : "";
 $pgAll = false;
-$perPage = 20;
+$perPage = 100;
 $showAllMaxRows = 500;
 $sortby = isset($_REQUEST['sortby']) ? $_REQUEST['sortby'] : "";
 

--- a/www/util.php
+++ b/www/util.php
@@ -2962,7 +2962,7 @@ function coverArtThumbnail($id, $size, $version, $params = "") {
     }
     global $nonce;
     return "<style nonce='$nonce'>.coverart__img { max-width: 35vw; height: auto; }</style>"
-        ."<img class='coverart__img' srcset=\"$thumbnail{$size}x$size$params, $thumbnail{$x15}x$x15$params 1.5x, $thumbnail{$x2}x$x2$params 2x, $thumbnail{$x3}x$x3$params 3x\" src=\"$thumbnail{$size}x$size$params\" height=$size width=$size border=0 alt=\"\">";
+        ."<img class='coverart__img' loading='lazy' srcset=\"$thumbnail{$size}x$size$params, $thumbnail{$x15}x$x15$params 1.5x, $thumbnail{$x2}x$x2$params 2x, $thumbnail{$x3}x$x3$params 3x\" src=\"$thumbnail{$size}x$size$params\" height=$size width=$size border=0 alt=\"\">";
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
I'm not sure how I feel about this one.

@alice-blue suggested in a forum thread that it might be easier to browse if the page size was larger.

Search/browse results currently show 20 items, which _does_ seem kinda small. There's an existing feature where if there are fewer than 500 search results, a "Show All" button appears. <s>So, I figured, why not try showing 500 items per page?</s>

EDIT: At @salty-horse's suggestion, I cranked it down to 100.

This changes the size of the `/search?browse` page from 5.7KB (34KB uncompressed) to 14KB (135KB uncompressed). But each cover art image is ~100KB, so maybe that's not really a big deal.

When I enable 20x CPU throttling + 3G network throttling in Chrome Dev Tools, on the main branch I see a 0.9s [Largest Contentful Paint](https://web.dev/articles/optimize-lcp) (LCP), and a 1.4s DOMContentLoaded (DCL) on my local dev environment.

On this branch, I see a 1.3s LCP testing, and a 5.45s DCL. I think LCP is barely affected because the HTML is streaming in, so the browser can start rendering search results and downloading images as soon as the first chunk of HTML is downloaded.

I also added lazy-loading of cover art, to ensure that users wouldn't accidentally download 500 pieces of cover art. Now, with lazy loading, we only start downloading the art as you scroll down through the page.

I have a hunch that we maybe shouldn't turn this on right now, but it might be OK to do it if we use a CDN #926.

Other related ideas:
* infinite scrolling, so subsequent pages of search results pop in, rather than having to click Next Next Next to get to subsequent pages
* Make the first page 20 items for people just exploring the site, but make the 2nd+ page 500 items (for people who want to dig deep)