### PR TITLE
Switch viewgame update APIs to JSON

### DIFF
--- a/www/ifdbutil.js
+++ b/www/ifdbutil.js
@@ -229,3 +229,48 @@ function forceDarkMode(force) {
         parseSheet(sheet);
     }
 }
+
+async function jsonSend(url, statusSpanID, cbFunc, content, silentMode)
+{
+    if (statusSpanID)
+        document.getElementById(statusSpanID).innerHTML = "";
+
+    const options = {
+        method: 'POST',
+    };
+    if (content != null) {
+        options.body = JSON.stringify(content);
+    }
+
+    let jsonResponse = null;
+    try {
+        const response = await fetch(url, options);
+        jsonResponse = await response.json();
+        const msgspan = (statusSpanID
+                       ? document.getElementById(statusSpanID)
+                       : null);
+
+        if (!response || !response.ok)
+            throw new Error();
+
+        if (msgspan) {
+            const lbl = jsonResponse.label;
+            if (lbl)
+                msgspan.innerHTML = lbl;
+        }
+
+        const errmsg = jsonResponse.error;
+        if (errmsg)
+            alert(errmsg);
+    } catch (e) {
+        if (msgspan)
+            msgspan.innerHTML = "Not Saved";
+        if (!silentMode)
+            alert("An error occurred sending the update to the server. "
+                   + "(" + response.status + ") "
+                   + "Please try again later.");
+    }
+    if (cbFunc) {
+        cbFunc(jsonResponse);
+    }
+}

--- a/www/reviews.php
+++ b/www/reviews.php
@@ -4,9 +4,6 @@
 //
 // include_once "pagetpl.php";
 //
-// put the following extra text in the <HEAD> section:
-//    scriptSrc('/xmlreq.js')
-//
 // call initReviewVote() somewhere in the <BODY> section, to insert the
 // javascript code for review voting
 //
