### PR TITLE
Do not leak unwishlist info for games

### DIFF
--- a/www/setunwishlist
+++ b/www/setunwishlist
@@ -88,10 +88,9 @@ if ($result) {
     $result = mysql_query(
         "select count(userid) from unwishlists
          where gameid='$qgameid'", $db);
-    list($newCnt) = mysql_fetch_row($result);
 
     // send the success reply
-    sendResponse("Saved", false, "Your change has been recorded.", $newCnt);
+    sendResponse("Saved", false, "Your change has been recorded.");
 }
 else
     sendResponse("Not Saved", "An error occurred updating the database "

--- a/www/viewgame
+++ b/www/viewgame
@@ -1267,13 +1267,9 @@ function updateWishList(id, stat)
 }
 function updateUnwishList(id, stat)
 {
-    var func = function(d)
-    {
-        updateUnwishlistCount(Number(xmlChildText(d, "newCount")));
-    };
     xmlSend("setunwishlist?game=<?php echo $id?>&add="
             + (ckboxIsChecked("ckUnwishList") ? "1" : "0"),
-            "ckUnwishlistSaveMsg", func, null);
+            "ckUnwishlistSaveMsg", null, null);
 }
 //-->
 </script>
@@ -1797,14 +1793,6 @@ function updateWishlistCount(n)
     document.getElementById("wishlistCount").innerHTML =
         (n == 0 ? "It's not on any wish lists yet" :
          "It's on " + n + " wishlist" + (n == 1 ? "." : "s."));
-}
-function updateUnwishlistCount(n)
-{
-<?php
-//    document.getElementById("unwishlistCount").innerHTML =
-//        (n == 0 ? "It's not on any no-interest lists" :
-//         "It's on " + n + " no-interest list" + (n == 1 ? "" : "s"));
-?>
 }
 </script>
 <?php


### PR DESCRIPTION
The "unwishlist" count was previously removed from the game page, but it was still returned in the API response.

If this information shouldn't be available, it should also be scrubbed from the database dump.