### PR TITLE
Allow custom stylesheets to force light/dark mode

### DIFF
--- a/sql/patch-schema-2.sql
+++ b/sql/patch-schema-2.sql
@@ -13,3 +13,8 @@ CREATE TABLE `blockedtagsynonyms` (
 
 insert into blockedtagsynonyms (blockedtag, preferredtag)
 values ('sci-fi', 'science fiction');
+
+
+ALTER TABLE `stylesheets` ADD COLUMN `dark` tinyint(1) NOT NULL DEFAULT 0;
+
+update stylesheets set contents = '@import url("/ifdb.css");', dark = 1, modified = now() where stylesheetid = 5;

--- a/www/ifdbutil.js
+++ b/www/ifdbutil.js
@@ -204,3 +204,28 @@ function replaceSelRange(ele, txt, selectNewText)
                       end: r.start + txt.length });
     }
 }
+
+// if the user has opted into a dark-mode stylesheet, activate all of the dark mode rules
+function forceDarkMode(force) {
+    if (!force) return;
+    var dark = force === 1;
+    function parseSheet(sheet) {
+        for (var i = sheet.cssRules.length - 1; i >=0 ; i--) {
+            var rule = sheet.cssRules[i];
+            if (rule.type === CSSRule.IMPORT_RULE) {
+                parseSheet(rule.styleSheet);
+                continue;
+            }
+            if (rule.media?.mediaText?.includes("prefers-color-scheme: dark")) {
+                if (dark) {
+                    rule.media.appendMedium("(prefers-color-scheme: light)");
+                } else {
+                    sheet.deleteRule(i);
+                }
+            }
+        }
+    }
+    for (const sheet of document.styleSheets) {
+        parseSheet(sheet);
+    }
+}

