### PR TITLE
Use <details> element for news items

### DIFF
--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -1477,27 +1477,21 @@ ul.horizontal > li {
 /*
 News items
 */
-div.newsItemHeadline {
+.newsItemHeadline {
     font-weight: bold;
 }
-div.newsItemDateline {
+.newsItemDateline {
     font-size: 85%;
     margin: .25ex 0 .75ex 0;
 }
-div.newsItemHeadline a {
-    text-decoration: none;
-}
-div.newsItemHeadline a:hover {
-    text-decoration: underline;
-}
-div.newsItemBody {
+.newsItemBody {
     margin: 0 0 1em 0;
 }
-div.newsItemFooter {
+.newsItemFooter {
     font-size: 85%;
     margin: 1ex 0 1em 0;
 }
-span.newsItemDate {
+.newsItemDate {
     padding-left: 2em;
     font-weight: normal;
     font-style: italic;

--- a/www/news.php
+++ b/www/news.php
@@ -53,13 +53,11 @@ function newsSummary($db, $sourceType, $sourceID, $maxItems,
             }
 
             // display it
-            echo "<div class=\"newsItemHeadline\">"
-                . "<a href=\"needjs\">"
-                . addEventListener('click', "expandNews($i); return false;")
-                . "$newshead</a>"
-                . " <span class=\"newsItemDate\">$newsdate</span>"
-                . "</div>"
-                . "<div id=\"newsBody$i\" class=\"newsItemBody displayNone\">"
+            echo "<details><summary class=\"newsItemHeadline\">"
+                . "<span>$newshead</span>"
+                . "<span class=\"newsItemDate\">$newsdate</span>"
+                . "</summary>"
+                . "<div id=\"newsBody$i\" class=\"newsItemBody\">"
                 . "<div>$newsbody</div>"
                 . "<span class=details>$byline | "
                 . "<a href=\"newslog?newsid=$newsid&history\">History</a> | "
@@ -67,28 +65,14 @@ function newsSummary($db, $sourceType, $sourceID, $maxItems,
                 . "Edit</a> | "
                 . "<a href=\"editnews?newsid=$newsid$src&delete\">Delete</a>"
                 . "</span>"
-                . "</div>";
+                . "</details>";
         }
 
-?>
-<script type="text/javascript" nonce="<?php global $nonce; echo $nonce; ?>">
-<!--
-
-function expandNews(n)
-{
-    var ele = document.getElementById("newsBody" + n);
-    ele.style.display = (ele.style.display == "block" ? "none" : "block");
-}
-
-//-->
-</script>
-<?php
-
-            echo "<span class=details>"
-                . "<a href=\"newslog?$src\">"
-                . ($rowcnt > $maxItems ? "More news..." : "Expand all")
-                . "</a> | <a href=\"editnews?$src\">"
-                . "Add a news item</a></span>$sectionFooter";
+        echo "<span class=details>"
+            . "<a href=\"newslog?$src\">"
+            . ($rowcnt > $maxItems ? "More news..." : "Expand all")
+            . "</a> | <a href=\"editnews?$src\">"
+            . "Add a news item</a></span>$sectionFooter";
     }
 
     return $rowcnt;


### PR DESCRIPTION
No more Javascript :D

I checked the `viewgame` page, and the `newslog` page - both appear fine. The news titles are bold, but are no longer link-colored. I think that's fine. The arrow on the side makes it clear that it's expandable.

Should the summary element have a hand cursor?