### PR TITLE
Add version numbers to all thumbnail cover art URLs

### DIFF
--- a/www/club
+++ b/www/club
@@ -275,7 +275,7 @@ if (isset($_REQUEST['wishlist']) || isset($_REQUEST['playlist']))
         if ($gpic) {
             echo "<p><table border=0 cellpadding=0 cellspacing=0 class=grid>"
                 . "<tr><td><a href=\"viewgame?id=$gid\">"
-                . coverArtThumbnail($gid, 80)
+                . coverArtThumbnail($gid, 80, null)
                 . "</a></td>"
                 . "<td><a href=\"viewgame?id=$gid\"><i>$gtitle</i></a>, "
                 . "by $gauthor<br>"

--- a/www/components/ifdb-recommends.php
+++ b/www/components/ifdb-recommends.php
@@ -325,6 +325,7 @@ if (count($recs) == 0) {
            games.author as author,
            games.`desc` as `desc`,
            (games.coverart is not null) as hasart,
+           games.pagevsn,
            starsort
          from
            games
@@ -384,6 +385,7 @@ if (count($recs) >= 2) {
         $author = htmlspecialcharx($r['author']);
         $author = collapsedAuthors($author);
         $hasart = $r['hasart'];
+        $pagevsn = $r['pagevsn'];
         list($summary, $len, $trunc) = summarizeHtml($r['desc'], 140);
         $summary = fixDesc($summary);
 
@@ -393,7 +395,7 @@ if (count($recs) >= 2) {
             echo "<table border=0 cellspacing=0 cellpadding=0>"
                 . "<tr valign=top><td>"
                 . "<a href=\"viewgame?id=$gameid\" class=\"ifdb-recommends__artLink\" aria-label=\"$title\">"
-                . coverArtThumbnail($gameid, 70)
+                . coverArtThumbnail($gameid, 70, $pagevsn)
                 . "</a></td><td>";
 
         echo "<a href=\"viewgame?id=$gameid\"><i><b>$title</b></i></a>, "

--- a/www/crossrec
+++ b/www/crossrec
@@ -450,7 +450,7 @@ if ($editMode) {
     // query the recommendations
     $result = mysql_query(
         "select
-           c.togame, g.title as title, g.author, g.`desc`, g.coverart,
+           c.togame, g.title as title, g.author, g.`desc`, g.coverart, g.pagevsn,
            r.avgRating as rating,
            c.userid, u.name,
            c.notes, date_format(c.created, '%M %e, %Y'),
@@ -550,7 +550,7 @@ if ($editMode) {
     for ($i = $firstOnPage ; $i <= $lastOnPage ; $i++) {
         // unpack the game record
         $rec = $recs[$i];
-        list($toID, $toTitle, $toAuthor, $toDesc, $toArt, $toRating) = $rec;
+        list($toID, $toTitle, $toAuthor, $toDesc, $toArt, $toVersion, $toRating) = $rec;
 
         $toTitle = htmlspecialcharx($toTitle);
         $toAuthor = htmlspecialcharx($toAuthor);
@@ -563,7 +563,7 @@ if ($editMode) {
         if ($toArt) {
             echo "<td class='crossrec__artCell'>"
                 . "<a href=\"viewgame?id=$toID\">"
-                . coverArtThumbnail($toID, 80)
+                . coverArtThumbnail($toID, 80, $toVersion)
                 . "(toArt=$toArt)</a></td>";
         } else {
             echo "<td class='crossrec__emptyCell'></td>";

--- a/www/lists.php
+++ b/www/lists.php
@@ -11,6 +11,7 @@ function listMatchItem($match, $num, $showArt, $rating, $hrefTarget)
     $author = collapsedAuthors($author);
     $pubyear = $match['pubyear'];
     $art = $showArt && $match['hasart'];
+    $pagevsn = $match['pagevsn'];
 
     if ($hrefTarget != "")
         $hrefTarget = " target=\"$hrefTarget\"";
@@ -23,7 +24,7 @@ function listMatchItem($match, $num, $showArt, $rating, $hrefTarget)
 
     if ($art)
         echo "<a href=\"viewgame?id=$id\"$hrefTarget class=\"lists__art\">"
-            . coverArtThumbnail($id, 100)
+            . coverArtThumbnail($id, 100, $pagevsn)
             . "</a>";
 
     if ($num)

--- a/www/newitems.php
+++ b/www/newitems.php
@@ -377,7 +377,7 @@ function showNewItemList($db, $items, $first, $last, $showFlagged, $allowHiddenB
                         . "&thumbnail=50x50\"></a>";
                 } else if ($r["hasart"]) {
                     echo "<a href=\"viewgame?id={$r['gameid']}\">"
-                        . coverArtThumbnail($r['gameid'], 50)
+                        . coverArtThumbnail($r['gameid'], 50, null)
                         . "</a>";
                 } else {
                     echo "<a href=\"viewgame?id={$r['gameid']}"
@@ -488,7 +488,7 @@ function showNewItemList($db, $items, $first, $last, $showFlagged, $allowHiddenB
             if (ENABLE_IMAGES) {
                 if ($g["hasart"]) {
                     echo "<a href=\"viewgame?id={$g['id']}\">"
-                        . coverArtThumbnail($g['id'], 50)
+                        . coverArtThumbnail($g['id'], 50, null)
                         . "</a>";
                 } else {
                     echo "<a href=\"viewgame?id={$g['id']}\">"
@@ -607,7 +607,7 @@ function showNewItemList($db, $items, $first, $last, $showFlagged, $allowHiddenB
                         . "&thumbnail=50x50\"></a>";
                 } else if ($n["hasart"]) {
                     echo "<a href=\"viewgame?id={$n['gameid']}\">"
-                        . coverArtThumbnail($gid, 50)
+                        . coverArtThumbnail($gid, 50, null)
                         . "</a>";
                 } else {
                     echo "<a href=\"newslog?newsid=$nid\">"

--- a/www/playlist
+++ b/www/playlist
@@ -149,6 +149,7 @@ if ($errMsg) {
            games.author as author,
            games.`desc` as `desc`,
            (games.coverart is not null) as hasart,
+           games.pagevsn as pagevsn,
            avg(r3.rating) as rating,
            count(r3.rating) as numratings,
            games.sort_title as sort_title,
@@ -231,13 +232,14 @@ if ($errMsg) {
             $urating = $rec['urating'];
             $numratings = $rec['numratings'];
             $hasart = $rec['hasart'];
+            $pagevsn = $rec['pagevsn'];
             $onPlayList = ($listtype == "reviewideas" && $rec['onPlayList']);
 
             if ($hasart)
                 echo "<p><table border=0 cellspacing=0 cellpadding=0>"
                     . "<tr valign=top><td class='playlist__artCell'>"
                     . "<a href=\"viewgame?id=$gameid\">"
-                    . coverArtThumbnail($gameid, 100)
+                    . coverArtThumbnail($gameid, 100, $pagevsn)
                     . "</a></td>"
                     . "<td>";
 

--- a/www/poll
+++ b/www/poll
@@ -1163,7 +1163,7 @@ function expandVote(id)
             "select
                v.userid, u.name, $curUserVoteExpr,
                v.gameid, g.title, g.author, count(v2.gameid) as votecount,
-               g.coverart,
+               g.coverart, g.pagevsn,
                v.quickquote, v.notes,
                date_format(v.votedate, '%M %e, %Y'),
                c.comments,
@@ -1207,7 +1207,7 @@ function expandVote(id)
             "select
                null, null, 0,
                c.gameid, g.title, g.author, 0,
-               null,
+               null, null,
                null, null,
                '',
                c.comments,
@@ -1235,7 +1235,7 @@ function expandVote(id)
                 // fetch the next row
                 list($voteUserID, $voteUserName, $curUserVote,
                      $gameID, $gameTitle, $gameAuthor, $voteCount,
-                     $coverArt,
+                     $coverArt, $pagevsn,
                      $quickQuote, $notes,
                      $voteDateFmt,
                      $comments,
@@ -1354,7 +1354,7 @@ function expandVote(id)
                 if ($coverArt) {
                     echo "<td class='poll__artCell'>"
                         . "<a href=\"viewgame?id=$gameID\">"
-                        . coverArtThumbnail($gameID, 80)
+                        . coverArtThumbnail($gameID, 80, $pagevsn)
                         . "</a></td>";
                 } else {
                     echo "<td width='1px'></td>";

--- a/www/random
+++ b/www/random
@@ -90,6 +90,7 @@ $selectList = "games.id as id,
                date_format(published, '%Y') as pubyear,
                published,
                (coverart is not null) as hasart,
+               pagevsn,
                avgRating as avgrating,
                numRatingsInAvg as ratingcnt,
                stdDevRating as ratingdev,
@@ -176,6 +177,7 @@ if ($rowcnt == 0) {
         $stars = showStars($row['avgrating']);
         $year = output_encode(htmlspecialcharx($row['pubyear']));
         $art = $row['hasart'];
+        $pagevsn = $row['pagevsn'];
         $dev = $row['ratingdev'];
 
         // show the item
@@ -185,7 +187,7 @@ if ($rowcnt == 0) {
             echo "<table class=grid border=0 cellspacing=0 cellpadding=0>"
                 . "<tr><td>"
                 . "<a href=\"viewgame?id=$id\">"
-                . coverArtThumbnail($id, 80)
+                . coverArtThumbnail($id, 80, $pagevsn)
                 . "</a></td><td>"
                 . "<a href=\"viewgame?id=$id\">"
                 . "<b>$title</b></a><br>"

--- a/www/search
+++ b/www/search
@@ -1522,7 +1522,7 @@ else if ($term || $browse)
                     echo "<table class=grid border=0 cellspacing=0 cellpadding=0>"
                         . "<tr><td>"
                         . "<a class='$eagerness' href=\"viewgame?id=$id\">"
-                        . coverArtThumbnail($id, 80, "&version=$pagevsn")
+                        . coverArtThumbnail($id, 80, $pagevsn)
                         . "</a></td><td>"
                         . "<h3 class=result><a href=\"viewgame?id=$id\">"
                         . "<b>$title</b></a></h3>$xlink<br>"

--- a/www/showuser
+++ b/www/showuser
@@ -382,6 +382,7 @@ if ($errMsg) {
            date_format(games.published, '%Y') as year,
            games.`desc` as `desc`,
            (coverart is not null) as hasart,
+           games.pagevsn,
            grv.avgRating as rating,
            grv.numRatingsInAvg as ratingCnt,
            flags
@@ -407,6 +408,7 @@ if ($errMsg) {
             $author = htmlspecialcharx($rec['author']);
             $author = collapsedAuthors($author);
             $art = $rec['hasart'];
+            $pagevsn = $rec['pagevsn'];
             $descInfo = summarizeHtml($rec['desc'], 200);
             $desc = fixDesc($descInfo[0]);
             $shouldHide = $rec['flags'] & FLAG_SHOULD_HIDE;
@@ -428,7 +430,7 @@ if ($errMsg) {
                 echo "<table class=grid border=0 cellspacing=0 cellpadding=0>"
                     . "<tr><td>"
                     . "<a href=\"viewgame?id=$gid\">"
-                    . coverArtThumbnail($gid, 80)
+                    . coverArtThumbnail($gid, 80, $pagevsn)
                     . "</a></td><td>"
                     . "<a href=\"viewgame?id=$gid\"><b>$title</b></a>, "
                     . "by $author"

--- a/www/util.php
+++ b/www/util.php
@@ -2952,11 +2952,14 @@ function check_admin_privileges($db, $userid) {
 
 }
 
-function coverArtThumbnail($id, $size, $params = "") {
+function coverArtThumbnail($id, $size, $version, $params = "") {
     $thumbnail = "/coverart?id=$id&thumbnail=";
     $x15 = round($size * 3 / 2);
     $x2 = $size * 2;
     $x3 = $size * 3;
+    if ($version) {
+        $params .= "&version=$version";
+    }
     global $nonce;
     return "<style nonce='$nonce'>.coverart__img { max-width: 35vw; height: auto; }</style>"
         ."<img class='coverart__img' srcset=\"$thumbnail{$size}x$size$params, $thumbnail{$x15}x$x15$params 1.5x, $thumbnail{$x2}x$x2$params 2x, $thumbnail{$x3}x$x3$params 3x\" src=\"$thumbnail{$size}x$size$params\" height=$size width=$size border=0 alt=\"\">";

--- a/www/viewgame
+++ b/www/viewgame
@@ -1391,7 +1391,7 @@ if ($hasart) {
                <td class=coverart>
 
                   <a href="<?php echo $arthref ?>&ldesc">
-                     <?php echo coverArtThumbnail($id, 175, isset($_REQUEST['version']) ? "&version=".$_REQUEST['version'] : "&version=$pagevsn"); ?>
+                     <?php echo coverArtThumbnail($id, 175, isset($_REQUEST['version']) ? $_REQUEST['version'] : $pagevsn); ?>
                   </a>
                </td>
                <?php
@@ -1679,6 +1679,7 @@ if (!isEmpty($genre)) {
                g.author as author,
                g.`desc` as `desc`,
                (g.coverart is not null) as hasart,
+               g.pagevsn,
                c.notes as notes,
                (select count(*) from crossrecs as c2
                 where c2.fromgame = '$qid' and c2.togame = c.togame)
@@ -3051,6 +3052,7 @@ if (count($inrefs) != 0 && !$historyView) {
                     $crdescInfo = summarizeHtml($c['desc'], 240);
                     $crdesc = fixDesc($crdescInfo[0]);
                     $crart = $c['hasart'];
+                    $crversion = $c['pagevsn'];
 
                     $gameRatingsView = getGameRatingsView($db);
                     $result = mysql_query(
@@ -3068,7 +3070,7 @@ if (count($inrefs) != 0 && !$historyView) {
                         echo "<table class=grid cellspacing=0 cellpadding=0 "
                             . "border=0><tr><td>"
                             . "<a href=\"viewgame?id=$crid\">"
-                            . coverArtThumbnail($crid, 80)
+                            . coverArtThumbnail($crid, 80, $crversion)
                             . "</a></td><td>";
 
                     echo "<a href=\"viewgame?id=$crid\"><b>$crtitle</b></a>"

--- a/www/viewlist
+++ b/www/viewlist
@@ -40,7 +40,7 @@ if (mysql_num_rows($result) == 0) {
     $result = mysql_query(
         "select gameid as tuid, title, author,
              date_format(published, '%Y') as pubyear,
-             (coverart is not null) as hasart,
+             (coverart is not null) as hasart, pagevsn,
              comments, displayorder, flags
          from
              reclistitems, games


### PR DESCRIPTION
This ensures that they all have a long cache lifetime.

I left the version `null` in a couple places: `/club` and `newitems.php` on the home page, because I don't want to bother working on clubs, and because the home page doesn't show cover art by default.