--- a/www/styles
+++ b/www/styles
@@ -30,7 +30,6 @@ if ($setID) {
     if ($userid) {
 
         if ($setID == 'default') {
-            $setVal = null;
             $newDesc = "the IFDB default";
         } else {
             // make sure the style sheet actually exists
@@ -82,15 +81,18 @@ if ($setID) {
     $reqTitle = false;
     $reqDesc = false;
     $reqContents = false;
+    $reqDark = false;
     if ($_SERVER['REQUEST_METHOD'] == 'POST') {
         $reqTitle = get_req_data('title');
         $reqDesc = get_req_data('desc');
         $reqContents = get_req_data('contents');
+        $reqDark = get_req_data('dark');
     }
 
     $dbTitle = false;
     $dbDesc = false;
     $dbContents = false;
+    $dbDark = false;
     if ($editID == 'new') {
         // creating a new one - no need to check for an existing copy
         $authorID = $userid;
@@ -100,7 +102,7 @@ if ($setID) {
         $result = mysqli_execute_query($db,
             "select
                s.stylesheetid, s.userid, count(u.id),
-               s.title, s.`desc`, s.contents
+               s.title, s.`desc`, s.contents, s.dark
              from stylesheets as s
                left join users as u
                  on u.stylesheetid = s.stylesheetid and u.id != ?
@@ -110,7 +112,7 @@ if ($setID) {
         $authorID = false;
         if (mysql_num_rows($result) > 0)
             [$ssid, $authorID, $userCnt,
-                 $dbTitle, $dbDesc, $dbContents] = mysql_fetch_row($result);
+                 $dbTitle, $dbDesc, $dbContents, $dbDark] = mysql_fetch_row($result);
     }
 
     if (!$userid) {
@@ -132,6 +134,7 @@ if ($setID) {
         $formTitle = $reqTitle;
         $formDesc = $reqDesc;
         $formContents = $reqContents;
+        $formDark = $reqDark;
 
         // note if it's a Save operation of some kind
         $isSave = isset($_REQUEST['saveStyle'])
@@ -178,8 +181,8 @@ if ($setID) {
                         $progress = "SIN003";
                         $result = mysqli_execute_query($db,
                             "insert into stylesheets
-                             (title, userid, `desc`, contents, created)
-                             values (?, ?, ?, ?, now())", [$formTitle, $userid, $formDesc, $formContents]);
+                             (title, userid, `desc`, contents, dark, created)
+                             values (?, ?, ?, ?, now())", [$formTitle, $userid, $formDesc, $formContents, $formDark]);
 
                         // if we succeeded, note the new ID
                         if ($result)
@@ -194,8 +197,8 @@ if ($setID) {
                         "update stylesheets
                          set
                            title = ?, `desc` = ?,
-                           contents = ?
-                         where stylesheetid = ?", [$formTitle, $formDesc, $formContents, $editID]);
+                           contents = ?, dark = ?
+                         where stylesheetid = ?", [$formTitle, $formDesc, $formContents, $formDark, $editID]);
                 }
             }
 
@@ -224,6 +227,7 @@ if ($setID) {
         $formTitle = $dbTitle;
         $formDesc = $dbDesc;
         $formContents = $dbContents;
+        $formDark = $dbDark;
     }
 
     // quote all of the form values
@@ -266,7 +270,7 @@ if ($setID) {
             echo "<b><span class=warning>Please be aware that $userCnt "
                 . "other $usersWord $usersAre currently using this style "
                 . "sheet. Any changes you make will affect everyone "
-                . "using the style sheet.</span>";
+                . "using the style sheet.</span></b>";
         }
 
         echo "<form name=\"editstyle\" method=\"post\" "
@@ -279,9 +283,19 @@ if ($setID) {
             . "<p><b>2. Enter a brief description:</b><br>"
             . "<textarea name=desc id=desc rows=3 cols=60>$formDesc"
             .    "</textarea>"
-            . "<p>"
+            . "</p>"
 
-            . "<b>3. Enter the CSS for the style sheet:</b><br>"
+            . "<p><b>3. Force dark mode:</b> "
+            . "<select name='dark'>"
+            . "<option value='0' " . ($formDark == 0 ? "selected" : "") . ">Don't Force</option>"
+            . "<option value='1' " . ($formDark == 1 ? "selected" : "") . ">Force Dark</option>"
+            . "<option value='2' " . ($formDark == 2 ? "selected" : "") . ">Force Light</option>"
+            . "</select>"
+            . "<br><span class='details'>"
+            . "When dark mode is forced, all of the <code>(prefers-color-scheme: dark)</code> rules will be enabled, "
+            . "even if the user's browser hasn't picked a color preference.</p>"
+
+            . "<p><b>4. Enter the CSS for the style sheet:</b><br>"
 
             . "<div class=tipbox>"
             . helpWinLink("help-css", "Click here")

--- a/www/styles
+++ b/www/styles
@@ -30,20 +30,17 @@ if ($setID) {
     if ($userid) {
 
         if ($setID == 'default') {
-            $setVal = 'null';
+            $setVal = null;
             $newDesc = "the IFDB default";
         } else {
-            $setID = mysql_real_escape_string($setID, $db);
-            $setVal = "'" . $setID . "'";
-
             // make sure the style sheet actually exists
-            $result = mysql_query(
+            $result = mysqli_execute_query($db,
                 "select
                    s.title, u.id, u.name
                  from
                    stylesheets as s
                    left join users as u on u.id = s.userid
-                 where s.stylesheetid = '$setID'", $db);
+                 where s.stylesheetid = ?", [$setID]);
             if (mysql_num_rows($result) > 0) {
 
                 // get the style sheet information
@@ -60,9 +57,9 @@ if ($setID) {
 
         // update the profile data, if we haven't encountered an error already
         if (!$errMsg) {
-            $result = mysql_query(
-                "update users set stylesheetid = $setVal
-                where id = '$userid'", $db);
+            $result = mysqli_execute_query($db,
+                "update users set stylesheetid = ?
+                where id = ?", [$setID, $userid]);
             if ($result)
                 $succMsg = "Your profile has been updated - your new "
                            . "style sheet is now $newDesc.";
@@ -79,7 +76,6 @@ if ($setID) {
 
 } else if ($editID) {
     // ------------------- edit one of my style sheets ----------------------
-    $editID = mysql_real_escape_string($editID, $db);
     $formErrCode = $formErrMsg = false;
 
     // if this is a POST, get the values from the request parameters
@@ -101,20 +97,20 @@ if ($setID) {
         $userCnt = 0;
     } else {
         // make sure it exists, and that it's really mine
-        $result = mysql_query(
+        $result = mysqli_execute_query($db,
             "select
                s.stylesheetid, s.userid, count(u.id),
                s.title, s.`desc`, s.contents
              from stylesheets as s
                left join users as u
-                 on u.stylesheetid = s.stylesheetid and u.id != '$userid'
-             where s.stylesheetid = '$editID'
+                 on u.stylesheetid = s.stylesheetid and u.id != ?
+             where s.stylesheetid = ?
              group by s.stylesheetid",
-            $db);
+            [$userid, $editID]);
         $authorID = false;
         if (mysql_num_rows($result) > 0)
-            list($ssid, $authorID, $userCnt,
-                 $dbTitle, $dbDesc, $dbContents) = mysql_fetch_row($result);
+            [$ssid, $authorID, $userCnt,
+                 $dbTitle, $dbDesc, $dbContents] = mysql_fetch_row($result);
     }
 
     if (!$userid) {
@@ -144,18 +140,13 @@ if ($setID) {
         // if this is a SAVE, try posting the update
         if ($isSave && !$errMsg) {
 
-            // quote the values for SQL
-            $qTitle = mysql_real_escape_string($formTitle, $db);
-            $qDesc = mysql_real_escape_string($formDesc, $db);
-            $qContents = mysql_real_escape_string($formContents, $db);
-
             // lock the style sheet table
             $progress = "SLC001";
             $result = mysql_query(
                 "lock tables stylesheets write, users write", $db);
 
             // make sure we have a title
-            if ($qTitle == '') {
+            if ($formTitle == '') {
                 $formErrMsg = "Please enter a title for the style sheet.";
                 $result = false;
             }
@@ -185,11 +176,10 @@ if ($setID) {
                     if ($result) {
                         // add the row
                         $progress = "SIN003";
-                        $result = mysql_query(
+                        $result = mysqli_execute_query($db,
                             "insert into stylesheets
                              (title, userid, `desc`, contents, created)
-                             values ('$qTitle', '$userid', '$qDesc',
-                                     '$qContents', now())", $db);
+                             values (?, ?, ?, ?, now())", [$formTitle, $userid, $formDesc, $formContents]);
 
                         // if we succeeded, note the new ID
                         if ($result)
@@ -200,20 +190,20 @@ if ($setID) {
 
                     // it's an existing row - update it
                     $progress = "SUP004";
-                    $result = mysql_query(
+                    $result = mysqli_execute_query($db,
                         "update stylesheets
                          set
-                           title = '$qTitle', `desc` = '$qDesc',
-                           contents = '$qContents'
-                         where stylesheetid = '$editID'", $db);
+                           title = ?, `desc` = ?,
+                           contents = ?
+                         where stylesheetid = ?", [$formTitle, $formDesc, $formContents, $editID]);
                 }
             }
 
             // if desired, activate the style
             if ($result && isset($_REQUEST['saveSetStyle'])) {
-                mysql_query(
-                    "update users set stylesheetid = '$editID'
-                     where id = '$userid'", $db);
+                mysqli_execute_query($db,
+                    "update users set stylesheetid = ?
+                     where id = ?", [$editID, $userid]);
             }
 
             // done with our table lock
@@ -325,17 +315,16 @@ if ($setID) {
 
 } else if ($deleteID) {
     // ------------------- delete one of my style sheets --------------------
-    $deleteID = mysql_real_escape_string($deleteID, $db);
 
     // make sure it exists, and that it's really mine
-    $result = mysql_query(
+    $result = mysqli_execute_query($db,
         "select s.stylesheetid, s.userid, count(u.id)
          from stylesheets as s
            left join users as u
-             on u.stylesheetid = s.stylesheetid and u.id != '$userid'
-         where s.stylesheetid = '$deleteID'
+             on u.stylesheetid = s.stylesheetid and u.id != ?
+         where s.stylesheetid = ?
          group by s.stylesheetid",
-        $db);
+        [$userid, $deleteID]);
     $ssid = false;
     $authorID = false;
     if (mysql_num_rows($result) > 0)
@@ -368,8 +357,8 @@ if ($setID) {
 
     } else {
         // we got confirmation, so delete it
-        $result = mysql_query(
-            "delete from stylesheets where stylesheetid = '$ssid'", $db);
+        $result = mysqli_execute_query($db,
+            "delete from stylesheets where stylesheetid = ?", [$ssid]);
 
         if ($result)
             $succMsg = "The style sheet has been deleted.";
@@ -391,8 +380,8 @@ if ($setID) {
     $curssid = false;
     if ($userid) {
         // get my current selection
-        $result = mysql_query(
-            "select stylesheetid from users where id='$userid'", $db);
+        $result = mysqli_execute_query($db,
+            "select stylesheetid from users where id=?", [$userid]);
         $curssid = mysql_result($result, 0, "stylesheetid");
     }
 

--- a/www/util.php
+++ b/www/util.php
@@ -49,6 +49,9 @@ define("FLAG_SHOULD_HIDE", 0x0001);
 define("POLL_FLAG_ANONYMOUS", 0x0001);
 define("POLL_FLAG_LOCKED", 0x0002);
 
+define("STYLESHEET_DARKFORCE_DARK", 1);
+define("STYLESHEET_DARKFORCE_LIGHT", 2);
+
 // --------------------------------------------------------------------------
 // shoot the recommendation cache
 //
@@ -391,7 +394,7 @@ function generateTUID($db, $tableCol, $maxtries)
 //
 function echoStylesheetLink()
 {
-    global $cssOverride;
+    global $cssOverride, $nonce, $ssdarkforce;
     $db = dbConnect();
 
     // check for a profile style
@@ -399,12 +402,12 @@ function echoStylesheetLink()
     $ssid = false;
     if ($userid && !$cssOverride) {
         $result = mysql_query(
-            "select u.stylesheetid, s.userid, s.modified
+            "select u.stylesheetid, s.userid, s.modified, s.dark
              from users as u
                join stylesheets as s on s.stylesheetid = u.stylesheetid
              where u.id='$userid'", $db);
         if (mysql_num_rows($result) > 0)
-            list($ssid, $ssauthor, $ssmodified) = mysql_fetch_row($result);
+            list($ssid, $ssauthor, $ssmodified, $ssdarkforce) = mysql_fetch_row($result);
     }
 
     // check for a temporary CSS override
@@ -412,9 +415,9 @@ function echoStylesheetLink()
         $db = dbConnect();
         $ssid = mysql_real_escape_string($cssOverride, $db);
         $result = mysql_query(
-            "select userid, modified from stylesheets
+            "select userid, dark, modified from stylesheets
              where stylesheetid = '$ssid'", $db);
-        list($ssauthor, $ssmodified) = mysql_fetch_row($result);
+        list($ssauthor, $ssdarkforce, $ssmodified) = mysql_fetch_row($result);
     }
 
     // If we found a custom style sheet selection, use it;
@@ -435,6 +438,11 @@ function echoStylesheetLink()
         $mtime = filemtime($_SERVER['DOCUMENT_ROOT'] . $stylesheet);
         echo "<link rel=\"stylesheet\" href=\"$stylesheet?t=$mtime\">";
     }
+
+    if ($ssdarkforce) {
+        echo "<script nonce='$nonce'>forceDarkMode($ssdarkforce);</script>";
+    }
+
 }
 
 // --------------------------------------------------------------------------
@@ -527,6 +535,7 @@ function sendImageLdesc($title, $imageID)
 //
 function showStars($num)
 {
+    global $ssdarkforce;
     // show no star image if there's no average
     if (isEmpty($num))
         return "";
@@ -541,13 +550,25 @@ function showStars($num)
     }
     // adding unused class='star-half-checked' and 'star-unchecked' so users can override them in IFDB custom stylesheets
     if (floor($roundedNum) != $roundedNum) {
-        $result .= "<picture><source srcset='/img/dark-images/star-half-checked.svg' media='(prefers-color-scheme: dark)'>"
-            ."<img height=13 class='star-half-checked' src='/img/star-half-checked.svg'></picture>";
+        if ($ssdarkforce === STYLESHEET_DARKFORCE_DARK) {
+            $result .= "<img height=13 class='star-half-checked' src='/img/dark-images/star-half-checked.svg'>";
+        } else if ($ssdarkforce === STYLESHEET_DARKFORCE_LIGHT) {
+            $result .= "<img height=13 class='star-half-checked' src='/img/star-half-checked.svg'>";
+        } else {
+            $result .= "<picture><source srcset='/img/dark-images/star-half-checked.svg' media='(prefers-color-scheme: dark)'>"
+                ."<img height=13 class='star-half-checked' src='/img/star-half-checked.svg'></picture>";
+        }
         $i++;
     }
     for (; $i <=5; $i++) {
-        $result .= "<picture><source srcset='/img/dark-images/star-unchecked.svg' media='(prefers-color-scheme: dark)'>"
-            ."<img height=13 class='star-unchecked' src='/img/star-unchecked.svg'></picture>";
+        if ($ssdarkforce === STYLESHEET_DARKFORCE_DARK) {
+            $result .= "<img height=13 class='star-unchecked' src='/img/dark-images/star-unchecked.svg'>";
+        } else if ($ssdarkforce === STYLESHEET_DARKFORCE_Light) {
+            $result .= "<img height=13 class='star-unchecked' src='/img/star-unchecked.svg'>";
+        } else {
+            $result .= "<picture><source srcset='/img/dark-images/star-unchecked.svg' media='(prefers-color-scheme: dark)'>"
+                ."<img height=13 class='star-unchecked' src='/img/star-unchecked.svg'></picture>";
+        }
     }
 
     $result .= "</span>";


### PR DESCRIPTION
Fixes #884, and, kinda, #669 

(Note that testing this requires stopping the Docker instance with `docker compose down`, `./prepare_dev_environment.sh`, and then `docker compose up`.

There's a new setting on custom stylesheets, "Force dark mode," which allows a stylesheet to force IFDB into dark mode or light mode.

When dark mode is forced, the rules that are set to `prefers-color-scheme: dark` are set to `prefers-color-scheme: light, prefers-color-scheme: dark`, i.e. the rule applies no matter what.

When light mode is forced, we remove the rules that are set to `prefers-color-scheme: dark`.

When this merges, I'll login as MJR one last time and set the Midnight CSS to be just `@import('ifdb.css')` with force dark mode. Then, future fixes to `ifdb.css` will automatically apply to Midnight users.

Furthermore, it will then be possible for users to pick a stylesheet that opts out of dark mode, even if their OS is set to prefer dark. I guess I'll create a new "Force Light" stylesheet and mention it in site news or something.