### PR TITLE
Home: Make scroll links stick to the top of the page

### DIFF
--- a/www/home
+++ b/www/home
@@ -34,8 +34,23 @@ if ($debugflag) echo "debug mode enabled...<br>";
 
 <?php pageHeader("The Interactive Fiction Database - IF and Text Adventures")?>
 
+<div class='scroll-links headline'>
+   <ul class='horizontal'>
+      <li><a href="#games">Games</a></li>
+      <li><a href="#reviews">Reviews</a></li>
+      <li><a href="#competitions">Competitions</a></li>
+      <li><a href="#polls">Polls</a></li>
+      <li><a href="#lists">Lists</a></li>
+      <li><a href="#ifdb-recommends">IFDB Recommends...</a></li>
+      <li><a href="#top-reviewers">Top Reviewers</a></li>
+      <li><a href="#new-to-if">New to IF?</a></li>
+      <li><a href="#stats">Database Stats</a></li>
+   </ul>
+</div>
+
 <div class="flexer prerender-moderate">
    <div class="column col-main">
+
       <div class="block">
          <details id="welcome-details" <?= $welcomeOpen ? "open" : ""?>>
          <summary>
@@ -91,18 +106,6 @@ if ($debugflag) echo "debug mode enabled...<br>";
       </div>
 
       <?php include "components/check-inbox.php"?>
-
-      <ul class='horizontal'>
-         <li><a href="#games">Games</a></li>
-         <li><a href="#reviews">Reviews</a></li>
-         <li><a href="#competitions">Competitions</a></li>
-         <li><a href="#polls">Polls</a></li>
-         <li><a href="#lists">Lists</a></li>
-         <li><a href="#ifdb-recommends">IFDB Recommends...</a></li>
-         <li><a href="#top-reviewers">Top Reviewers</a></li>
-         <li><a href="#new-to-if">New to IF?</a></li>
-         <li><a href="#stats">Database Stats</a></li>
-      </ul>
 
       <?php
       // get the latest site news, polls, competitions, and lists, and show a mix

--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -305,7 +305,7 @@ margins here.
 */
 div.main {
     max-width: 100ch;
-    padding: 1em 1em 1em 1em;
+    padding: 0 1em;
     margin: 0 auto;
 }
 
@@ -1199,7 +1199,15 @@ div.headline {
     margin: 2em 0 1em 0;
     display: flex;
     justify-content: space-between;
+    scroll-margin-top: 3em;
 }
+
+@media (max-width: 120ch) {
+    div.headline {
+        scroll-margin-top: 5em;
+    }
+}
+
 div.headline1 {
     margin-top: 0;
 }
@@ -1462,6 +1470,22 @@ element of the list.
 ul.doublespace li {
     margin-top: 1em;
     margin-bottom: 1em;
+}
+
+div.scroll-links {
+    position: sticky;
+    text-wrap: balance;
+    top: 0;
+    margin: 0 -0.5em 1em -0.5em;
+    display: flex;
+    font: revert;
+    width: revert;
+    justify-content: center;
+    padding: 0.5em 0;
+}
+
+.scroll-links ul {
+    margin: 0;
 }
 
 ul.horizontal {


### PR DESCRIPTION
I moved the scroll links to the top of the page, above "Welcome to IFDB," and I made them `position: sticky` and styled like a headline. This would have broken scrolling, but I added `scroll-margin-top` on headlines, to leave room for the wrapped links.

<img width="374" alt="image" src="https://github.com/user-attachments/assets/69b08d4d-debd-4ea0-904b-317f8cbb78a1">
