### PR TITLE
Streamline competitions and lists; restore `/allnew`

### DIFF
--- a/www/components/competitions.php
+++ b/www/components/competitions.php
@@ -9,7 +9,65 @@
 <?php
 
 // get the latest competitions and competition news
-showNewItems($db, 0, 4, false, false, false, NEWITEMS_COMPS | NEWITEMS_COMPNEWS);
+$items = getNewItems($db, 7, NEWITEMS_COMPS | NEWITEMS_COMPNEWS);
+
+for ($idx = 0 ; $idx <= 7; $idx++)
+{
+    // get this item
+    list($pick, $rawDate, $row) = $items[$idx];
+
+    $eager = ($idx < 4 ? "class='eager'" : "");
+
+    if ($pick == 'N')
+    {
+        // it's a news item
+        $n = $row;
+
+        // pull out the game news item
+        $gid = $n['sourceID'];
+        $gtitle = htmlspecialcharx($n['sourceTitle']);
+        $nid = $n['newsID'];
+        $ncre = $n['createdFmt'];
+        $nmod = $n['modifiedFmt'];
+        $nuid = $n['userID'];
+        $nuname = htmlspecialcharx($n['userName']);
+        $nuidOrig = $n['origUserID'];
+        $nunameOrig = htmlspecialcharx($n['origUserName']);
+        $nhead = htmlspecialcharx($n['headline']);
+
+        $href = "viewcomp?id=$gid";
+        $divclass = "new-comp-news";
+
+        // summarize the item
+        echo "<div class=\"$divclass\">"
+            . "News on <a href=\"$href\">$gtitle</a>: "
+            . "<b>$nhead</b> "
+            . "<span class=notes><i>$ncre</i></span> "
+            . "<a href=\"newslog?newsid=$nid\">Details</a>"
+            . "</span></div>"
+            . "</div>";
+    }
+    else if ($pick == 'C')
+    {
+        // it's a competition
+        $c = $row;
+
+        // pull out the competition item
+        $cid = $c["compid"];
+        $ctitle = htmlspecialcharx($c["title"]);
+        $cdate = $c["fmtdate"];
+
+
+        // summarize the item
+        echo "<div class=\"new-competition\">"
+            . "<a href=\"viewcomp?id=$cid\">"
+            . "$ctitle</a> <span class=notes><i>created $cdate</i></span>"
+            . "<br><div class=indented>"
+            . "</div>"
+            . "</div>";
+    }
+
+}
 
 ?>
 <p><span class=details>

--- a/www/components/competitions.php
+++ b/www/components/competitions.php
@@ -1,0 +1,18 @@
+<div class=headline id='competitions'><h1 class='unset'>Competitions</h1>
+    <span class=headlineRss>
+        <a href="/editcomp?id=new">Add a competition listing</a>
+    </span>
+</div>
+
+<p><a href="https://ifcomp.org/">IF Comp</a> | <a href="https://www.springthing.net/">Spring Thing</a> | <a href="https://xyzzyawards.org/">XYZZY Awards</a></p>
+
+<?php
+
+// get the latest competitions and competition news
+showNewItems($db, 0, 4, false, false, false, NEWITEMS_COMPS | NEWITEMS_COMPNEWS);
+
+?>
+<p><span class=details>
+    <a href="/search?browse&comp">Browse competitions</a> |
+    <a href="/search?comp">Search competitions</a>
+</span></p>