@@ -138,8 +135,8 @@ function initReviewVote()
 function sendReviewVote(reviewID, vote)
 {
     displayReviewVote(reviewID, vote);
-    xmlSend("reviewvote?id=" + reviewID + "&vote=" + vote,
-            "voteMsg_" + reviewID, null, null);
+    jsonSend("reviewvote?id=" + reviewID + "&vote=" + vote,
+             "voteMsg_" + reviewID);
 }
 function displayReviewVote(reviewID, vote)
 {

--- a/www/reviewvote
+++ b/www/reviewvote
@@ -2,67 +2,45 @@
 
 include_once "session-start.php";
 include_once "util.php";
-include_once "pagetpl.php";
 include_once "login-check.php";
+include_once "dbconnect.php";
 
-function sendResponse($statmsg, $errmsg, $detail)
-{
-    global $xml;
-
-    if ($xml)
-    {
-        header("Content-Type: text/xml");
-        header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-        header("Cache-Control: no-store, no-cache, must-revalidate");
-
-        echo "<?xml version=\"1.0\" encoding=\"UTF-8\" ?><response>"
-            . ($statmsg ? "<label>$statmsg</label>" : "")
-            . ($errmsg ? "<error>$errmsg</error>" : "")
-            . "</response>";
-    }
-    else
-    {
-        smallPageHeader("Review Vote");
-        if ($errmsg)
-            echo "<span class=errmsg>$errmsg</span><p>";
-
-        echo $detail;
-        smallPageFooter();
-    }
-
+if ($_SERVER['REQUEST_METHOD'] != 'POST') {
+    http_response_code(405);
+    echo "405 Method Not Allowed";
     exit();
 }
 
 // connect to the database
-include_once "dbconnect.php";
 $db = dbConnect();
 if ($db == false)
-    sendResponse("Not Saved", "An error occurred connecting to the database. "
-                 . "Please try again later.", false);
+    send_action_response("Not Saved", "An error occurred connecting to the database. "
+                         . "Please try again later.");
 
 // get the request parameters
 $id = $_REQUEST['id'];
 $vote = $_REQUEST['vote'];
-$xml = isset($_REQUEST['xml']);
 
 // make sure we process any persistent login state
 $userid = checkPersistentLogin();
-if (!$userid && !$xml && !logged_in(true))
+if (!$userid && !logged_in(true)) {
+    http_response_code(401);
+    echo "401 Unauthorized";
     exit();
+}
 
 if (!$userid)
-    sendResponse("Not Saved", "To vote on a review, please log in.", false);
+    send_action_response("Not Saved", "To vote on a review, please log in.");
 
 if (isEmpty($id) || isEmpty($vote) || strstr("YNR", $vote) == false)
-    sendResponse("Not Saved", "This voting link is not valid.", false);
+    send_action_response("Not Saved", "This voting link is not valid.");
 
 // make sure the game is valid
 $qid = mysql_real_escape_string($id, $db);
 $result = mysql_query("select id from reviews where id = '$qid'", $db);
 if (mysql_num_rows($result) == 0)
-    sendResponse("Not Saved",
-                 "This voting link refers to a non-existent review.",
-                 false);
+    send_action_response("Not Saved",
+                         "This voting link refers to a non-existent review.");
 
 // check for any past review for the same game by the same user
 $result = mysql_query("select vote from reviewvotes
@@ -82,26 +60,13 @@ if (strstr("YN", $vote)) {
 
     // explain what happened
     if ($result) {
-        sendResponse("Vote Recorded - Thanks!", false,
-                     "Thanks for voting! Your vote has been recorded."
-                     . (!isEmpty($oldvote)
-                        ? "<p>This replaces your previous vote for this review. "
-                        . "(Everyone gets one vote, so this doesn't count as an "
-                        . "extra vote, but you <i>can</i> switch your vote at any "
-                        . "time.)"
-                        : ""));
+        send_action_response("Vote Recorded - Thanks!");
     } else {
-        sendResponse("Not Saved", "An error occurred updating the database. "
-                     . "Please try again later.", false);
+        send_action_response("Not Saved", "An error occurred updating the database. "
+                     . "Please try again later.");
     }
 } else {
-// Reset Vote result
-    sendResponse("Vote Removed - Thanks!", false,
-                 "Thanks for voting! Your vote has been removed.", false);
-
+    // Reset Vote result
+    send_action_response("Vote Removed - Thanks!");
 }
-
-
-
-smallPageFooter();
 ?>

--- a/www/setplayed
+++ b/www/setplayed
@@ -2,64 +2,42 @@
 
 include_once "session-start.php";
 include_once "util.php";
-include_once "pagetpl.php";
 include_once "login-check.php";
+include_once "dbconnect.php";
 
-function sendResponse($statmsg, $errmsg, $detail, $newCnt = -1)
-{
-    global $xml;
-
-    if ($xml)
-    {
-        header("Content-Type: text/xml");
-        header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-        header("Cache-Control: no-store, no-cache, must-revalidate");
-
-        echo "<?xml version=\"1.0\" encoding=\"UTF-8\" ?><response>"
-            . ($statmsg ? "<label>$statmsg</label>" : "")
-            . ($errmsg ? "<error>$errmsg</error>" : "")
-            . ($newCnt >= 0 ? "<newCount>$newCnt</newCount>" : "")
-            . "</response>";
-    }
-    else
-    {
-        smallPageHeader("Review Vote");
-        if ($errmsg)
-            echo "<span class=errmsg>$errmsg</span><p>";
-
-        echo $detail;
-        smallPageFooter();
-    }
-
+if ($_SERVER['REQUEST_METHOD'] != 'POST') {
+    http_response_code(405);
+    echo "405 Method Not Allowed";
     exit();
 }
 
 // connect to the database
-include_once "dbconnect.php";
 $db = dbConnect();
 if ($db == false)
-    sendResponse("Not Saved", "An error occurred connecting to the database. "
-                 . "Please try again later.", false);
+    send_action_response("Not Saved", "An error occurred connecting to the database. "
+                         . "Please try again later.");
 
 // get the request parameters
 $gameid = get_req_data("game");
 $qgameid = mysql_real_escape_string($gameid, $db);
 $played = (int)get_req_data("played");
-$xml = isset($_REQUEST['xml']);
 
 // make sure it's a valid game
 $result = mysql_query("select title from games where id='$qgameid'", $db);
 if (mysql_num_rows($result) == 0)
-    sendResponse("Not Saved", "The specified game doesn't exist in the "
-                 . "database.");
+    send_action_response("Not Saved", "The specified game doesn't exist in the "
+                         . "database.");
 
 // make sure we process any persistent login state
 $userid = checkPersistentLogin();
-if (!$userid && !$xml && !logged_in(true))
+if (!$userid && !logged_in(true)) {
+    http_response_code(401);
+    echo "401 Unauthorized";
     exit();
+}
 
 if (!$userid)
-    sendResponse("Not Saved", "You must log in to use this feature.", false);
+    send_action_response("Not Saved", "You must log in to use this feature.");
 
 $progress = "QU107";
 $result = mysql_query(
@@ -89,11 +67,10 @@ if ($result) {
     list($newCnt) = mysql_fetch_row($result);
 
     // send the success reply
-    sendResponse("Saved", false, "Your change has been recorded.", $newCnt);
+    send_action_response("Saved", null, ["newCount" => $newCnt]);
 }
 else
-    sendResponse("Not Saved", "An error occurred updating the database "
-                 . "(failed operation: $progress). Please try again later.",
-                 false);
+    send_action_response("Not Saved", "An error occurred updating the database "
+                         . "(failed operation: $progress). Please try again later.");
 
 ?>

--- a/www/setrating
+++ b/www/setrating
@@ -2,67 +2,47 @@
 
 include_once "session-start.php";
 include_once "util.php";
-include_once "pagetpl.php";
 include_once "login-check.php";
+include_once "dbconnect.php";
 
-function sendResponse($statmsg, $errmsg, $detail)
-{
-    global $xml;
-
-    if ($xml)
-    {
-        header("Content-Type: text/xml");
-        header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-        header("Cache-Control: no-store, no-cache, must-revalidate");
-
-        echo "<?xml version=\"1.0\" encoding=\"UTF-8\" ?><response>"
-            . ($statmsg ? "<label>$statmsg</label>" : "")
-            . ($errmsg ? "<error>$errmsg</error>" : "")
-            . "</response>";
-    }
-    else
-    {
-        smallPageHeader("Rate a Game");
-        if ($errmsg)
-            echo "<span class=errmsg>$errmsg</span><p>";
-
-        echo $detail;
-        smallPageFooter();
-    }
-
+if ($_SERVER['REQUEST_METHOD'] != 'POST') {
+    http_response_code(405);
+    echo "405 Method Not Allowed";
     exit();
 }
 
 // connect to the database
-include_once "dbconnect.php";
 $db = dbConnect();
-if ($db == false)
-    sendResponse("Not Saved", "An error occurred connecting to the database. "
-                 . "Please try again later.", false);
+if ($db == false) {
+    send_action_response("Not Saved", "An error occurred connecting to the database. "
+                         . "Please try again later.");
+}
 
 // get the request parameters
 $game = get_req_data('game');
 $rating = (int)get_req_data('rating');
-$xml = isset($_REQUEST['xml']);
 
 // make sure there's a game
 if ($game == "")
-    sendResponse("Not Saved", "No game was specified.", false);
+    send_action_response("Not Saved", "No game was specified.");
 
 // make sure we process any persistent login state
 $userid = checkPersistentLogin();
-if (!$userid && !$xml && !logged_in(true))
+if (!$userid && !logged_in(true)) {
+    http_response_code(401);
+    echo "401 Unauthorized";
     exit();
+}
 
 // make sure we're logged in
 if (!$userid)
-    sendResponse("Not Saved", "To rate a game, please log in.", false);
+    send_action_response("Not Saved", "To rate a game, please log in.");
 
 // make sure the game is valid
 $qgame = mysql_real_escape_string($game, $db);
 $result = mysql_query("select id from games where id = '$qgame'", $db);
 if (mysql_num_rows($result) == 0)
-    sendResponse("Not Saved", "The specified game was not found.", false);
+    send_action_response("Not Saved", "The specified game was not found.");
 
 // if there's an existing review for this user for this game, simply update
 // the rating; otherwise insert a new row with an empty review
@@ -82,7 +62,7 @@ if ($result && mysql_num_rows($result)) {
 }
 
 if ($rating < 0 || $rating > 5) {
-    sendResponse("Not Saved", "The rating specified is not valid.", false);
+    send_action_response("Not Saved", "The rating specified is not valid.");
 }
 
 // set the rating:
@@ -119,13 +99,12 @@ mysql_query("unlock tables", $db);
 
 // check the result
 if ($result) {
-    sendResponse("Saved", false, $ok);
+    send_action_response("Saved");
 } else if ($ok) {
-    sendResponse("Not Saved", "An error occurred updating the database. "
-                 . "Please try again later.", false);
+    send_action_response("Not Saved", "An error occurred updating the database. "
+                         . "Please try again later.");
 } else {
-    sendResponse("Not Saved", "The request was invalid.", false);
+    send_action_response("Not Saved", "The request was invalid.");
 }
 
-smallPageFooter();
 ?>

--- a/www/setunwishlist
+++ b/www/setunwishlist
@@ -2,49 +2,24 @@
 
 include_once "session-start.php";
 include_once "util.php";
-include_once "pagetpl.php";
 include_once "login-check.php";
+include_once "dbconnect.php";
 
-function sendResponse($statmsg, $errmsg, $detail, $newCount = -1)
-{
-    global $xml;
-
-    if ($xml)
-    {
-        header("Content-Type: text/xml");
-        header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-        header("Cache-Control: no-store, no-cache, must-revalidate");
-
-        echo "<?xml version=\"1.0\" encoding=\"UTF-8\" ?><response>"
-            . ($statmsg ? "<label>$statmsg</label>" : "")
-            . ($errmsg ? "<error>$errmsg</error>" : "")
-            . ($newCount >= 0 ? "<newCount>$newCount</newCount>" : "")
-            . "</response>";
-    }
-    else
-    {
-        smallPageHeader("Review Vote");
-        if ($errmsg)
-            echo "<span class=errmsg>$errmsg</span><p>";
-
-        echo $detail;
-        smallPageFooter();
-    }
-
+if ($_SERVER['REQUEST_METHOD'] != 'POST') {
+    http_response_code(405);
+    echo "405 Method Not Allowed";
     exit();
 }
 
 // connect to the database
-include_once "dbconnect.php";
 $db = dbConnect();
 if ($db == false)
-    sendResponse("Not Saved", "An error occurred connecting to the database. "
-                 . "Please try again later.", false);
+    send_action_response("Not Saved", "An error occurred connecting to the database. "
+                         . "Please try again later.");
 
 // get the request parameters
 $gameid = get_req_data("game");
 $add = (int)get_req_data("add");
-$xml = isset($_REQUEST['xml']);
 
 // validate & quote the parameters
 $qgameid = mysql_real_escape_string($gameid, $db);
@@ -52,16 +27,19 @@ $qgameid = mysql_real_escape_string($gameid, $db);
 // make sure it's a valid game
 $result = mysql_query("select title from games where id='$qgameid'", $db);
 if (mysql_num_rows($result) == 0)
-    sendResponse("Not Saved", "The specified game doesn't exist in the "
-                 . "database.");
+    send_action_response("Not Saved", "The specified game doesn't exist in the "
+                         . "database.");
 
 // make sure we process any persistent login state
 $userid = checkPersistentLogin();
-if (!$userid && !$xml && !logged_in(true))
+if (!$userid && !logged_in(true)) {
+    http_response_code(401);
+    echo "401 Unauthorized";
     exit();
+}
 
 if (!$userid)
-    sendResponse("Not Saved", "You must log in to use this feature.", false);
+    send_action_response("Not Saved", "You must log in to use this feature.");
 
 $progress = "QU107";
 $result = mysql_query(
@@ -84,11 +62,10 @@ if ($cnt == 0 && $add) {
 
 if ($result) {
     // send the success reply
-    sendResponse("Saved", false, "Your change has been recorded.");
+    send_action_response("Saved");
 }
 else
-    sendResponse("Not Saved", "An error occurred updating the database "
-                 . "(failed operation: $progress). Please try again later.",
-                 false);
+    send_action_response("Not Saved", "An error occurred updating the database "
+                         . "(failed operation: $progress). Please try again later.");
 
 ?>

--- a/www/setwishlist
+++ b/www/setwishlist
@@ -2,49 +2,24 @@
 
 include_once "session-start.php";
 include_once "util.php";
-include_once "pagetpl.php";
 include_once "login-check.php";
+include_once "dbconnect.php";
 
-function sendResponse($statmsg, $errmsg, $detail, $newCount = -1)
-{
-    global $xml;
-
-    if ($xml)
-    {
-        header("Content-Type: text/xml");
-        header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-        header("Cache-Control: no-store, no-cache, must-revalidate");
-
-        echo "<?xml version=\"1.0\" encoding=\"UTF-8\" ?><response>"
-            . ($statmsg ? "<label>$statmsg</label>" : "")
-            . ($errmsg ? "<error>$errmsg</error>" : "")
-            . ($newCount >= 0 ? "<newCount>$newCount</newCount>" : "")
-            . "</response>";
-    }
-    else
-    {
-        smallPageHeader("Review Vote");
-        if ($errmsg)
-            echo "<span class=errmsg>$errmsg</span><p>";
-
-        echo $detail;
-        smallPageFooter();
-    }
-
+if ($_SERVER['REQUEST_METHOD'] != 'POST') {
+    http_response_code(405);
+    echo "405 Method Not Allowed";
     exit();
 }
 
 // connect to the database
-include_once "dbconnect.php";
 $db = dbConnect();
 if ($db == false)
-    sendResponse("Not Saved", "An error occurred connecting to the database. "
-                 . "Please try again later.", false);
+    send_action_response("Not Saved", "An error occurred connecting to the database. "
+                         . "Please try again later.");
 
 // get the request parameters
 $gameid = get_req_data("game");
 $add = (int)get_req_data("add");
-$xml = isset($_REQUEST['xml']);
 
 // validate & quote the parameters
 $qgameid = mysql_real_escape_string($gameid, $db);
@@ -52,16 +27,19 @@ $qgameid = mysql_real_escape_string($gameid, $db);
 // make sure it's a valid game
 $result = mysql_query("select title from games where id='$qgameid'", $db);
 if (mysql_num_rows($result) == 0)
-    sendResponse("Not Saved", "The specified game doesn't exist in the "
-                 . "database.");
+    send_action_response("Not Saved", "The specified game doesn't exist in the "
+                         . "database.");
 
 // make sure we process any persistent login state
 $userid = checkPersistentLogin();
-if (!$userid && !$xml && !logged_in(true))
+if (!$userid && !logged_in(true)) {
+    http_response_code(401);
+    echo "401 Unauthorized";
     exit();
+}
 
 if (!$userid)
-    sendResponse("Not Saved", "You must log in to use this feature.", false);
+    send_action_response("Not Saved", "You must log in to use this feature.");
 
 $progress = "QU107";
 $result = mysql_query(
@@ -91,11 +69,10 @@ if ($result) {
     list($newCnt) = mysql_fetch_row($result);
 
     // send the success reply
-    sendResponse("Saved", false, "Your change has been recorded.", $newCnt);
+    send_action_response("Saved", null, ["newCount" => $newCnt]);
 }
 else
-    sendResponse("Not Saved", "An error occurred updating the database "
-                 . "(failed operation: $progress). Please try again later.",
-                 false);
+    send_action_response("Not Saved", "An error occurred updating the database "
+                         . "(failed operation: $progress). Please try again later.");
 
 ?>

--- a/www/util.php
+++ b/www/util.php
@@ -2905,4 +2905,38 @@ function collapsedAuthors($authors) {
     return $str;
 }
 
+// ----------------------------------------------------------------------------
+//
+// Sends a JSON response, used by the API
+//
+
+function send_json_response($data) {
+    header("Content-Type: application/json");
+    header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
+    header("Cache-Control: no-store, no-cache, must-revalidate");
+
+    echo json_encode($data);
+}
+
+// ----------------------------------------------------------------------------
+//
+// Sends a response to small update operations made by users
+//
+
+function send_action_response($label, $error = null, $extra = null) {
+    $arr = [];
+    if ($label)
+        $arr['label'] = $label;
+    if ($error)
+        $arr['error'] = $error;
+    if ($extra) {
+        foreach ($extra as $k => $v) {
+            $arr[$k] = $v;
+        }
+    }
+
+    send_json_response($arr);
+    exit();
+}
+
 ?>

--- a/www/viewgame
+++ b/www/viewgame
@@ -1785,6 +1785,8 @@ if (!$should_hide) {
 <!--
 function updatePlaylistCount(n)
 {
+    if (n === null || n === undefined)
+        return;
     document.getElementById("playlistCount").innerHTML =
         "" + (n == 0 ? "No" : n) + " member" + (n == 1 ? " has" : "s have")
         + " played this game.";

--- a/www/viewgame
+++ b/www/viewgame
@@ -1243,8 +1243,8 @@ function updateRating(rating)
     } else {
         submitRating.style.display = 'none';
     }
-    xmlSend("setrating?game=<?php echo $id?>&rating=" + rating,
-            "ratingSaveMsg", null, null);
+    jsonSend("setrating?game=<?php echo $id?>&rating=" + rating,
+             "ratingSaveMsg");
 }
 function updatePlayed(id, stat)
 {

--- a/www/viewgame
+++ b/www/viewgame
@@ -1260,9 +1260,9 @@ function updateWishList(id, stat)
 }
 function updateUnwishList(id, stat)
 {
-    xmlSend("setunwishlist?game=<?php echo $id?>&add="
-            + (ckboxIsChecked("ckUnwishList") ? "1" : "0"),
-            "ckUnwishlistSaveMsg", null, null);
+    jsonSend("setunwishlist?game=<?php echo $id?>&add="
+             + (ckboxIsChecked("ckUnwishList") ? "1" : "0"),
+             "ckUnwishlistSaveMsg");
 }
 //-->
 </script>

--- a/www/viewgame
+++ b/www/viewgame
@@ -1248,13 +1248,9 @@ function updateRating(rating)
 }
 function updatePlayed(id, stat)
 {
-    var func = function(d)
-    {
-        updatePlaylistCount(Number(xmlChildText(d, "newCount")));
-    };
-    xmlSend("setplayed?game=<?php echo $id?>&played="
-            + (ckboxIsChecked("ckPlayed") ? "1" : "0"),
-            "ckPlaySaveMsg", func, null);
+    jsonSend("setplayed?game=<?php echo $id?>&played="
+             + (ckboxIsChecked("ckPlayed") ? "1" : "0"),
+             "ckPlaySaveMsg", (d) => {updatePlaylistCount(d.newCount);});
 }
 function updateWishList(id, stat)
 {

--- a/www/viewgame
+++ b/www/viewgame
@@ -1254,13 +1254,9 @@ function updatePlayed(id, stat)
 }
 function updateWishList(id, stat)
 {
-    var func = function(d)
-    {
-        updateWishlistCount(Number(xmlChildText(d, "newCount")));
-    };
-    xmlSend("setwishlist?game=<?php echo $id?>&add="
-            + (ckboxIsChecked("ckWishList") ? "1" : "0"),
-            "ckWishlistSaveMsg", func, null);
+    jsonSend("setwishlist?game=<?php echo $id?>&add="
+             + (ckboxIsChecked("ckWishList") ? "1" : "0"),
+             "ckWishlistSaveMsg", (d) => {updateWishlistCount(d.newCount)});
 }
 function updateUnwishList(id, stat)
 {
@@ -1789,6 +1785,8 @@ function updatePlaylistCount(n)
 }
 function updateWishlistCount(n)
 {
+    if (n === null || n === undefined)
+        return;
     document.getElementById("wishlistCount").innerHTML =
         (n == 0 ? "It's not on any wish lists yet" :
          "It's on " + n + " wishlist" + (n == 1 ? "." : "s."));


### PR DESCRIPTION
This updates `reviewvote`, `setrating`, `setplayed`, `setwishlist`, `setunwishlist` to JSON and forcing POST requests.

It also applies the change from #954 to not leak the unwishlist count.

The new `jsonSend` currently only supports POST requests. While `xmlSend` is used in a few other places for `GET` requests, I think it can be replaced with a simpler `jsonGet`.