### PR TITLE
Support JSON output in search page

### DIFF
--- a/www/editcomp
+++ b/www/editcomp
@@ -1511,7 +1511,6 @@ function activateListeners(divno, model)
         var idx = "" + divno + "_" + i;
         (function(i){
             document.querySelectorAll('a.editLink' + idx).forEach(function(editLink) {
-                console.log({editLink});
                 editLink.addEventListener('click', function(event) {
                     event.preventDefault();
                     editGame(divno, i);
@@ -1520,7 +1519,6 @@ function activateListeners(divno, model)
         })(i);
 
         document.querySelectorAll('#gameplace'+idx).forEach(function(comboField) {
-            console.log({comboField});
             comboField.addEventListener('keydown', function(event) {
                 var result = comboFieldKey(event,comboField.name,comboField.name + 'CBSel','D');
                 if (result === false) event.preventDefault();
@@ -1531,7 +1529,6 @@ function activateListeners(divno, model)
             });
         });
         document.querySelectorAll('a[data-name=gameplace'+idx+']').forEach(function(comboArrow) {
-            console.log({comboArrow});
             comboArrow.addEventListener('click', function (event) {
                 event.preventDefault();
                 var name = comboArrow.dataset.name;
@@ -1550,7 +1547,6 @@ function activateListeners(divno, model)
         });
 
         document.querySelectorAll('#gameplace'+idx+"CBDiv").forEach(function(comboList) {
-            console.log({comboList});
             comboList.addEventListener('mouseover', function () {
                 overComboMenu = true;
             });
@@ -1560,7 +1556,6 @@ function activateListeners(divno, model)
         });
 
         document.querySelectorAll('#gameplace'+idx+"CBSel").forEach(function(comboSelect) {
-            console.log({comboSelect});
             var name = comboSelect.id.substring(0, comboSelect.id.length - 5);
             comboSelect.addEventListener('click', function (event) {
                 setComboText(name,event.target.value,null);

--- a/www/editcomp
+++ b/www/editcomp
@@ -1472,7 +1472,7 @@ function activateListeners(divno, model)
 
         const url = '/search?' + new URLSearchParams({
             searchbar: 'tag:' + tag,
-            xml: 1,
+            json: 1,
             pg: 'all',
             sortby: 'ttl',
         }).toString();
@@ -1482,23 +1482,19 @@ function activateListeners(divno, model)
             if (!response.ok) {
                 throw new Error("Failed loading results");
             }
-            const xml = await response.text();
+            const json = await response.json();
 
-            const results = [...new DOMParser().parseFromString(xml, "application/xml").querySelectorAll('game')].map(game => ({
-                id: game.querySelector('tuid').textContent,
-                title: game.querySelector('title').textContent,
-                author: game.querySelector('author').textContent,
-            }))
+            const results = json.games;
 
             if (!results.length) {
                 throw new Error("No results");
             }
 
-            for (const { id, title, author } of results) {
+            for (const { tuid, title, author } of results) {
                 const i = window[divModel0.vals].length;
                 gfInsRow('divModel0', i);
                 document.getElementById('gameplace0_' + i).value = "Entrant";
-                gameSearchPopupSetID(id, title, author);
+                gameSearchPopupSetID(tuid, title, author);
             }
         } catch (e) {
             alert("Error: " + e.message);

--- a/www/gamesearchpopup.php
+++ b/www/gamesearchpopup.php
@@ -62,18 +62,11 @@ function openGameSearchPopup(ele, doneFunc, defaultTitle, openerBtn)
     fld.focus();
     fld.value = defaultTitle;
 }
-async function gameSearchPopupKey(event)
+function gameSearchPopupKey(event)
 {
-    var ch = (window.event || event.keyCode ? event.keyCode : event.which);
-    if (ch == 13 || ch == 10) {
-        await gameSearchPopupGo();
-        return false;
-    }
-    if (ch == 27) {
+    if (event.code === 'Escape') {
         gameSearchPopupClose();
-        return false;
     }
-    return true;
 }
 function gameSearchPopupClose()
 {
@@ -206,17 +199,10 @@ function gameSearchPopupDiv()
           <input type=submit name="gameSearchPopupGoBtn"
               id="gameSearchPopupGoBtn" value="Search">
           <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
-            gameSearchPopupSearchBox.addEventListener('keypress', async function (event) {
-                var result = await gameSearchPopupKey(event);
-                if (result === false) event.preventDefault();
-            });
-            gameSearchPopupSearchBox.addEventListener('keydown', async function (event) {
-                var result = await gameSearchPopupKey(event);
-                if (result === false) event.preventDefault();
-            });
+            gameSearchPopupSearchBox.addEventListener('keydown', gameSearchPopupKey);
             gameSearchPopupGoBtn.addEventListener('click', async function (event) {
                 event.preventDefault();
-                await gameSearchPopupGo();
+                gameSearchPopupGo();
             });
           </script>
           <div id="gameSearchPopupStep2" class="displayNone">

--- a/www/profilelink.php
+++ b/www/profilelink.php
@@ -170,19 +170,6 @@ function aplClose()
     document.getElementById("aplStep2").style.display = "none";
     document.getElementById("aplDiv").style.display = "none";
 }
-async function aplPopupKey(event)
-{
-    var ch = (window.event || event.keyCode ? event.keyCode : event.which);
-    if (ch == 13 || ch == 10) {
-        await aplSearch();
-        return false;
-    }
-    if (ch == 27) {
-        aplClose();
-        return false;
-    }
-    return true;
-}
 async function aplSearch()
 {
     document.getElementById("aplStep2").style.display = "none";
@@ -291,17 +278,16 @@ function profileLinkDiv()
       <p><b>Step 1:</b> Search for an IFDB profile by member name.
       <br>
       <input id="aplSearchBox" type=text size=50>
-      <input type=submit name="aplSearchGo" id="aplSearchGo"
+      <input type=button name="aplSearchGo" id="aplSearchGo"
          value="Search">
       <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
-        aplSearchBox.addEventListener('keypress', async function(event) {
-            var result = await aplPopupKey(event);
-            if (result === false) event.preventDefault();
-        })
-        aplSearchGo.addEventListener('click', async function (event) {
-            event.preventDefault();
-            await aplSearch();
-        })
+        aplSearchBox.addEventListener('keypress', function({code}) {
+            if (code === 'Enter') aplSearch();
+        });
+        aplSearchBox.addEventListener('keydown', function({code}) {
+            if (code === 'Escape') aplClose();
+        });
+        aplSearchGo.addEventListener('click', aplSearch);
       </script>
       <div id="aplStep2" class="displayNone">
          <p><b>Step 2:</b> Click in the <span id="aplFieldName">text</span>

--- a/www/profilelink.php
+++ b/www/profilelink.php
@@ -170,11 +170,11 @@ function aplClose()
     document.getElementById("aplStep2").style.display = "none";
     document.getElementById("aplDiv").style.display = "none";
 }
-function aplPopupKey(event)
+async function aplPopupKey(event)
 {
     var ch = (window.event || event.keyCode ? event.keyCode : event.which);
     if (ch == 13 || ch == 10) {
-        aplSearch();
+        await aplSearch();
         return false;
     }
     if (ch == 27) {
@@ -183,12 +183,19 @@ function aplPopupKey(event)
     }
     return true;
 }
-function aplSearch()
+async function aplSearch()
 {
     document.getElementById("aplStep2").style.display = "none";
-    xmlSend("search?xml&member&searchfor="
-            + encodeURI8859(document.getElementById("aplSearchBox").value),
-            null, aplSearchDone, null);
+    try {
+        const response = await fetch("search?json&member&searchfor="
+                + encodeURI8859(document.getElementById("aplSearchBox").value));
+        if (!response.ok) {
+            throw new Error("Failed fetching the profiles.");
+        }
+        aplSearchDone(await response.json());
+    } catch (e) {
+        alert("Error: " + e.message);
+    }
 }
 function aplInsertID(id)
 {
@@ -205,15 +212,12 @@ function aplSearchDone(d)
 {
     if (d)
     {
-        var lst = d.getElementsByTagName('member');
         var s = "";
-        for (var i = 0 ; i < lst.length ; i++)
+        for (const m of d.members)
         {
-            var nm = lst[i].getElementsByTagName('name')[0].firstChild.data;
-            var id = lst[i].getElementsByTagName('tuid')[0].firstChild.data;
-            s += "<a href=\"needjs\" data-id='"+id+"'>"
-                 + encodeHTML(nm) + "</a>"
-                 + " - <a href=\"showuser?id=" + id + "\" target=\"_blank\">"
+            s += "<a href=\"needjs\" data-id='"+m.tuid+"'>"
+                 + encodeHTML(m.name) + "</a>"
+                 + " - <a href=\"showuser?id=" + m.tuid + "\" target=\"_blank\">"
                  + "view profile</a><br>";
         }
         if (s == "")
@@ -290,13 +294,13 @@ function profileLinkDiv()
       <input type=submit name="aplSearchGo" id="aplSearchGo"
          value="Search">
       <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
-        aplSearchBox.addEventListener('keypress', function(event) {
-            var result = aplPopupKey(event);
+        aplSearchBox.addEventListener('keypress', async function(event) {
+            var result = await aplPopupKey(event);
             if (result === false) event.preventDefault();
         })
-        aplSearchGo.addEventListener('click', function (event) {
+        aplSearchGo.addEventListener('click', async function (event) {
             event.preventDefault();
-            aplSearch();
+            await aplSearch();
         })
       </script>
       <div id="aplStep2" class="displayNone">

--- a/www/search
+++ b/www/search
@@ -14,7 +14,12 @@ include_once "dbconnect.php";
 $db = dbConnect();
 
 // check for API requests
-$xml = isset($_REQUEST['xml']);
+$api_mode = null;
+foreach (['xml', 'json'] as $api_param) {
+    if (isset($_REQUEST[$api_param])) {
+        $api_mode = $api_param;
+    }
+}
 
 // get the request parameters
 $term = get_req_data('searchfor');
@@ -26,14 +31,14 @@ if ($term == "" && $bTerm != "")
 
 // check for special API requests
 $enum = get_req_data("enum");
-if ($xml && $enum)
+if ($api_mode && $enum)
 {
     // assume no error
     $errmsg = false;
     $itemType = false;
 
     // queries for the various types
-    $queries = array(
+    $queries = [
         "genre" => "select distinct genre from games",
         "forgiveness" => "select distinct forgiveness from games",
         "language" => "select distinct language from games",
@@ -44,7 +49,8 @@ if ($xml && $enum)
                   .   "join filetypes as f on f.id = gl.fmtid "
                   .   "left outer join operatingsystems as os "
                   .       "on os.id = gl.osid "
-                  . "where f.fmtclass in ('X', 'G')");
+                  . "where f.fmtclass in ('X', 'G')"
+    ];
 
     // get the query
     if (isset($queries[$enum]))
@@ -279,7 +285,7 @@ if ($term || $browse) {
     }
 
     // if there's exactly one row, jump directly to the result page
-    if ($rowcnt == 1 && !$browse && !$xml) {
+    if ($rowcnt == 1 && !$browse && !$api_mode) {
         $redir = false;
         switch ($searchType) {
         case "game":
@@ -323,7 +329,7 @@ if ($term || $browse) {
 //   Start the page, if we're showing a UI (i.e., HTML mode, not XML mode)
 //
 
-if (!$xml) {
+if (!$api_mode) {
 
     // start the page
     $searchTypeName = ($searchType == "list" ? "Recommended Lists" :
@@ -381,11 +387,11 @@ function helpExtLink($title, $url)
         . "</div>";
 }
 
-if (!$xml) {
+if (!$api_mode) {
     echo "<div class='prerender-moderate'>\n";
 }
 
-if (!$browse && !$xml) {
+if (!$browse && !$api_mode) {
     $otherTabs = "<div class=\"browseLabel\">Searching</div>"
                  . "<div class=\"browseBar\">"
                  . "<div class=\"browseTabs\">";
@@ -457,7 +463,7 @@ function populateHelpList(id, div, tableWid, params, xml)
     <?php
 }
 
-if ($xml) {
+if ($api_mode) {
 
     // no UI in XML mode - this is an API request
 
@@ -889,7 +895,7 @@ else {  // ...default is searching games
 
         <p><b>authorid:<i>id</i></b> lists games by the author with
             the given id.
-       
+
         <p><b>competitionid:<i>id</i></b> lists games in a competition with
             the given id.
 
@@ -944,195 +950,196 @@ else {  // ...default is searching games
 //   If we had a search term, show the results
 //
 
-if ($xml) {
+if ($api_mode) {
 
-    // start the XML reply
-    header("Content-type: text/xml");
+    // start the API reply
+    if ($api_mode == 'json') {
+        header("Content-type: application/json");
+    } else if ($api_mode == 'xml') {
+        header("Content-type: text/xml");
+    }
     header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
     header("Cache-Control: no-store, no-cache, must-revalidate");
 
-    echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-        . "<searchReply xmlns=\"http://ifdb.org/api/xmlns\">";
+    if ($api_mode == 'xml') {
+        echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>";
+    }
 
     // check for errors
     if ($errMsg)
     {
-        echo "<error>"
-            . rss_encode(htmlspecialcharx($errMsg))
-            . "</error>"
-            . "</searchReply>";
+        $error_answer = [
+            'error'=> $errMsg,
+        ];
+
+        if ($api_mode == 'json') {
+            echo json_encode($error_answer);
+        } else if ($api_mode == 'xml') {
+            echo serialize_xml(['searchReply' => $error_answer]);
+        }
         exit();
     }
 
+    if ($api_mode == 'xml') {
+        echo "<searchReply xmlns=\"http://ifdb.org/api/xmlns\">";
+    }
+
     // we have a valid reply - start it
-    $grouptags = array(
+    $grouptags = [
         "game" => "games",
         "list" => "lists",
         "poll" => "polls",
         "comp" => "competitions",
         "member" => "members"
-    );
+    ];
+    $group_item_names = [
+        'comp' => 'competition',
+    ];
+
     $grouptag = $grouptags[$searchType];
-    echo "<$grouptag>";
+    $groupItemName = $group_item_names[$searchType] ?? $searchType;
+
+    if ($api_mode == 'json') {
+        echo "{\n    \"$grouptag\": [\n";
+    } else if ($api_mode == 'xml') {
+        echo "<$grouptag>";
+    }
 
     $showFlagged = isset($_GET['showFlagged']) && $_GET['showFlagged'];
     // send the results
-    for ($i = 0 ; $i < count($rows) ; $i++)
+    foreach ($rows as $i => $row)
     {
-        $row = $rows[$i];
+        // Convert database row from latin1 to UTF-8
+        array_walk($row, function(&$value, $key) {
+            if (is_string($value)) {
+                $value = rss_encode($value);
+                $value = html_entity_decode($value);
+            }
+        });
+
         switch($searchType)
         {
         case "game":
             $id = $row['id'];
-            $flags = $row['flags'];
-            $shouldHide = $flags & FLAG_SHOULD_HIDE;
+            $shouldHide = $row['flags'] & FLAG_SHOULD_HIDE;
             if (!$showFlagged && $shouldHide) {
                 break;
             }
-            $title = htmlspecialcharx($row['title']);
-            $author = htmlspecialcharx($row['author']);
-            $published = $row['published'];
-            $pubfmt = $row['pubfmt'];
-            $devsys = $row['devsys'];
-            $rating = $row['avgrating'];
-            list($stars) = roundStars($rating);
-            $ratingCnt = $row['ratingcnt'];
-            $starsort = $row['starsort'];
-            $art = ($row['hasart'] ? "yes" : "no");
-            $link = htmlspecialcharx(get_root_url() . "viewgame?id=$id");
 
-            $coverArtLink = "";
-            if ($art == "yes") {
-                $coverArtLink =
-                    "<coverArtLink>"
-                    . htmlspecialcharx(get_root_url() . "coverart?id=$id&version={$row['pagevsn']}")
-                    . "</coverArtLink>";
+            $item = [
+                'tuid' => $id,
+                'title' => $row['title'],
+                'link' => get_root_url() . "viewgame?id=$id",
+                'author' => $row['author'],
+                'hasCoverArt' => boolval($row['hasart']),
+                'devsys' => $row['devsys'],
+                'published' => [
+                    'machine' => $row['published'],
+                    'printable' => $row['pubfmt'],
+                ]
+            ];
+            if (!$shouldHide) {
+                $rating = $row['avgrating'];
+                $item['averageRating'] = $rating;
+                $item['numRatings'] = $row['ratingcnt'];
+                [$item['starRating']] = roundStars($rating);
+                $item['starSort'] = $row['starsort'];
+            }
+            if ($row['hasart']) {
+                $item['coverArtLink'] =
+                    get_root_url() . "coverart?id=$id&version={$row['pagevsn']}";
             }
 
-            echo rss_encode(
-                "<game>"
-                .   "<tuid>$id</tuid>"
-                .   "<title>$title</title>"
-                .   "<link>$link</link>"
-                .   "<author>$author</author>"
-                .   ($shouldHide ? "" : (
-                        "<averageRating>$rating</averageRating>"
-                    .   "<numRatings>$ratingCnt</numRatings>"
-                    .   "<starRating>$stars</starRating>"
-                    .   "<starSort>$starsort</starSort>"
-                ))
-                .   "<hasCoverArt>$art</hasCoverArt>"
-                .   "<devsys>$devsys</devsys>"
-                .   "<published>"
-                .     "<machine>$published</machine>"
-                .     "<printable>$pubfmt</printable>"
-                .   "</published>"
-                .   $coverArtLink
-                . "</game>");
             break;
 
         case "list":
             $id = $row['id'];
-            $title = htmlspecialcharx($row['title']);
-            $desc = htmlspecialcharx(fixDesc($row['desc']));
-            $userid = $row['userid'];
-            $username = htmlspecialcharx($row['username']);
-            $items = $row['itemcount'];
-            $link = htmlspecialcharx(get_root_url() . "viewlist?id=$id");
 
-            echo rss_encode(
-                "<list>"
-                .  "<tuid>$id</tuid>"
-                .  "<title>$title</title>"
-                .   "<link>$link</link>"
-                .  "<desc>$desc</desc>"
-                .  "<creatorID>$userid</creatorID>"
-                .  "<creatorName>$username</creatorName>"
-                .  "<numItems>$items</numItems>"
-                . "</list>");
+            $item = [
+                'tuid' => $id,
+                'title' => $row['title'],
+                'link' => get_root_url() . "viewlist?id=$id",
+                'desc' => fixDesc($row['desc']),
+                'creatorID' => $row['userid'],
+                'creatorName' => $row['username'],
+                'numItems' => $row['itemcount'],
+            ];
             break;
 
         case "poll":
             $id = $row['id'];
-            $title = htmlspecialcharx($row['title']);
-            $desc = fixDesc($row['desc']);
-            $userid = $row['userid'];
-            $username = htmlspecialcharx($row['username']);
-            $votecnt = $row['votecnt'];
-            $gamecnt = $row['gamecnt'];
-            $link = htmlspecialcharx(get_root_url() . "poll?id=$id");
 
-            echo rss_encode(
-                "<poll>"
-                .  "<tuid>$id</tuid>"
-                .  "<title>$title</title>"
-                .   "<link>$link</link>"
-                .  "<desc>$desc</desc>"
-                .  "<creatorID>$userid</creatorID>"
-                .  "<creatorName>$username</creatorName>"
-                .  "<numVotes>$votecnt</numVotes>"
-                .  "<numGames>$gamecnt</numGames>"
-                . "</poll>");
+            $item = [
+                'tuid' => $id,
+                'title' => $row['title'],
+                'link' => get_root_url() . "poll?id=$id",
+                'desc' => fixDesc($row['desc']),
+                'creatorID' => $row['userid'],
+                'creatorName' => $row['username'],
+                'numVotes' => $row['votecnt'],
+                'numGames' => $row['gamecnt'],
+            ];
             break;
 
         case "comp":
             $id = $row['compid'];
-            $title = htmlspecialcharx($row['title']);
-            $desc = fixDesc($row['desc']);
-            $gamecnt = $row['gamecnt'];
-            $divcnt = $row['divcnt'];
-            $link = htmlspecialcharx(get_root_url() . "viewcomp?id=$id");
 
-            echo rss_encode(
-                "<competition>"
-                .  "<tuid>$id</tuid>"
-                .  "<title>$title</title>"
-                .   "<link>$link</link>"
-                .  "<desc>$desc</desc>"
-                .  "<numGames>$gamecnt</numGames>"
-                .  "<numDivisions>$divcnt</numDivisions>"
-                . "</competition>");
+            $item = [
+                'tuid' => $id,
+                'title' => $row['title'],
+                'link' => get_root_url() . "viewcomp?id=$id",
+                'desc' => fixDesc($row['desc']),
+                'numGames' => $row['gamecnt'],
+                'numDivisions' => $row['divcnt'],
+            ];
             break;
 
         case "member":
             $id = $row['id'];
-            $name = htmlspecialcharx($row['name']);
-            $loc = htmlspecialcharx($row['location']);
-            $pic = ($row['haspic'] ? "yes" : "no");
             $badgeInfo = $badges ? ($badges[$id] ?? false) : false;
-            $badge = ($badgeInfo ? $badgeInfo[1] : false);
-            $link = htmlspecialcharx(get_root_url() . "showuser?id=$id");
 
-            $picLink = "";
-            if ($pic == "yes") {
-                $picLink =
-                    "<pictureLink>"
-                    . htmlspecialcharx(get_root_url() . "showuser?id=$id&pic")
-                    . "</pictureLink>";
+            $item = [
+                'tuid' => $id,
+                'name' => $row['name'],
+                'link' => get_root_url() . "showuser?id=$id",
+                'location' => $row['location'],
+                'hasPicture' => boolval($row['haspic']),
+                'badge' => ($badgeInfo ? $badgeInfo[1] : ''),
+            ];
+
+            if ($row['haspic']) {
+                $item['pictureLink'] = get_root_url() . "showuser?id=$id&pic";
             }
 
-            echo rss_encode(
-                "<member>"
-                .  "<tuid>$id</tuid>"
-                .  "<name>$name</name>"
-                .   "<link>$link</link>"
-                .  "<location>$loc</location>"
-                .  "<hasPicture>$pic</hasPicture>"
-                .  $picLink
-                .  "<badge>$badge</badge>"
-                . "</member>");
             break;
 
         case "tag":
             $id = $row['tag'];
             $link = htmlspecialcharx(get_root_url() . "search?searchfor=tag:$id");
             break;
+
+        default:
+            $item = [];
+        }
+
+        if ($api_mode == 'json') {
+            echo "        ";
+            echo json_encode($item);
+            if ($i != count($rows) - 1) {
+                echo ",\n";
+            }
+        } else if ($api_mode == 'xml') {
+            echo serialize_xml([$groupItemName => $item]);
         }
     }
 
-    // end the XML reply
-    echo "</$grouptag>"
-        . "</searchReply>";
+    // end the reply
+    if ($api_mode == 'json') {
+        echo "\n    ]\n}";
+    } else if ($api_mode == 'xml') {
+        echo "</$grouptag></searchReply>";
+    }
+
     exit();
 }
 else if ($term || $browse)
@@ -1598,7 +1605,7 @@ else if ($term || $browse)
 
 }
 
-if (!$xml) {
+if (!$api_mode) {
 ?>
 </div>
 <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">

--- a/www/search
+++ b/www/search
@@ -34,7 +34,6 @@ $enum = get_req_data("enum");
 if ($api_mode && $enum)
 {
     // assume no error
-    $errmsg = false;
     $itemType = false;
 
     // queries for the various types
@@ -52,18 +51,26 @@ if ($api_mode && $enum)
                   . "where f.fmtclass in ('X', 'G')"
     ];
 
+    $responseObj = [];
+
     // get the query
-    if (isset($queries[$enum]))
+    $enum_query = $queries[$enum] ?? null;
+    if (!$enum_query)
+    {
+        $responseObj['enumError'] = 'Invalid enumeration type';
+    }
+    else
     {
         // query the data set
-        $result = mysql_query($queries[$enum], $db);
+        $result = mysqli_execute_query($db, $enum_query);
 
         // fetch the rows
-        for ($i = 0, $cnt = mysql_num_rows($result), $items = array() ;
-             $i < $cnt ; ++$i)
+        $items = [];
+        while ([$g] = mysql_fetch_row($result))
         {
-            // fetch this row
-            list($g) = mysql_fetch_row($result);
+            // Convert database row from latin1 to UTF-8
+            $g = rss_encode($g);
+            $g = html_entity_decode($g);
 
             // apply any special per-row handling
             switch ($enum)
@@ -103,22 +110,22 @@ if ($api_mode && $enum)
                 if (preg_match("/^([a-z0-9]+)-/i", $l, $m))
                     $l = $m[1];
 
-                // lower-case it and quote it
-                $l = mysql_real_escape_string(strtolower($l), $db);
+                // lower-case it
+                $l = strtolower($l);
 
                 // figure the search column
                 $col = (strlen($l) == 2 ? "id2" : "id3");
 
                 // look up this language
-                $result = mysql_query(
+                $result = mysqli_execute_query($db,
                     "select group_concat(distinct name separator '/') "
                     . "from iso639x "
-                    . "where $col = '$l' "
-                    . "group by $col", $db);
+                    . "where $col = ? "
+                    . "group by $col", [$l]);
 
                 if (mysql_num_rows($result) > 0)
                 {
-                    list($langName) = mysql_fetch_row($result);
+                    [$langName] = mysql_fetch_row($result);
                     $items[$i] = "$langName ($lorig)";
                 }
             }
@@ -146,29 +153,19 @@ if ($api_mode && $enum)
             if ($g && ($dst == 0 || strcasecmp($g, $items[$dst-1]) != 0))
                 $items[$dst++] = $g;
         }
-    }
-    else
-    {
-        $errmsg = "<enumError>Invalid enumeration type</enumError>";
+        $items = array_slice($items , 0, $dst);
     }
 
     // send the results
-    ini_set("default_charset", "ISO-8859-1");
-    header("Content-type: text/xml");
+    ini_set("default_charset", "utf-8");
+    header("Content-type: application/json");
     header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
     header("Cache-Control: no-store, no-cache, must-revalidate");
 
-    echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-        . "<searchEnum xmlns=\"http://ifdb.org/api/xmlns\">"
-        . rss_encode($errmsg)
-        . "<itemType>$enum</itemType>"
-        . "<items>";
+    if ($items)
+        $responseObj['items'] = $items;
 
-    for ($i = 0 ; $i < $dst ; $i++)
-        echo "<item>" . rss_encode(htmlspecialcharx($items[$i])) . "</item>";
-
-    echo "</items>"
-        . "</searchEnum>";
+    echo json_encode($responseObj);
 
     // done
     exit();
@@ -415,31 +412,34 @@ if (!$browse && !$api_mode) {
     ?>
 <script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
 
-function openHelpList(id, tableWid, params)
+async function openHelpList(id, tableWid, params)
 {
     var divId = "helpList." + id;
     var div = document.getElementById(divId);
-    xmlSend("search?enum=" + id, divId,
-            function(xml) {
-                populateHelpList(id, div, tableWid, params, xml);
-            }, null);
     div.innerHTML = "(Retrieving list...)";
+    const response = await fetch("search?json&enum=" + id);
+    if (!response.ok) {
+        div.innerHTML = "Failed loading list";
+        return;
+    }
+    const json = await response.json();
+    populateHelpList(id, div, tableWid, params, json);
 }
 
-function populateHelpList(id, div, tableWid, params, xml)
+function populateHelpList(id, div, tableWid, params, json)
 {
-    var err = xmlChildText(xml, "enumError");
+    const err = json.enumError;
     if (err)
     {
         div.innerHTML = err;
         return;
     }
 
-    var items = xml.getElementsByTagName("item");
+    const items = json.items;
     var s = [];
-    for (var i = 0 ; i < items.length ; ++i)
+    for (const [i, item] of items.entries())
     {
-        var txt = items[i].firstChild.data;
+        const txt = item;
         var hrefParam = txt;
 
         var match;

--- a/www/util.php
+++ b/www/util.php
@@ -90,6 +90,48 @@ function rss_encode($str)
 
 // ------------------------------------------------------------------------
 //
+// XML serialization of arrays. Assumes UTF-8 data.
+//
+function serialize_xml($array) {
+    $parts = [];
+
+    foreach ($array as $key => $value) {
+        if (is_int($key)) {
+            $parts[] = serialize_xml($value);
+            continue;
+        }
+
+        $attrs_str = '';
+        if ($attrs = $value['_attrs'] ?? null) {
+            $attrs_parts = [];
+            foreach ($attrs as $akey => $avalue) {
+                $avalue = htmlspecialcharx($avalue);
+                $attrs_parts[] = " ${akey}=\"${avalue}\"";
+            }
+            $attrs_str = implode('', $attrs_parts);
+
+            $value = $value['_contents'];
+        }
+
+        $parts[] = "<$key$attrs_str>";
+        if (is_array($value)) {
+            $parts[] = serialize_xml($value);
+        } else {
+            if (is_string($value)) {
+                $value = htmlspecialcharx($value);
+            } else if (is_bool($value)) {
+                $value = $value ? 'yes' : 'no';
+            }
+            $parts[] = $value;
+        }
+        $parts[] = "</$key>";
+    }
+
+    return implode('', $parts);
+}
+
+// ------------------------------------------------------------------------
+//
 // Determine if the string is UTF-8 encoded.
 //
 function is_utf8($str)


### PR DESCRIPTION
* Implemented using "streaming" like the current XML output, so it writes records line by line, instead of serializing a whole JSON object from memory.
* Tested with latin1 and other encodings. To [test latin1](http://localhost:8080/search?searchfor=author%3ALinus+%C5kesson&json), see "Linus Åkesson" author of "The Impossible Bottle" which appears when browsing the top games. To test Unicode, search for [`author:taha`](http://localhost:8080/search?searchfor=author%3Ataha&searchgo=Search+Games&json) Strings with `&#xXXXX;` HTML escape sequences (straight from the database) are converted to unicode.
* yes/no values in XML were turned into booleans for JSON.
* The new `serialize_xml()` can be used in the RSS code as a future cleanup process.
* Most of the boolean values are redundant. You can deduce "hasCoverArt" from the existence of the "coverArtLink" field - can it be removed, maybe just for the new JSON API?
* There's some odd handling of some fields, like "badge" for members. It makes more sense to not return a field when it doesn't exist, rather than an empty element (or empty string in JSON), but I kept it as is.
* What's up with the `tag` search? It's not properly implemented for XML, and returning an error. Should it be removed?
* The [documentation](https://ifdb.org/api/search) needs to be updated.
* I think I used this JSON API in three places - are there more? `xmlSend` can't be used because it's adding the `xml` parameter (which does nothing since `json` in the URL takes precedence, but still...). Maybe it's time for a new modern "send" function based on `fetch` which doesn't try to load ActiveX objects?