--- a/www/components/competitions.php
+++ b/www/components/competitions.php
@@ -14,7 +14,7 @@ $items = getNewItems($db, 7, NEWITEMS_COMPS | NEWITEMS_COMPNEWS);
 for ($idx = 0 ; $idx <= 7; $idx++)
 {
     // get this item
-    list($pick, $rawDate, $row) = $items[$idx];
+    [$pick, $rawDate, $row] = $items[$idx];
 
     $eager = ($idx < 4 ? "class='eager'" : "");
 

--- a/www/components/games.php
+++ b/www/components/games.php
@@ -1,0 +1,22 @@
+<div class=headline id='games'>
+    <h1 class='unset'>Games</h1>
+    <span class=headlineRss>
+        <a href="/editgame?id=new">Add a game listing</a>
+    </span>
+</div>
+
+<ul class='horizontal'>
+    <li><a href="/search?browse&sortby=lnew">New</a><li>
+    <li><a href="/search?browse">Top</a></li>
+    <li><a href="/search?searchbar=added%3A60d-">Hot</a></li>
+    <li><a href="/random">Random</a></li>
+    <li><a href="/search?sortby=lnew&searchfor=%23reviews%3A0+wontplay%3Ano">Unreviewed</a></li>
+    <li><a href="/search">Advanced Search</a></li>
+</ul>
+<?php
+
+// get the latest games and game news
+$game_items = getNewItems($db, 7, NEWITEMS_GAMES | NEWITEMS_GAMENEWS);
+showNewItems($db, 0, 5, $game_items, false, false, NEWITEMS_GAMES | NEWITEMS_GAMENEWS);
+?>
+<p><span class='details'><a href='search?browse&sortby=lnew'>See the full list...</a></span></p>

--- a/www/components/games.php
+++ b/www/components/games.php
@@ -14,8 +14,6 @@
     <li><a href="/search">Advanced Search</a></li>
 </ul>
 <?php
-define("ENABLE_IMAGES", 1);
-
 // get the latest games and game news
 $items = getNewItems($db, 6, NEWITEMS_GAMES | NEWITEMS_GAMENEWS);
 

--- a/www/components/games.php
+++ b/www/components/games.php
@@ -14,9 +14,116 @@
     <li><a href="/search">Advanced Search</a></li>
 </ul>
 <?php
+define("ENABLE_IMAGES", 1);
 
 // get the latest games and game news
-$game_items = getNewItems($db, 7, NEWITEMS_GAMES | NEWITEMS_GAMENEWS);
-showNewItems($db, 0, 5, $game_items, false, false, NEWITEMS_GAMES | NEWITEMS_GAMENEWS);
+$items = getNewItems($db, 6, NEWITEMS_GAMES | NEWITEMS_GAMENEWS);
+
+// show the items
+$totcnt = count($items);
+
+for ($idx = 0 ; $idx <= 5; $idx++)
+{
+    // get this item
+    list($pick, $rawDate, $row) = $items[$idx];
+
+    $eager = ($idx < 4 ? "class='eager'" : "");
+
+    // display the item according to its type
+    if (ENABLE_IMAGES) {
+        global $nonce;
+        echo "<style nonce='$nonce'>\n"
+            . ".new-item tr:first-child { vertical-align: top }\n"
+            . ".new-item td:first-child { padding-right: 1em }\n"
+            . "</style>\n";
+
+        echo "<table border=\"0\" cellpadding=\"0\" "
+            . "cellspacing=\"0\" class=\"new-item\">"
+            . "<tr>"
+            . "<td>";
+    }
+
+    if ($pick == 'G')
+    {
+        // it's a game
+        $g = $row;
+
+        // show the image: game cover art if available, otherwise the
+        // generic game icon
+        if (ENABLE_IMAGES) {
+            if ($g["hasart"]) {
+                echo "<a href=\"viewgame?id={$g['id']}\">"
+                    . coverArtThumbnail($g['id'], 50, $g['pagevsn'])
+                    . "</a>";
+            } else {
+                // echo "<a href=\"viewgame?id={$g['id']}\">"
+                //     . "<img border=0 src=\"game50.gif\"></a>";
+            }
+            echo "</td><td>";
+        }
+
+        // summarize this game
+        echo "<div class=\"new-game\">"
+            . "<a $eager href=\"viewgame?id={$g['id']}\"><b><i>"
+            . output_encode(htmlspecialcharx($g['title']))
+            . "</i></b></a>, by "
+            . output_encode(htmlspecialcharx($g['author']));
+
+        if ($g['system']) echo " <div class=details>{$g['system']}</div>";
+
+        echo "</div>";
+    }
+    else if ($pick == 'N')
+    {
+        // it's a news item
+        $n = $row;
+
+        // pull out the game news item
+        $gid = $n['sourceID'];
+        $gtitle = htmlspecialcharx($n['sourceTitle']);
+        $nid = $n['newsID'];
+        $ncre = $n['createdFmt'];
+        $nmod = $n['modifiedFmt'];
+        $nuid = $n['userID'];
+        $nuname = htmlspecialcharx($n['userName']);
+        $nuidOrig = $n['origUserID'];
+        $nunameOrig = htmlspecialcharx($n['origUserName']);
+        $nhead = htmlspecialcharx($n['headline']);
+
+        $divclass = "new-game-news";
+        $href = "viewgame?id=$gid";
+
+        // show the image: user image if available, otherwise game
+        // image, otherwise generic review icon
+        if (ENABLE_IMAGES) {
+            if (isset($n["haspic"]) && $n["haspic"]) {
+                echo "<a href=\"showuser?id={$n['userID']}\">"
+                    . "<img border=0 width=50 height=50 src=\"showuser?id={$n['userID']}&pic"
+                    . "&thumbnail=50x50\"></a>";
+            } else if ($n["hasart"]) {
+                echo "<a href=\"viewgame?id={$n['gameid']}\">"
+                    . coverArtThumbnail($gid, 50, $n['pagevsn'])
+                    . "</a>";
+            } else {
+                // echo "<a href=\"newslog?newsid=$nid\">"
+                //     . "<img border=0 src=\"news50.gif\"></a>";
+            }
+            echo "</td><td>";
+        }
+
+        // summarize the item
+        echo "<div class=\"$divclass\">"
+            . "News on <a href=\"$href\">$gtitle</a>: "
+            . "<b>$nhead</b> "
+            . " <span class=details>"
+            . "<a href=\"newslog?newsid=$nid\">Details</a>"
+            . "</span>"
+            . "</div>";
+    }
+
+    if (ENABLE_IMAGES)
+        echo "</tr></table>";
+}
+
 ?>
 <p><span class='details'><a href='search?browse&sortby=lnew'>See the full list...</a></span></p>

--- a/www/components/games.php
+++ b/www/components/games.php
@@ -23,7 +23,7 @@ $totcnt = count($items);
 for ($idx = 0 ; $idx <= 5; $idx++)
 {
     // get this item
-    list($pick, $rawDate, $row) = $items[$idx];
+    [$pick, $rawDate, $row] = $items[$idx];
 
     $eager = ($idx < 4 ? "class='eager'" : "");
 

--- a/www/components/recommended-lists.php
+++ b/www/components/recommended-lists.php
@@ -8,7 +8,60 @@
 <?php
 
 // get the latest lists
-showNewItems($db, 0, 4, false, false, false, NEWITEMS_LISTS);
+$items = getNewItems($db, 10, NEWITEMS_LISTS);
+
+// show the items
+
+for ($idx = 0 ; $idx <= 8; $idx++)
+{
+    // get this item
+    list($pick, $rawDate, $l) = $items[$idx];
+
+    $eager = ($idx < 4 ? "class='eager'" : "");
+
+    // display the item according to its type
+    if (ENABLE_IMAGES) {
+        global $nonce;
+        echo "<style nonce='$nonce'>\n"
+            . ".new-item tr:first-child { vertical-align: top }\n"
+            . ".new-item td:first-child { padding-right: 1em }\n"
+            . "</style>\n";
+
+        echo "<table border=\"0\" cellpadding=\"0\" "
+            . "cellspacing=\"0\" class=\"new-item\">"
+            . "<tr>"
+            . "<td>";
+    }
+
+    // pull out the list record
+    $itemcnt = $l['itemcnt'];
+    $itemS = $itemcnt == 1 ? "" : "s";
+    $title = output_encode(htmlspecialcharx($l['title']));
+    $username = output_encode(htmlspecialcharx($l['username']));
+
+    // show the image: user image if available, otherwise the
+    // generic list icon
+    if (ENABLE_IMAGES) {
+        if ($l["haspic"]) {
+            echo "<a href=\"showuser?id={$l['userid']}\">"
+                . "<img border=0 width=50 height=50 src=\"showuser?id={$l['userid']}&pic"
+                . "&thumbnail=50x50\"></a>";
+        } else {
+            // echo "<a href=\"viewlist?id={$l['id']}\">"
+            //     . "<img border=0 src=\"reclist50.gif\"></a>";
+        }
+        echo "</td><td>";
+    }
+
+    // summarize it
+    echo "<div class=\"new-list\">"
+        . "<a href=\"viewlist?id={$l['id']}\"><b>$title</b></a> "
+        . "by <a href=\"showuser?id={$l['userid']}\"><b>$username</b></a>, "
+        . "<span class=details>$itemcnt item$itemS</span></div>";
+
+    if (ENABLE_IMAGES)
+        echo "</tr></table>";
+}
 ?>
 <p><span class=details>
     <a href="/search?browse&list">Browse lists</a> |

--- a/www/components/recommended-lists.php
+++ b/www/components/recommended-lists.php
@@ -15,7 +15,7 @@ $items = getNewItems($db, 10, NEWITEMS_LISTS);
 for ($idx = 0 ; $idx <= 8; $idx++)
 {
     // get this item
-    list($pick, $rawDate, $l) = $items[$idx];
+    [$pick, $rawDate, $l] = $items[$idx];
 
     $eager = ($idx < 4 ? "class='eager'" : "");
 

--- a/www/components/recommended-lists.php
+++ b/www/components/recommended-lists.php
@@ -1,0 +1,16 @@
+<div class=headline id='lists'><h1 class='unset'>Lists</h1>
+    <span class=headlineRss>
+        <a href="/editlist?id=new">Create a recommended list</a>
+    </span>
+</div>
+
+<p><span class=details></span></p>
+<?php
+
+// get the latest lists
+showNewItems($db, 0, 4, false, false, false, NEWITEMS_LISTS);
+?>
+<p><span class=details>
+    <a href="/search?browse&list">Browse lists</a> |
+    <a href="/search?list">Search lists</a>
+</span></p>

--- a/www/components/reviews.php
+++ b/www/components/reviews.php
@@ -9,7 +9,7 @@ $totcnt = count($items);
 for ($idx = 0 ; $idx <= 5 ; $idx++)
 {
     // get this item
-    list($pick, $rawDate, $r) = $items[$idx];
+    [$pick, $rawDate, $r] = $items[$idx];
 
     $eager = ($idx < 4 ? "class='eager'" : "");
 

--- a/www/components/reviews.php
+++ b/www/components/reviews.php
@@ -1,7 +1,5 @@
 <div class=headline id='reviews'><h1 class='unset'>Reviews</h1></div>
 <?php
-define("ENABLE_IMAGES", 1);
-
 // get the latest reviews
 $items = getNewItems($db, 7, NEWITEMS_REVIEWS);
 
@@ -15,7 +13,7 @@ for ($idx = 0 ; $idx <= 5 ; $idx++)
 
     $eager = ($idx < 4 ? "class='eager'" : "");
 
-    if (($row['flags'] & FLAG_SHOULD_HIDE)) {
+    if (($r['flags'] & FLAG_SHOULD_HIDE)) {
         continue;
     }
 

--- a/www/components/reviews.php
+++ b/www/components/reviews.php
@@ -1,0 +1,9 @@
+<div class=headline id='reviews'><h1 class='unset'>Reviews</h1></div>
+<?php
+
+// get the latest reviews
+$review_items = getNewItems($db, 7, NEWITEMS_REVIEWS);
+showNewItems($db, 0, 5, $review_items, false, false, NEWITEMS_REVIEWS);
+
+?>
+<p><span class='details'><a href='allnew?reviews'>See the full list...</a></span></p>

--- a/www/components/reviews.php
+++ b/www/components/reviews.php
@@ -1,9 +1,95 @@
 <div class=headline id='reviews'><h1 class='unset'>Reviews</h1></div>
 <?php
+define("ENABLE_IMAGES", 1);
 
 // get the latest reviews
-$review_items = getNewItems($db, 7, NEWITEMS_REVIEWS);
-showNewItems($db, 0, 5, $review_items, false, false, NEWITEMS_REVIEWS);
+$items = getNewItems($db, 7, NEWITEMS_REVIEWS);
+
+// show the items
+$totcnt = count($items);
+
+for ($idx = 0 ; $idx <= 5 ; $idx++)
+{
+    // get this item
+    list($pick, $rawDate, $r) = $items[$idx];
+
+    $eager = ($idx < 4 ? "class='eager'" : "");
+
+    if (($row['flags'] & FLAG_SHOULD_HIDE)) {
+        continue;
+    }
+
+    // display the item according to its type
+    if (ENABLE_IMAGES) {
+        global $nonce;
+        echo "<style nonce='$nonce'>\n"
+            . ".new-item tr:first-child { vertical-align: top }\n"
+            . ".new-item td:first-child { padding-right: 1em }\n"
+            . "</style>\n";
+
+        echo "<table border=\"0\" cellpadding=\"0\" "
+            . "cellspacing=\"0\" class=\"new-item\">"
+            . "<tr>"
+            . "<td>";
+    }
+
+    // show the image: user image if available, otherwise game
+    // image, otherwise generic review icon
+    if (ENABLE_IMAGES) {
+        if ($r["haspic"]) {
+            echo "<a href=\"showuser?id={$r['userid']}\">"
+                . "<img border=0 width=50 height=50 src=\"showuser?id={$r['userid']}&pic"
+                . "&thumbnail=50x50\"></a>";
+        } else if ($r["hasart"]) {
+            echo "<a href=\"viewgame?id={$r['gameid']}\">"
+                . coverArtThumbnail($r['gameid'], 50, $r['pagevsn'])
+                . "</a>";
+        } else {
+            // echo "<a href=\"viewgame?id={$r['gameid']}"
+            //     . "&review={$r['reviewid']}\">"
+            //     . "<img border=0 src=\"review50.gif\"></a>";
+        }
+        echo "</td><td>";
+    }
+
+    // summarize this review
+    echo "<div class=\"new-review\">";
+
+    if (is_null($r['special']))
+        echo "<a href=\"showuser?id={$r['userid']}\"><b>"
+            . output_encode(htmlspecialcharx($r['username']))
+            . "</b></a> reviews ";
+    else
+        echo "A new review of ";
+
+    echo "<a href=\"viewgame?id={$r['gameid']}\"><i><b>"
+        . output_encode(htmlspecialcharx($r['title']))
+        . "</b></i></a>";
+
+    if (!is_null($r['special'])) {
+        $result = mysql_query("select name from specialreviewers
+            where id = '{$r['special']}'", $db);
+        echo " - " . mysql_result($result, 0, "name");
+    } else {
+        echo ": \""
+            . output_encode(htmlspecialcharx($r['summary']))
+            . "\" ";
+    }
+
+    echo showStars($r['rating']);
+
+    echo " - <a $eager href=\"viewgame?id={$r['gameid']}"
+        . "&review={$r['id']}\">See full review</a>";
+
+    echo "</div>";
+    if (ENABLE_IMAGES)
+        echo "</td>";
+
+    if (ENABLE_IMAGES)
+        echo "</tr></table>";
+}
+
+
 
 ?>
 <p><span class='details'><a href='allnew?reviews'>See the full list...</a></span></p>

--- a/www/home
+++ b/www/home
@@ -136,24 +136,7 @@ if ($debugflag) echo "debug mode enabled...<br>";
 
       <div class="block flexer">
          <div class="column col-peer">
-            <div class=headline id='competitions'><h1 class='unset'>Competitions</h1>
-               <span class=headlineRss>
-                  <a href="/editcomp?id=new">Add a competition listing</a>
-               </span>
-            </div>
-
-            <p><a href="https://ifcomp.org/">IF Comp</a> | <a href="https://www.springthing.net/">Spring Thing</a> | <a href="https://xyzzyawards.org/">XYZZY Awards</a></p>
-
-            <?php
-
-            // get the latest competitions and competition news
-            showNewItems($db, 0, 4, false, false, false, NEWITEMS_COMPS | NEWITEMS_COMPNEWS);
-
-            ?>
-            <p><span class=details>
-               <a href="/search?browse&comp">Browse competitions</a> |
-               <a href="/search?comp">Search competitions</a>
-            </span></p>
+            <?php include "components/competitions.php"?>
          </div>
          <div class="column col-peer">
             <?php include "components/poll-sampler.php"?>

--- a/www/home
+++ b/www/home
@@ -130,15 +130,7 @@ if ($debugflag) echo "debug mode enabled...<br>";
             <?php include "components/games.php"?>
          </div>
          <div class="column col-peer">
-            <div class=headline id='reviews'><h1 class='unset'>Reviews</h1></div>
-            <?php
-
-            // get the latest reviews
-            $review_items = getNewItems($db, 7, NEWITEMS_REVIEWS);
-            showNewItems($db, 0, 5, $review_items, false, false, NEWITEMS_REVIEWS);
-
-            ?>
-            <p><span class='details'><a href='allnew?reviews'>See the full list...</a></span></p>
+            <?php include "components/reviews.php"?>
          </div>
       </div>
 

--- a/www/home
+++ b/www/home
@@ -145,22 +145,7 @@ if ($debugflag) echo "debug mode enabled...<br>";
 
       <div class="block flexer">
          <div class="column col-peer">
-            <div class=headline id='lists'><h1 class='unset'>Lists</h1>
-               <span class=headlineRss>
-                  <a href="/editlist?id=new">Create a recommended list</a>
-               </span>
-            </div>
-
-            <p><span class=details></span></p>
-            <?php
-
-            // get the latest lists
-            showNewItems($db, 0, 4, false, false, false, NEWITEMS_LISTS);
-            ?>
-            <p><span class=details>
-               <a href="/search?browse&list">Browse lists</a> |
-               <a href="/search?list">Search lists</a>
-            </span></p>
+            <?php include "components/recommended-lists.php"?>
          </div>
          <div class="column col-peer">
             <?php include "components/ifdb-recommends.php"?>

--- a/www/home
+++ b/www/home
@@ -127,27 +127,7 @@ if ($debugflag) echo "debug mode enabled...<br>";
 
       <div class="block flexer">
          <div class="column col-peer">
-            <div class=headline id='games'><h1 class='unset'>Games</h1>
-            <span class=headlineRss>
-               <a href="/editgame?id=new">Add a game listing</a>
-            </span>
-         </div>
-
-            <ul class='horizontal'>
-               <li><a href="/search?browse&sortby=lnew">New</a><li>
-               <li><a href="/search?browse">Top</a></li>
-               <li><a href="/search?searchbar=added%3A60d-">Hot</a></li>
-               <li><a href="/random">Random</a></li>
-               <li><a href="/search?sortby=lnew&searchfor=%23reviews%3A0+wontplay%3Ano">Unreviewed</a></li>
-               <li><a href="/search">Advanced Search</a></li>
-            </ul>
-            <?php
-
-            // get the latest games and game news
-            $game_items = getNewItems($db, 7, NEWITEMS_GAMES | NEWITEMS_GAMENEWS);
-            showNewItems($db, 0, 5, $game_items, false, false, NEWITEMS_GAMES | NEWITEMS_GAMENEWS);
-            ?>
-            <p><span class='details'><a href='search?browse&sortby=lnew'>See the full list...</a></span></p>
+            <?php include "components/games.php"?>
          </div>
          <div class="column col-peer">
             <div class=headline id='reviews'><h1 class='unset'>Reviews</h1></div>

--- a/www/newitems.php
+++ b/www/newitems.php
@@ -482,13 +482,28 @@ function showNewItemList($db, $items, $first, $last, $showFlagged, $allowHiddenB
             } else {
                 echo ": \""
                     . output_encode(htmlspecialcharx($r['summary']))
-                    . "\" ";
+                    . "\" <span class=notes><i>{$r['fmtdate']}</i></span>";
             }
 
-            echo showStars($r['rating']);
+            $stars = showStars($r['rating']);
+            list($summary, $len, $trunc) = summarizeHtml($r['review'], 140);
+            $summary = fixDesc($summary);
+            if ($len != 0 || $stars != "")
+            {
+                echo "<br><div class=indented><span class=details>";
 
-            echo " - <a $eager href=\"viewgame?id={$r['gameid']}"
-                . "&review={$r['id']}\">See full review</a>";
+                if ($stars != "")
+                    echo "$stars ";
+
+                if ($len != 0)
+                    echo "<i>\"$summary\"</i>";
+
+                if ($trunc)
+                    echo " - <a class=eager href=\"viewgame?id={$r['gameid']}"
+                        . "&review={$r['id']}\">See full review</a>";
+
+                echo "</span></div>";
+            }
 
             echo "</div>";
             if (ENABLE_IMAGES)
@@ -510,6 +525,8 @@ function showNewItemList($db, $items, $first, $last, $showFlagged, $allowHiddenB
             $itemS = $itemcnt == 1 ? "" : "s";
             $title = output_encode(htmlspecialcharx($l['title']));
             $username = output_encode(htmlspecialcharx($l['username']));
+            list($desc, $len, $trunc) = summarizeHtml($l['desc'], 210);
+            $desc = fixDesc($desc);
 
             // show the image: user image if available, otherwise the
             // generic list icon
@@ -533,7 +550,7 @@ function showNewItemList($db, $items, $first, $last, $showFlagged, $allowHiddenB
                 . "<span class=notes><i>{$l['fmtdate']}</i></span><br>"
                 . "<div class=indented>"
                 . "<span class=details>$itemcnt item$itemS</span><br>"
-                . "</div></div>";
+                . "<span class=details><i>$desc</i></span></div></div>";
         }
         else if ($pick == 'G')
         {
@@ -556,12 +573,19 @@ function showNewItemList($db, $items, $first, $last, $showFlagged, $allowHiddenB
 
             // summarize this game
             echo "<div class=\"new-game\">"
-                . "<a $eager href=\"viewgame?id={$g['id']}\"><b><i>"
+                . "A new listing for "
+                . "<a class=eager href=\"viewgame?id={$g['id']}\"><b><i>"
                 . output_encode(htmlspecialcharx($g['title']))
                 . "</i></b></a>, by "
-                . output_encode(htmlspecialcharx($g['author']));
+                . output_encode(htmlspecialcharx($g['author']))
+                . " <span class=notes><i>{$g['fmtdate']}</i></span>";
 
-            if ($g['system']) echo " <div class=details>{$g['system']}</div>";
+            list($summary, $len, $trunc) = summarizeHtml($g['desc'], 210);
+            $summary = fixDesc($summary);
+            if ($len != 0)
+                echo "<br><div class=indented><span class=details><i>"
+                    . $summary
+                    . "</i></span></div>";
 
             echo "</div>";
         }
@@ -627,6 +651,8 @@ function showNewItemList($db, $items, $first, $last, $showFlagged, $allowHiddenB
             $nuidOrig = $n['origUserID'];
             $nunameOrig = htmlspecialcharx($n['origUserName']);
             $nhead = htmlspecialcharx($n['headline']);
+            list($nbody, $len, $trunc) = summarizeHtml($n['body'], 210);
+            $nbody = fixDesc($nbody);
 
             switch ($n['sourceType'])
             {
@@ -668,9 +694,10 @@ function showNewItemList($db, $items, $first, $last, $showFlagged, $allowHiddenB
             echo "<div class=\"$divclass\">"
                 . "News on <a href=\"$href\">$gtitle</a>: "
                 . "<b>$nhead</b> "
-                . " <span class=details>"
+                . "<span class=notes><i>$ncre</i></span><br>"
+                . "<div class=indented><span class=details>$nbody - "
                 . "<a href=\"newslog?newsid=$nid\">Details</a>"
-                . "</span>"
+                . "</span></div>"
                 . "</div>";
         }
         else if ($pick == 'C')
@@ -681,6 +708,8 @@ function showNewItemList($db, $items, $first, $last, $showFlagged, $allowHiddenB
             // pull out the competition item
             $cid = $c["compid"];
             $ctitle = htmlspecialcharx($c["title"]);
+            list($cdesc, $len, $trunc) = summarizeHtml($c["desc"], 210);
+            $cdesc = fixDesc($cdesc);
             $cdate = $c["fmtdate"];
 
             // show the generic competition icon
@@ -695,6 +724,8 @@ function showNewItemList($db, $items, $first, $last, $showFlagged, $allowHiddenB
             echo "<div class=\"new-competition\">"
                 . "A new competition page: <a href=\"viewcomp?id=$cid\">"
                 . "$ctitle</a> <span class=notes><i>created $cdate</i></span>"
+                . "<br><div class=indented>"
+                . "<span class=details><i>$cdesc</i></span>"
                 . "</div>"
                 . "</div>";
         }


### PR DESCRIPTION
The `/allnew` page was designed to be the extended version of "New on IFDB," and it's designed to contain a mix of items, so each item begins with a little preamble:

* A new game listing for:
* A new Recommended List by
* A new competition page:

But that preamble is useless in the home page sections. So, in this PR, which looks big, but isn't really _that_ big, I'm copying and pasting the rendering code from `newitems.php` into the home page (refactoring out into new components in each step), and then streamlining the display of components that I didn't already streamline.

Then, I'm restoring the display on `newitems.php`, so `/allnew` looks pretty much the way it used to look.