### PR TITLE
Streamline "New on IFDB"

### DIFF
--- a/www/allnew
+++ b/www/allnew
@@ -43,7 +43,7 @@ echo "<h1>$pageTitle</h1>\n<div class='prerender-moderate'>\n";
 echo "$pageCtl<p><hr class=dots><p>";
 
 // show the new items
-showNewItems($db, $firstOnPage, $lastOnPage, $items, $showFlagged, false, $type);
+showNewItems($db, $firstOnPage, $lastOnPage, $items, ['showFlagged' => $showFlagged]);
 
 // show the page controls again at the bottom
 echo "<p><hr class=dots><p>$pageCtl<br>\n";

--- a/www/components/games.php
+++ b/www/components/games.php
@@ -14,6 +14,8 @@
     <li><a href="/search">Advanced Search</a></li>
 </ul>
 <?php
+define("ENABLE_IMAGES", 1);
+
 // get the latest games and game news
 $items = getNewItems($db, 6, NEWITEMS_GAMES | NEWITEMS_GAMENEWS);
 

--- a/www/home
+++ b/www/home
@@ -124,7 +124,12 @@ if ($debugflag) echo "debug mode enabled...<br>";
             <div class=headline><h1 class='unset'>New on IFDB</h1></div>
             <div>
             <?php
-            showNewItems($db, 0, 8, $items, [ 'allowHiddenBanner' => false, 'days' => $days, 'showDescriptions' => false ]);
+            showNewItems($db, 0, 8, $items, [
+               'allowHiddenBanner' => false,
+               'days' => $days,
+               'showDescriptions' => false,
+               'enableImages' => false,
+            ]);
             ?>
             </div>
             </div>

--- a/www/home
+++ b/www/home
@@ -115,7 +115,7 @@ if ($debugflag) echo "debug mode enabled...<br>";
             <div class=headline><h1 class='unset'>New on IFDB</h1></div>
             <div>
             <?php
-            showNewItems($db, 0, 8, $items, false, false, NEWITEMS_SITENEWS | NEWITEMS_LISTS | NEWITEMS_POLLS | NEWITEMS_COMPS | NEWITEMS_COMPNEWS, $days);
+            showNewItems($db, 0, 8, $items, [ 'allowHiddenBanner' => false, 'days' => $days ]);
             ?>
             </div>
             </div>

--- a/www/home
+++ b/www/home
@@ -115,7 +115,7 @@ if ($debugflag) echo "debug mode enabled...<br>";
             <div class=headline><h1 class='unset'>New on IFDB</h1></div>
             <div>
             <?php
-            showNewItems($db, 0, 8, $items, [ 'allowHiddenBanner' => false, 'days' => $days ]);
+            showNewItems($db, 0, 8, $items, [ 'allowHiddenBanner' => false, 'days' => $days, 'showDescriptions' => false ]);
             ?>
             </div>
             </div>

--- a/www/home
+++ b/www/home
@@ -107,7 +107,16 @@ if ($debugflag) echo "debug mode enabled...<br>";
       <?php
       // get the latest site news, polls, competitions, and lists, and show a mix
       $days = 3;
-      $items = getNewItems($db, 8, NEWITEMS_SITENEWS | NEWITEMS_LISTS | NEWITEMS_POLLS | NEWITEMS_COMPS | NEWITEMS_COMPNEWS, $days);
+      $items = getNewItems($db, 8,
+         NEWITEMS_SITENEWS | NEWITEMS_LISTS | NEWITEMS_POLLS | NEWITEMS_COMPS | NEWITEMS_COMPNEWS,
+         [
+            'days' => $days,
+            'sitenews_limit' => 1,
+            'lists_limit' => 2,
+            'polls_limit' => 2,
+            'comps_limit' => 2,
+         ]
+      );
       if ($items) {
          ?>
       <div class="block flexer">

--- a/www/newitems.php
+++ b/www/newitems.php
@@ -1,6 +1,5 @@
 <?php
 
-define("ENABLE_IMAGES", 1);
 define("NEWITEMS_SITENEWS", 0x0001);
 define("NEWITEMS_GAMES", 0x0002);
 define("NEWITEMS_LISTS", 0x0004);
@@ -366,6 +365,7 @@ function showNewItemList($db, $items, $first, $last, $options)
     $showFlagged = $options['showFlagged'] ?? false;
     $allowHiddenBanner = $options['allowHiddenBanner'] ?? true;
     $showDescriptions = $options['showDescriptions'] ?? true;
+    $enableImages = $options['enableImages'] ?? true;
 
     // show the items
     $totcnt = count($items);
@@ -405,7 +405,7 @@ function showNewItemList($db, $items, $first, $last, $options)
         }
 
         // display the item according to its type
