### PR TITLE
Disable ifwiki check when previewing a stylesheet

### DIFF
--- a/www/viewgame
+++ b/www/viewgame
@@ -2859,6 +2859,7 @@ dispTags();
                         echo "<div id=\"ifwiki-link\" class=\"displayNone\"><a href=\"https://www.ifwiki.org/\">IF Wiki</a>: <a href=\"https://www.ifwiki.org/index.php?title=IFID:"
                             .htmlspecialcharx($ifids[0])."\">$title</a><br></div>";
                         $jifid = htmlspecialcharx(str_replace("\"", "&#34;", $ifids[0]));
+                        if (!$cssOverride) {
                         ?>
                         <script nonce="<?php global $nonce; echo $nonce; ?>">
                             xmlSend("ifwiki-check?ifid=<?php echo $jifid ?>", null,
@@ -2869,6 +2870,7 @@ dispTags();
                                 }, null);
                         </script>
                         <?php
+                        }
                     }
                 ?>
                <?php if(!isEmpty($bafsid))


### PR DESCRIPTION
When viewing the style sheet gallery, many pages are loaded in iframes, and the server is flooded with duplicate calls to `ifwiki-check`. Some of them even fail, which makes `xmlSend` pop up an alert.

This disables the check when `cssOverride` is active.

It would be nice if some of the other resources in the page could be cached on the browser, to avoid all the rest of the duplicate requests.