### PR TITLE
Initialize sandbox variable for logged-out users

### DIFF
--- a/www/viewgame
+++ b/www/viewgame
@@ -18,8 +18,9 @@ include_once "news.php";
 $db = dbConnect();
 $curuser = checkPersistentLogin();
 
-// check the user for ADMIN privileges
+// check the user for ADMIN privileges and sandbox setting
 $userprivs = $adminPriv = false;
+$mysandbox = 0;
 if ($curuser) {
     $result = mysqli_execute_query($db,
         "select `privileges`, `sandbox` from users where id=?", [$curuser]);


### PR DESCRIPTION
When viewing the game page while logged out, `$mysandbox` was used uninitialized here:
```php
// check for explicit cross-recommendations
$sandbox = $mysandbox ? "1" : "not(u.sandbox) and not (u2.sandbox)";
```