-        if (ENABLE_IMAGES) {
+        if ($enableImages) {
             global $nonce;
             echo "<style nonce='$nonce'>\n"
                 . ".new-item tr:first-child { vertical-align: top }\n"
@@ -425,7 +425,7 @@ function showNewItemList($db, $items, $first, $last, $options)
 
             // show the image: user image if available, otherwise game
             // image, otherwise generic review icon
-            if (ENABLE_IMAGES) {
+            if ($enableImages) {
                 if ($r["haspic"]) {
                     echo "<a href=\"showuser?id={$r['userid']}\">"
                         . "<img border=0 width=50 height=50 src=\"showuser?id={$r['userid']}&pic"
@@ -487,7 +487,7 @@ function showNewItemList($db, $items, $first, $last, $options)
             }
 
             echo "</div>";
-            if (ENABLE_IMAGES)
+            if ($enableImages)
                 echo "</td>";
         }
         else if ($pick == 'S')
@@ -511,7 +511,7 @@ function showNewItemList($db, $items, $first, $last, $options)
 
             // show the image: user image if available, otherwise the
             // generic list icon
-            if (ENABLE_IMAGES) {
+            if ($enableImages) {
                 if ($l["haspic"]) {
                     echo "<a href=\"showuser?id={$l['userid']}\">"
                         . "<img border=0 width=50 height=50 src=\"showuser?id={$l['userid']}&pic"
@@ -541,7 +541,7 @@ function showNewItemList($db, $items, $first, $last, $options)
 
             // show the image: game cover art if available, otherwise the
             // generic game icon
-            if (ENABLE_IMAGES) {
+            if ($enableImages) {
                 if ($g["hasart"]) {
                     echo "<a href=\"viewgame?id={$g['id']}\">"
                         . coverArtThumbnail($g['id'], 50, $g['pagevsn'])
@@ -593,7 +593,7 @@ function showNewItemList($db, $items, $first, $last, $options)
 
             // show the image: user image if available, otherwise the
             // generic list icon
-            if (ENABLE_IMAGES) {
+            if ($enableImages) {
                 if ($p["haspic"]) {
                     echo "<a href=\"showuser?id={$p['userid']}\">"
                         . "<img border=0 width=50 height=50 src=\"showuser?id={$p['userid']}&pic"
@@ -651,7 +651,7 @@ function showNewItemList($db, $items, $first, $last, $options)
 
             // show the image: user image if available, otherwise game
             // image, otherwise generic review icon
-            if (ENABLE_IMAGES) {
+            if ($enableImages) {
                 if (isset($n["haspic"]) && $n["haspic"]) {
                     echo "<a href=\"showuser?id={$n['userID']}\">"
                         . "<img border=0 width=50 height=50 src=\"showuser?id={$n['userID']}&pic"
@@ -690,7 +690,7 @@ function showNewItemList($db, $items, $first, $last, $options)
             $cdate = $c["fmtdate"];
 
             // show the generic competition icon
-            if (ENABLE_IMAGES) {
+            if ($enableImages) {
                 // echo "<a href=\"viewcomp?id=$cid\">"
                 //     . "<img border=0 src=\"competition50.gif\">"
                 //     . "</a>";
@@ -707,7 +707,7 @@ function showNewItemList($db, $items, $first, $last, $options)
                 . "</div>";
         }
 
-        if (ENABLE_IMAGES)
+        if ($enableImages)
             echo "</tr></table>";
     }
 

--- a/www/newitems.php
+++ b/www/newitems.php
@@ -260,7 +260,7 @@ function sortNewItemsByDate($a, $b)
     // in the mysql raw date format, which collates like an ascii string,
     // so we can compare with strcmp.  Reverse the sense of the test so
     // that we sort newest first.
-    if ($a[1] == $b[1]) {
+    if ($a[1] == $b[1] && is_numeric($a[2]['id'])) {
         return $b[2]['id'] - $a[2]['id'];
     } else {
         return strcmp($b[1], $a[1]);

--- a/www/newitems.php
+++ b/www/newitems.php
@@ -354,13 +354,13 @@ function showNewItems($db, $first, $last, $items, $options = [])
         $items = getNewItems($db, $last, $itemTypes, $options);
 
     // show them
-    showNewItemList($db, $items, $first, $last, $options);
+    showNewItemList($db, $first, $last, $items, $options);
 
     // indicate whether there's more to come
     return count($items) > $last;
 }
 
-function showNewItemList($db, $items, $first, $last, $options)
+function showNewItemList($db, $first, $last, $items, $options)
 {
     $showFlagged = $options['showFlagged'] ?? false;
     $allowHiddenBanner = $options['allowHiddenBanner'] ?? true;

--- a/www/newitems.php
+++ b/www/newitems.php
@@ -357,6 +357,7 @@ function showNewItemList($db, $items, $first, $last, $options)
 {
     $showFlagged = $options['showFlagged'] ?? false;
     $allowHiddenBanner = $options['allowHiddenBanner'] ?? true;
+    $showDescriptions = $options['showDescriptions'] ?? true;
 
     // show the items
     $totcnt = count($items);
@@ -521,8 +522,9 @@ function showNewItemList($db, $items, $first, $last, $options)
                 . "<a href=\"viewlist?id={$l['id']}\"><b>$title</b></a> "
                 . "<span class=notes><i>{$l['fmtdate']}</i></span><br>"
                 . "<div class=indented>"
-                . "<span class=details>$itemcnt item$itemS</span><br>"
-                . "<span class=details><i>$desc</i></span></div></div>";
+                . "<span class=details>$itemcnt item$itemS</span>"
+                . ($showDescriptions ? "<br><span class=details><i>$desc</i></span>" : "")
+                . "</div></div>";
         }
         else if ($pick == 'G')
         {
@@ -601,10 +603,10 @@ function showNewItemList($db, $items, $first, $last, $options)
                 . "$uname</a>, "
                 . "<a $eager href=\"poll?id=$pid\"><b>$title</b></a> "
                 . "<span class=notes><i>created $fmtdate</i></span>"
-                . "<br><div class=indented>"
+                . ($showDescriptions ? "<br><div class=indented>"
                 . "<span class=details>$cntdesc</span><br>"
                 . "<span class=details><i>$desc</i></span>"
-                . "</div>"
+                . "</div>" : "")
                 . "</div>";
         }
         else if ($pick == 'N')
@@ -691,9 +693,9 @@ function showNewItemList($db, $items, $first, $last, $options)
             echo "<div class=\"new-competition\">"
                 . "A new competition page: <a href=\"viewcomp?id=$cid\">"
                 . "$ctitle</a> <span class=notes><i>created $cdate</i></span>"
-                . "<br><div class=indented>"
+                . ($showDescriptions ? "<br><div class=indented>"
                 . "<span class=details><i>$cdesc</i></span>"
-                . "</div>"
+                . "</div>" : "")
                 . "</div>";
         }
 

--- a/www/newitems.php
+++ b/www/newitems.php
@@ -338,21 +338,26 @@ function queryNewNews(&$items, $db, $limit, $sourceType,
     }
 }
 
-function showNewItems($db, $first, $last, $items, $showFlagged = false, $allowHiddenBanner = true, $itemTypes = NEWITEMS_ALLITEMS, $days = null)
+function showNewItems($db, $first, $last, $items, $options = [])
 {
+    $itemTypes = $options['itemTypes'] ?? NEWITEMS_ALLITEMS;
+    $days = $options['days'] ?? null;
     // if the caller didn't provide the new item lists, query them
     if (!$items)
         $items = getNewItems($db, $last, $itemTypes, $days);
 
     // show them
-    showNewItemList($db, $items, $first, $last, $showFlagged, $allowHiddenBanner, $itemTypes);
+    showNewItemList($db, $items, $first, $last, $options);
 
     // indicate whether there's more to come
     return count($items) > $last;
 }
 
-function showNewItemList($db, $items, $first, $last, $showFlagged, $allowHiddenBanner, $itemTypes)
+function showNewItemList($db, $items, $first, $last, $options)
 {
+    $showFlagged = $options['showFlagged'] ?? false;
+    $allowHiddenBanner = $options['allowHiddenBanner'] ?? true;
+
     // show the items
     $totcnt = count($items);
 


### PR DESCRIPTION
Fixes #976 and #978.

re: descriptions, I missed a spot in #959. Restoring descriptions on the `/allnew` page restored descriptions in the "New on IFDB" section.

In working on this, to avoid adding _even more_ optional parameters, I converted `getNewItems()`, `showNewItems()` and `showNewItemList()` to take an associative array of `$options`.