### PR TITLE
Fix restricted banner colors in dark mode

### DIFF
--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -2553,6 +2553,11 @@ span.sfl-save-autodesc {
     #tagDeletor span.cklabel {
         color: #9090ff;
     }
+
+    .restricted {
+        background: #444;
+    }
+
     input.go-button {
         background: url("/dark-images/go-button-midnight.gif") no-repeat center center;
     }


### PR DESCRIPTION
To reproduce, search for "Necromancer." You'll see a banner, "Some results were hidden. See all results"

When you click the banner, the game "Necromancer" will appear. Click through to it, and you'll see another banner:

"Links to this page and its ratings have been restricted, due to violations of our Code of Conduct"

# Before

<img width="820" alt="image" src="https://github.com/user-attachments/assets/b85de43c-4a7a-4356-8068-784e6da46f6f">

<img width="780" alt="image" src="https://github.com/user-attachments/assets/6a021d7f-199d-409f-84d3-7cdeb5ac1be6">

# After

<img width="794" alt="image" src="https://github.com/user-attachments/assets/4740bc80-1ba2-49e7-8b78-d97fc69d69d3">

<img width="725" alt="image" src="https://github.com/user-attachments/assets/921fd67c-57d5-4779-84d6-b12193b04f04">
