### PR TITLE
Remove deprecated get_magic_quotes_gpc()

### DIFF
--- a/www/util.php
+++ b/www/util.php
@@ -256,10 +256,6 @@ function get_req_data($id)
     $val = (isset($_POST[$id]) && $_POST[$id]) ? $_POST[$id] :
            (isset($_REQUEST[$id]) ? $_REQUEST[$id] : "");
 
-    // if magic quotes are on, strip slashes
-    if (get_magic_quotes_gpc())
-        $val = stripslashes($val);
-
     // Opera has a bug (at least, it looks like a bug to me) that we need
     // to work around here.  If the form data contain certain extended
     // characters, Opera will encode them as &#dddd; entities.  This is


### PR DESCRIPTION
The last of the PHP 8 changes from #260 that should be applied to 7.

The [docs say](https://www.php.net/manual/en/function.get-magic-quotes-gpc.php):
> This function has been DEPRECATED as of PHP 7.4.0, and REMOVED as of PHP 8.0.0.
> Always returns `false`.