### PR TITLE
Fix RSS encoding

### DIFF
--- a/www/allnew-rss
+++ b/www/allnew-rss
@@ -16,7 +16,7 @@ $numItems = 25;
 iconv_set_encoding("output_encoding", "UTF-8");
 
 // send the RSS content-type header
-header("Content-Type: application/rss+xml");
+header("Content-Type: application/rss+xml; charset=utf-8");
 header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
 header("Cache-Control: no-store, no-cache, must-revalidate");
 header("Cache-Control: post-check=0, pre-check=0", false);

--- a/www/commentlog
+++ b/www/commentlog
@@ -137,7 +137,7 @@ if ($pg == 'all') {
 if ($rss) {
 
     // send the RSS content-type header
-    header("Content-Type: application/rss+xml");
+    header("Content-Type: application/rss+xml; charset=utf-8");
     header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
     header("Cache-Control: no-store, no-cache, must-revalidate");
     header("Cache-Control: post-check=0, pre-check=0", false);

--- a/www/news
+++ b/www/news
@@ -27,7 +27,7 @@ if (isset($_REQUEST['rss'])) {
     iconv_set_encoding("output_encoding", "UTF-8");
 
     // send the RSS content-type header
-    header("Content-Type: application/rss+xml");
+    header("Content-Type: application/rss+xml; charset=utf-8");
     header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
     header("Cache-Control: no-store, no-cache, must-revalidate");
     header("Cache-Control: post-check=0, pre-check=0", false);

--- a/www/poll
+++ b/www/poll
@@ -996,7 +996,7 @@ administrators can see who voted for what.)
         iconv_set_encoding("output_encoding", "UTF-8");
 
         // send the RSS content header
-        header("Content-Type: application/rss+xml");
+        header("Content-Type: application/rss+xml; charset=utf-8");
         header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
         header("Cache-Control: no-store, no-cache, must-revalidate");
         header("Cache-Control: post-check=0, pre-check=0", false);

--- a/www/putific
+++ b/www/putific
@@ -16,7 +16,7 @@ $db = dbConnect();
 //
 function replyXml($body)
 {
-    header("Content-type: text/xml");
+    header("Content-type: text/xml; charset=utf-8");
     header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
     header("Cache-Control: no-store, no-cache, must-revalidate");
     header("Cache-Control: post-check=0, pre-check=0", false);

--- a/www/reviewcommentlog
+++ b/www/reviewcommentlog
@@ -127,7 +127,7 @@ list($rowcnt) = mysql_fetch_row($result2);
 if ($rss) {
 
     // send the RSS content-type header
-    header("Content-Type: application/rss+xml");
+    header("Content-Type: application/rss+xml; charset=utf-8");
     header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
     header("Cache-Control: no-store, no-cache, must-revalidate");
     header("Cache-Control: post-check=0, pre-check=0", false);

--- a/www/rss.php
+++ b/www/rss.php
@@ -23,7 +23,7 @@ function sendRSS($title, $link, $desc, $items, $limit)
     $body = implode("", array_map("getRssItemBody", $items));
 
     // send the RSS content-type header
-    header("Content-Type: application/rss+xml");
+    header("Content-Type: application/rss+xml; charset=utf-8");
     header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
     header("Cache-Control: no-store, no-cache, must-revalidate");
     header("Cache-Control: post-check=0, pre-check=0", false);

--- a/www/util.php
+++ b/www/util.php
@@ -85,7 +85,7 @@ function output_encode($str)
 //
 function rss_encode($str)
 {
-    return iconv("ISO-8859-1", "UTF-8", $str);
+    return iconv("WINDOWS-1252", "UTF-8", $str);
 }
 
 // ------------------------------------------------------------------------


### PR DESCRIPTION
RSS was attempting to convert from ISO-8859-1 to UTF-8 but it wasn't working correctly; I'm not entirely sure why.

But there's a much easier way: converting all non-ASCII characters (e.g. smart quotes) into XML entities. It means that we never have to worry about charsets, automatic charset translation, etc. etc.

So, that's what this PR does.