### PR TITLE
Support JSON in game tags APIs

### DIFF
--- a/www/gametags
+++ b/www/gametags
@@ -6,15 +6,37 @@ include_once "login-check.php";
 
 function sendResponse($status, $errmsg, $tagInfo)
 {
+    global $json;
+
     header("HTTP/1.1 $status");
-    header("Content-Type: text/xml");
     header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
     header("Cache-Control: no-store, no-cache, must-revalidate");
+    if ($json) {
+        header("Content-Type: application/json");
+    } else {
+        header("Content-Type: text/xml");
+        echo "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>";
+    }
 
-    echo "<?xml version=\"1.0\" encoding=\"UTF-8\" ?><response>"
-        . ($errmsg ? "<error>$errmsg</error>" : "")
-        . $tagInfo
-        . "</response>";
+    $responseObj = [];
+    if ($errmsg) {
+        $responseObj['error'] = $errmsg;
+    }
+
+    if ($tagInfo) {
+        if (!$json) {
+            $tagInfo = array_map(fn($tag) => ['tag' => $tag], $tagInfo);
+        }
+        $responseObj['tags'] = $tagInfo;
+    }
+
+    if ($json) {
+        echo json_encode($responseObj);
+    } else {
+        echo serialize_xml([
+            'response' => $responseObj,
+        ]);
+    }
 
     exit();
 }
@@ -26,9 +48,9 @@ if ($db == false)
     sendResponse("500 Internal Server Error", "An error occurred connecting to the database. "
                  . "Please try again later.", false, false);
 
+$json = isset($_REQUEST['json']);
 $id = get_req_data('id');
-$qid = mysql_real_escape_string($id, $db);
-$result = mysql_query("select id from games where id = '$qid'", $db);
+$result = mysqli_execute_query($db, "select id from games where id = ?", [$id]);
 if (mysql_num_rows($result) == 0)
     sendResponse("404 Not Found", 
                  "This tag request refers to a non-existent game.",
@@ -38,58 +60,35 @@ $mine_only = get_req_data('mine_only');
 if ($mine_only) {
     $username = get_req_data("username");
     $password = get_req_data("password");
-    list($userid, $errCode, $errMsg) = doLogin($db, $username, $password);
+    [$userid, $errCode, $errMsg] = doLogin($db, $username, $password);
     if (!$userid) {
-        sendResponse("401 Unauthorized", "Not Saved", "Please specify a valid username and password to login.", false, false);
+        sendResponse("401 Unauthorized", "Please specify a valid username and password to login.");
     }
 }
 
+$tagInfo = [];
 if ($result) {
-
     $mine_only_clause = "";
+    $mine_only_params = [];
     if ($mine_only) {
-        $mine_only_clause = "AND userid = '$userid'";
+        $mine_only_clause = "AND userid = ?";
+        $mine_only_params[] = $userid;
     }
-    $result = mysql_query(
-        "select tag from gametags where gameid = '$qid' $mine_only_clause", $db);
-
-    for ($i = 0, $allTags = array(), $tagList = array(), $cnt = mysql_num_rows($result) ; $i < $cnt ; $i++) {
-        $curTag = mysql_result($result, $i, "tag");
-        $allTags[] = $curTag;
-        $tagList[] = "'" . mysql_real_escape_string($curTag, $db) . "'";
-    }
-
-    if (count($allTags) != 0) {
-        $allTags = implode(",", $allTags);
-        $allTags = '\'' . mysql_real_escape_string($allTags, $db) . '\'';
-        $tagList = implode(",", $tagList);
-    } else {
-        $allTags = "null";
-        $tagList = "";
-    }
-}
-
-
-$tagInfo = "";
-if ($result && $tagList) {
-
-    $result = mysql_query(
+    $result = mysqli_execute_query($db,
         "select
            tag,
-           sum(gameid = '$qid') as tagcnt,
+           cast(sum(gameid = ?) as int) as tagcnt,
            count(distinct gameid) as gamecnt
          from gametags
-         where tag in ($tagList)
-         group by tag
-         having tagcnt != 0", $db);
+         where tag in (select tag from gametags where gameid = ? $mine_only_clause)
+         group by tag", array_merge([$id, $id], $mine_only_params));
 
-    for ($i = 0, $tagInfo, $cnt = mysql_num_rows($result) ;
-         $i < $cnt ; $i++) {
-        list($tag, $tagCnt, $gameCnt) = mysql_fetch_row($result);
-        $tagInfo .= "<tag><name>" . htmlspecialcharx($tag) . "</name>"
-                    . "<tagcnt>$tagCnt</tagcnt>"
-                    . "<gamecnt>$gameCnt</gamecnt>"
-                    . "</tag>";
+    while ([$tag, $tagCnt, $gameCnt] = mysql_fetch_row($result)) {
+        $tagInfo[] = [
+            'name' => $tag,
+            'tagcnt' => $tagCnt,
+            'gamecnt' => $gameCnt,
+        ];
     }
 }
 
@@ -97,6 +96,6 @@ if ($result && $tagList) {
 if ($result) {
     sendResponse("200 OK", false, $tagInfo);
 } else {
-    sendResponse("500 Internal Server Error", "An error occurred updating the database. "
+    sendResponse("500 Internal Server Error", "An error occurred querying the database. "
                  . "Please try again later.", false);
 }

--- a/www/taggame
+++ b/www/taggame
@@ -2,34 +2,49 @@
 
 include_once "session-start.php";
 include_once "util.php";
-include_once "pagetpl.php";
 include_once "login-check.php";
 
-function sendResponse($status, $statmsg, $errmsg, $detail, $tagInfo)
+function sendResponse($status, $statmsg, $errmsg, $tagInfo = null)
 {
     global $xml;
 
+    $responseObj = [];
+
+    if ($xml) {
+        // Use an indexed array, due to serialize_xml() limitations
+        if ($statmsg) {
+            $responseObj[] = ['label' => $statmsg];
+        }
+        if ($errmsg) {
+            $responseObj[] = ['error' => $errmsg];
+        }
+        if ($tagInfo) {
+            $responseObj[] = ['tags' => array_map(fn($tag) => ['tag' => $tag], $tagInfo)];
+        }
+    } else {
+        if ($statmsg) {
+            $responseObj['label'] = $statmsg;
+        }
+        if ($errmsg) {
+            $responseObj['error'] = $errmsg;
+        }
+        if ($tagInfo != null) {
+            $responseObj['tags'] = $tagInfo;
+        }
+    }
+
     header("HTTP/1.1 $status");
+    header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
+    header("Cache-Control: no-store, no-cache, must-revalidate");
     if ($xml)
     {
         header("Content-Type: text/xml");
-        header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-        header("Cache-Control: no-store, no-cache, must-revalidate");
-
-        echo "<?xml version=\"1.0\" encoding=\"UTF-8\" ?><response>"
-            . ($statmsg ? "<label>$statmsg</label>" : "")
-            . ($errmsg ? "<error>$errmsg</error>" : "")
-            . $tagInfo
-            . "</response>";
-    }
-    else
-    {
-        smallPageHeader("Tag a Game");
-        if ($errmsg)
-            echo "<span class=errmsg>$errmsg</span><p>";
-
-        echo $detail;
-        smallPageFooter();
+        echo "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>";
+        echo serialize_xml([
+            'response' => $responseObj,
+        ]);
+    } else {
+        echo send_json_response($responseObj);
     }
 
     exit();
@@ -40,7 +55,7 @@ include_once "dbconnect.php";
 $db = dbConnect();
 if ($db == false)
     sendResponse("500 Internal Server Error", "Not Saved", "An error occurred connecting to the database. "
-                 . "Please try again later.", false, false);
+                 . "Please try again later.");
 
 // get the request parameters
 $id = get_req_data('id');
@@ -65,66 +80,61 @@ for ($i = 0, $tags = array() ; ; $i++) {
 
 // make sure we process any persistent login state
 $userid = checkPersistentLogin();
-if (!$userid && $xml) {
+if (!$userid) {
     $username = get_req_data("username");
     $password = get_req_data("password");
     [$userid, $errCode, $errMsg] = doLogin($db, $username, $password);
 }
 
 if (!$userid) {
-    if ($xml) {
-        sendResponse("401 Unauthorized", "Not Saved", "Please specify a valid username and password to login.", false, false);
-    } else {
-        sendResponse("401 Unauthorized", "Not Saved", "To tag a game, please log in.", false, false);
-    }
+    sendResponse("401 Unauthorized", "Not Saved", "Please specify a valid username and password to login.");
 }
 
 $result = mysqli_execute_query($db, "select acctstatus, profilestatus, sandbox from users where id=?", [$userid]);
 if (!$result || mysql_num_rows($result) == 0) {
     // you're logged in, but there's no users row?!?
-    sendResponse("500 Internal Server Error", "Not Saved", "This service is currently unavailable. We apologize for the inconvenience. (Diagnostic information: code APS0930)", false, false);
+    sendResponse("500 Internal Server Error", "Not Saved", "This service is currently unavailable. We apologize for the inconvenience. (Diagnostic information: code APS0930)");
 } else {
     [$acctstatus, $profilestatus, $sandbox] = mysql_fetch_row($result);
 }
 
 if ($sandbox == 1) {
     // troll sandbox
-    sendResponse("500 Internal Server Error", "Not Saved", "This service is currently unavailable. We apologize for the inconvenience. (Diagnostic information: code TCE0916)", false, false);
+    sendResponse("500 Internal Server Error", "Not Saved", "This service is currently unavailable. We apologize for the inconvenience. (Diagnostic information: code TCE0916)");
 }
 
 if ($profilestatus == 'R') {
     sendResponse("401 Unauthorized", "Not Saved", "Your new user account is still pending review. "
             . "Editing is not available until the account has "
-            . "been approved.", false, false);
+            . "been approved.");
 }
 
 if ($acctstatus == 'A') {
     // active, allowed
 } else if ($acctstatus == 'D') {
     sendResponse("401 Unauthorized", "Not Saved", "Your user account has not yet been activated. "
-        . "You must complete the activation process before you can use this account for editing.", false, false);
+        . "You must complete the activation process before you can use this account for editing.");
 } else {
-    sendResponse("401 Unauthorized", "Not Saved", "Editing is not available with this account.", false, false);
+    sendResponse("401 Unauthorized", "Not Saved", "Editing is not available with this account.");
 }
 
 if (isEmpty($id))
     sendResponse(
-        "400 Bad Request", "Not Saved", "No game was specified in the tag request.", false, false);
+        "400 Bad Request", "Not Saved", "No game was specified in the tag request.");
 
 // make sure the game is valid
 $qid = mysql_real_escape_string($id, $db);
 $result = mysql_query("select id from games where id = '$qid'", $db);
 if (mysql_num_rows($result) == 0)
     sendResponse("404 Not Found", "Not Saved",
-                 "This tag request refers to a non-existent game.",
-                 false, false);
+                 "This tag request refers to a non-existent game.");
 
 foreach ($tags as $t) {
     $result = mysqli_execute_query($db, "select preferredtag from blockedtagsynonyms where blockedtag=?", [$t]);
     if (mysql_num_rows($result)) {
         [$preferred_tag] = mysqli_fetch_array($result, MYSQLI_NUM);
         sendResponse("400 Bad Request", "Not Saved",
-            "To help keep IFDB's tags tidy, please use the existing tag \"$preferred_tag\" instead of \"$t\".", false, false);
+            "To help keep IFDB's tags tidy, please use the existing tag \"$preferred_tag\" instead of \"$t\".");
     }
 }
 
@@ -170,37 +180,34 @@ if ($result) {
 }
 
 // query the new counts
-$tagInfo = "";
+$tagInfo = [];
 if ($result && $tagList) {
 
-    $result = mysql_query(
+    $result = mysqli_execute_query($db,
         "select
            tag,
-           sum(gameid = '$qid') as tagcnt,
+           cast(sum(gameid = '$qid') as int) as tagcnt,
            count(distinct gameid) as gamecnt
          from gametags
          where tag in ($tagList)
          group by tag
-         having tagcnt != 0", $db);
+         having tagcnt != 0");
 
-    for ($i = 0, $tagInfo, $cnt = mysql_num_rows($result) ;
-         $i < $cnt ; $i++) {
-        [$tag, $tagCnt, $gameCnt] = mysql_fetch_row($result);
-        $tagInfo .= "<tag><name>" . htmlspecialcharx($tag) . "</name>"
-                    . "<tagcnt>$tagCnt</tagcnt>"
-                    . "<gamecnt>$gameCnt</gamecnt>"
-                    . "</tag>";
+    while ([$tag, $tagCnt, $gameCnt] = mysql_fetch_row($result)) {
+        $tagInfo[] = [
+            'name' => $tag,
+            'tagcnt' => $tagCnt,
+            'gamecnt' => $gameCnt,
+        ];
     }
 }
 
 // explain what happened
 if ($result) {
-    sendResponse("200 OK", "Saved", false,
-                 "Your tags have been saved.", $tagInfo);
+    sendResponse("200 OK", "Saved", false, $tagInfo);
 } else {
     sendResponse("500 Internal Server Error", "Not Saved", "An error occurred updating the database. "
-                 . "Please try again later.", false, false);
+                 . "Please try again later.");
 }
 
-smallPageFooter();
 ?>

--- a/www/taggame
+++ b/www/taggame
@@ -58,31 +58,63 @@ if ($db == false)
                  . "Please try again later.");
 
 // get the request parameters
-$id = get_req_data('id');
 $xml = isset($_REQUEST['xml']);
-for ($i = 0, $tags = array() ; ; $i++) {
-    if (!isset($_REQUEST["t$i"]))
-        break;
+if (!$xml) {
+    if ($_SERVER['REQUEST_METHOD'] != 'POST') {
+        http_response_code(405);
+        echo "405 Method Not Allowed";
+        exit();
+    }
 
-    // get this tag
-    $tag = get_req_data("t$i");
+    $input_json = json_decode(file_get_contents('php://input'), true);
+    if (is_null($input_json)) {
+        http_response_code(400);
+        echo "400 Bad Request";
+        exit();
+    }
+    $id = $input_json['id'] ?? null;
+    $tags = [];
+    foreach(($input_json['tags'] ?? []) as $tag) {
+        // convert smart apostrophes, quotes, etc. to ASCII
+        $tag = approx_utf8($tag);
 
-    // convert smart apostrophes, quotes, etc. to ASCII
-    $tag = approx_utf8($tag);
+        $tag = trim($tag);
 
-    // trim it
-    $tag = trim($tag);
+        if (strlen($tag))
+            $tags[] = $tag;
+    }
+} else {
+    $id = get_req_data('id');
 
-    // if it's not an empty string, add it to the list
-    if (strlen($tag))
-        $tags[] = $tag;
+    for ($i = 0, $tags = array() ; ; $i++) {
+        if (!isset($_REQUEST["t$i"]))
+            break;
+
+        // get this tag
+        $tag = get_req_data("t$i");
+
+        // convert smart apostrophes, quotes, etc. to ASCII
+        $tag = approx_utf8($tag);
+
+        // trim it
+        $tag = trim($tag);
+
+        // if it's not an empty string, add it to the list
+        if (strlen($tag))
+            $tags[] = $tag;
+    }
 }
 
 // make sure we process any persistent login state
 $userid = checkPersistentLogin();
 if (!$userid) {
-    $username = get_req_data("username");
-    $password = get_req_data("password");
+    if (!$xml) {
+        $username = $input_json['username'] ?? null;
+        $password = $input_json['password'] ?? null;
+    } else {
+        $username = get_req_data("username");
+        $password = get_req_data("password");
+    }
     [$userid, $errCode, $errMsg] = doLogin($db, $username, $password);
 }
 

--- a/www/taggame
+++ b/www/taggame
@@ -123,8 +123,7 @@ if (isEmpty($id))
         "400 Bad Request", "Not Saved", "No game was specified in the tag request.");
 
 // make sure the game is valid
-$qid = mysql_real_escape_string($id, $db);
-$result = mysql_query("select id from games where id = '$qid'", $db);
+$result = mysqli_execute_query($db, "select id from games where id = ?", [$id]);
 if (mysql_num_rows($result) == 0)
     sendResponse("404 Not Found", "Not Saved",
                  "This tag request refers to a non-existent game.");
@@ -140,16 +139,15 @@ foreach ($tags as $t) {
 
 
 // delete any old tags set by this user
-mysql_query(
-    "delete from gametags where userid = '$userid' and gameid='$qid'", $db);
+mysqli_execute_query($db,
+    "delete from gametags where userid = ? and gameid = ?", [$userid, $id]);
 
 // insert the new tags
 $result = true;
 foreach ($tags as $t) {
-    $t = mysql_real_escape_string($t, $db);
-    $result = mysql_query(
+    $result = mysqli_execute_query($db,
         "insert into gametags (gameid, userid, tag)
-         values ('$qid', '$userid', '$t')", $db);
+         values (?, ?, ?)", [$id, $userid, $t]);
     if (!$result)
         break;
 }
@@ -157,41 +155,38 @@ foreach ($tags as $t) {
 // copy the new full set of tags for the game into the GAMES table
 if ($result) {
 
-    $result = mysql_query(
-        "select tag from gametags where gameid = '$qid'", $db);
+    $result = mysqli_execute_query($db,
+        "select tag from gametags where gameid = ?", [$id]);
 
-    for ($i = 0, $allTags = array(), $tagList = array(), $cnt = mysql_num_rows($result) ; $i < $cnt ; $i++) {
-        $curTag = mysql_result($result, $i, "tag");
-        $allTags[] = $curTag;
-        $tagList[] = "'" . mysql_real_escape_string($curTag, $db) . "'";
+    $tagList = [];
+    while ([$tag] = mysql_fetch_row($result)) {
+        $tagList[] = $tag;
     }
 
-    if (count($allTags) != 0) {
-        $allTags = implode(",", $allTags);
-        $allTags = '\'' . mysql_real_escape_string($allTags, $db) . '\'';
-        $tagList = implode(",", $tagList);
+    if (count($tagList) != 0) {
+        $allTags = implode(",", $tagList);
     } else {
-        $allTags = "null";
-        $tagList = "";
+        $allTags = null;
     }
 
-    $result = mysql_query(
-        "update games set tags = $allTags where id = '$qid'", $db);
+    $result = mysqli_execute_query($db,
+        "update games set tags = ? where id = ?", [$allTags, $id]);
 }
 
 // query the new counts
 $tagInfo = [];
 if ($result && $tagList) {
 
+    $questionMarks = implode(',', array_fill(0, count($tagList), '?'));
     $result = mysqli_execute_query($db,
         "select
            tag,
-           cast(sum(gameid = '$qid') as int) as tagcnt,
+           cast(sum(gameid = ?) as int) as tagcnt,
            count(distinct gameid) as gamecnt
          from gametags
-         where tag in ($tagList)
+         where tag in ($questionMarks)
          group by tag
-         having tagcnt != 0");
+         having tagcnt != 0", array_merge([$id], $tagList));
 
     while ([$tag, $tagCnt, $gameCnt] = mysql_fetch_row($result)) {
         $tagInfo[] = [

--- a/www/taggame
+++ b/www/taggame
@@ -3,6 +3,7 @@
 include_once "session-start.php";
 include_once "util.php";
 include_once "login-check.php";
+include_once "tags.php";
 
 function sendResponse($status, $statmsg, $errmsg, $tagInfo = null)
 {
@@ -184,49 +185,9 @@ foreach ($tags as $t) {
         break;
 }
 
-// copy the new full set of tags for the game into the GAMES table
 if ($result) {
-
-    $result = mysqli_execute_query($db,
-        "select tag from gametags where gameid = ?", [$id]);
-
-    $tagList = [];
-    while ([$tag] = mysql_fetch_row($result)) {
-        $tagList[] = $tag;
-    }
-
-    if (count($tagList) != 0) {
-        $allTags = implode(",", $tagList);
-    } else {
-        $allTags = null;
-    }
-
-    $result = mysqli_execute_query($db,
-        "update games set tags = ? where id = ?", [$allTags, $id]);
-}
-
-// query the new counts
-$tagInfo = [];
-if ($result && $tagList) {
-
-    $questionMarks = implode(',', array_fill(0, count($tagList), '?'));
-    $result = mysqli_execute_query($db,
-        "select
-           tag,
-           cast(sum(gameid = ?) as int) as tagcnt,
-           count(distinct gameid) as gamecnt
-         from gametags
-         where tag in ($questionMarks)
-         group by tag
-         having tagcnt != 0", array_merge([$id], $tagList));
-
-    while ([$tag, $tagCnt, $gameCnt] = mysql_fetch_row($result)) {
-        $tagInfo[] = [
-            'name' => $tag,
-            'tagcnt' => $tagCnt,
-            'gamecnt' => $gameCnt,
-        ];
-    }
+    // copy the new full set of tags for the game into the GAMES table
+    [$result, $tagInfo] = updateGameTagsColumn($id);
 }
 
 // explain what happened

--- a/www/taggamedelete
+++ b/www/taggamedelete
@@ -3,6 +3,7 @@
 include_once "util.php";
 include_once "login-check.php";
 include_once "dbconnect.php";
+include_once "tags.php";
 
 if ($_SERVER['REQUEST_METHOD'] != 'POST') {
     http_response_code(405);
@@ -39,8 +40,7 @@ if (!$adminPriv) {
 }
 
 // make sure the game is valid
-$qid = mysql_real_escape_string($id, $db);
-$result = mysql_query("select id from games where id = '$qid'", $db);
+$result = mysqli_execute_query($db, "select id from games where id = ?", [$id]);
 if (mysql_num_rows($result) == 0)
     send_action_response("Not Saved",
                          "This tag request refers to a non-existent game.");
@@ -56,64 +56,12 @@ foreach(($input_json['tags'] ?? []) as $tag) {
         $tags[] = $tag;
 }
 
-foreach ($tags as $t) {
-    $t = mysql_real_escape_string($t, $db);
-    $result = mysql_query("delete from gametags where gameid = '$qid' and tag ='$t'", $db);
+$questionMarks = implode(',', array_fill(0, count($tags), '?'));
+$result = mysqli_execute_query($db, "delete from gametags where gameid = ? and tag in ($questionMarks)", array_merge([$id], $tags));
 
-    if (!$result)
-        break;
-}
-
-
-
-
-// copy the new full set of tags for the game into the GAMES table
 if ($result) {
-
-    $result = mysql_query(
-        "select tag from gametags where gameid = '$qid'", $db);
-
-    for ($i = 0, $allTags = array(), $tagList = array(), $cnt = mysql_num_rows($result) ; $i < $cnt ; $i++) {
-        $curTag = mysql_result($result, $i, "tag");
-        $allTags[] = $curTag;
-        $tagList[] = "'" . mysql_real_escape_string($curTag, $db) . "'";
-    }
-
-    if (count($allTags) != 0) {
-        $allTags = implode(",", $allTags);
-        $allTags = '\'' . mysql_real_escape_string($allTags, $db) . '\'';
-        $tagList = implode(",", $tagList);
-    } else {
-        $allTags = "null";
-        $tagList = "";
-    }
-
-    $result = mysql_query(
-        "update games set tags = $allTags where id = '$qid'", $db);
-}
-
-
-// query the new counts
-$tagInfo = [];
-if ($result && $tagList) {
-
-    $result = mysql_query(
-        "select
-           tag,
-           sum(gameid = '$qid') as tagcnt,
-           count(distinct gameid) as gamecnt
-         from gametags
-         where tag in ($tagList)
-         group by tag
-         having tagcnt != 0", $db);
-
-    while ([$tag, $tagCnt, $gameCnt] = mysql_fetch_row($result)) {
-        $tagInfo[] = [
-            "name" => $tag,
-            "tagcnt" => $tagCnt,
-            "gamecnt" => $gameCnt,
-        ];
-    }
+    // copy the new full set of tags for the game into the GAMES table
+    [$result, $tagInfo] = updateGameTagsColumn($id);
 }
 
 // explain what happened

--- a/www/taggamedelete
+++ b/www/taggamedelete
@@ -1,63 +1,28 @@
 <?php
 
 include_once "util.php";
-include_once "pagetpl.php";
 include_once "login-check.php";
+include_once "dbconnect.php";
 
-function sendResponse($statmsg, $errmsg, $detail, $tagInfo)
-{
-    global $xml;
-
-    if ($xml)
-    {
-        header("Content-Type: text/xml");
-        header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-        header("Cache-Control: no-store, no-cache, must-revalidate");
-
-        echo "<?xml version=\"1.0\" encoding=\"UTF-8\" ?><response>"
-            . ($statmsg ? "<label>$statmsg</label>" : "")
-            . ($errmsg ? "<error>$errmsg</error>" : "")
-            . $tagInfo
-            . "</response>";
-    }
-    else
-    {
-        smallPageHeader("Tag a Game");
-        if ($errmsg)
-            echo "<span class=errmsg>$errmsg</span><p>";
-
-        echo $detail;
-        smallPageFooter();
-    }
-
+if ($_SERVER['REQUEST_METHOD'] != 'POST') {
+    http_response_code(405);
+    echo "405 Method Not Allowed";
     exit();
 }
 
 // connect to the database
-include_once "dbconnect.php";
 $db = dbConnect();
 if ($db == false)
-    sendResponse("Not Saved", "An error occurred connecting to the database. "
-                 . "Please try again later.", false);
+    send_action_response("Not Saved", "An error occurred connecting to the database. "
+                         . "Please try again later.");
 
-// get the request parameters
-$id = get_req_data('id');
-$xml = isset($_REQUEST['xml']);
-for ($i = 0, $tags = array() ; ; $i++) {
-    if (!isset($_REQUEST["t$i"]))
-        break;
+// process the request
+$input_json = json_decode(file_get_contents('php://input'), true);
+$id = $input_json['id'] ?? null;
 
-    // get this tag
-    $tag = get_req_data("t$i");
-
-    // trim it
-    $tag = trim($tag);
-
-    // if it's not an empty string, add it to the list
-    if (strlen($tag))
-        $tags[] = $tag;
-}
-
+if (isEmpty($id))
+    send_action_response(
+        "Not Saved", "No game was specified in the tag request.");
 
 // make sure we process any persistent login state
 $userid = checkPersistentLogin();
@@ -73,18 +38,23 @@ if (!$adminPriv) {
     exit("Only administrators are allowed to delete tags.");
 }
 
-if (isEmpty($id))
-    sendResponse(
-        "Not Saved", "No game was specified in the tag request.", false);
-
-
 // make sure the game is valid
 $qid = mysql_real_escape_string($id, $db);
 $result = mysql_query("select id from games where id = '$qid'", $db);
 if (mysql_num_rows($result) == 0)
-    sendResponse("Not Saved",
-                 "This tag request refers to a non-existent game.",
-                 false);
+    send_action_response("Not Saved",
+                         "This tag request refers to a non-existent game.");
+
+$tags = [];
+
+foreach(($input_json['tags'] ?? []) as $tag) {
+    // trim it
+    $tag = trim($tag);
+
+    // if it's not an empty string, add it to the list
+    if (strlen($tag))
+        $tags[] = $tag;
+}
 
 foreach ($tags as $t) {
     $t = mysql_real_escape_string($t, $db);
@@ -124,7 +94,7 @@ if ($result) {
 
 
 // query the new counts
-$tagInfo = "";
+$tagInfo = [];
 if ($result && $tagList) {
 
     $result = mysql_query(
@@ -137,25 +107,21 @@ if ($result && $tagList) {
          group by tag
          having tagcnt != 0", $db);
 
-    for ($i = 0, $tagInfo, $cnt = mysql_num_rows($result) ;
-         $i < $cnt ; $i++) {
-        list($tag, $tagCnt, $gameCnt) = mysql_fetch_row($result);
-        $tagInfo .= "<tag><name>" . htmlspecialcharx($tag) . "</name>"
-                    . "<tagcnt>$tagCnt</tagcnt>"
-                    . "<gamecnt>$gameCnt</gamecnt>"
-                    . "</tag>";
+    while ([$tag, $tagCnt, $gameCnt] = mysql_fetch_row($result)) {
+        $tagInfo[] = [
+            "name" => $tag,
+            "tagcnt" => $tagCnt,
+            "gamecnt" => $gameCnt,
+        ];
     }
 }
 
 // explain what happened
 if ($result) {
-    sendResponse("Saved", false,
-                 "Your tags have been saved.", $tagInfo);
+    send_action_response("Saved", false, ["tags" => $tagInfo]);
 } else {
-    sendResponse("Not Saved", "An error occurred updating the database. "
-                 . "Please try again later.", false, false);
+    send_action_response("Not Saved", "An error occurred updating the database. "
+                         . "Please try again later.");
 }
 
-
-smallPageFooter();
 ?>

--- a/www/tags.php
+++ b/www/tags.php
@@ -1,0 +1,57 @@
+<?php
+
+include_once "dbconnect.php";
+
+// ------------------------------------------------------------------------
+//
+// Updates the tags column of a game with its list of tags from gametags,
+// and return those tags.
+//
+function updateGameTagsColumn($gameid) {
+    $db = dbConnect();
+
+    $result = mysqli_execute_query($db,
+        "select tag from gametags where gameid = ?", [$gameid]);
+
+    $tagList = [];
+    while ([$tag] = mysql_fetch_row($result)) {
+        $tagList[] = $tag;
+    }
+
+    if (count($tagList) != 0) {
+        $allTags = implode(",", $tagList);
+    } else {
+        $allTags = null;
+    }
+
+    $result = mysqli_execute_query($db,
+        "update games set tags = ? where id = ?", [$allTags, $gameid]);
+
+    // query the new counts
+    $tagInfo = [];
+    if ($result && $tagList) {
+
+        $questionMarks = implode(',', array_fill(0, count($tagList), '?'));
+        $result = mysqli_execute_query($db,
+            "select
+               tag,
+               cast(sum(gameid = ?) as int) as tagcnt,
+               count(distinct gameid) as gamecnt
+             from gametags
+             where tag in ($questionMarks)
+             group by tag
+             having tagcnt != 0", array_merge([$gameid], $tagList));
+
+        while ([$tag, $tagCnt, $gameCnt] = mysql_fetch_row($result)) {
+            $tagInfo[] = [
+                'name' => $tag,
+                'tagcnt' => $tagCnt,
+                'gamecnt' => $gameCnt,
+            ];
+        }
+    }
+
+    return [$result, $tagInfo];
+}
+
+?>

--- a/www/viewgame
+++ b/www/viewgame
@@ -2606,13 +2606,6 @@ function dispDeleteTags()
 
 function deleteTag(tag)
 {
-//    alert (tag);
-
-    var c = "id=<?php echo $id ?>";
-    c += "&t=" + encodeURI8859(tag);
-
-    //xmlSend("taggamedelete", "tagStatusSpan", cbSaveTags, c);
-
     for (var j = 0 ; j < memTagList.length ; j++)
     {
         if (memTagList[j].tag == tag)
@@ -2673,44 +2666,35 @@ function saveTags()
 {
     addTags();
     dbTagList = [];
-    var c = "id=<?php echo $id ?>";
-    var i, j, k;
-    for (i = j = k = 0 ; i < memTagList.length ; i++)
+    const tags = [];
+    for (const t of memTagList)
     {
-        var t = memTagList[i];
         if (t.tagcnt != 0)
-            dbTagList[j++] = t;
+            dbTagList.push(t);
         if (t.isMine)
-            c += "&t" + (k++) + "=" + encodeURI8859(t.tag);
+            tags.push(t.tag);
     }
     dispTags();
     closeTags("tagEditor");
-    xmlSend("taggame", "tagStatusSpan", cbSaveTags, c, true);
+    jsonSend("taggame", "tagStatusSpan", cbSaveTags,
+        {"id": "<?php echo $id ?>", "tags": tags}, true);
 }
 
 function saveTagsDelete()
 {
-//    dbTagList = [];
-    var c = "id=<?php echo $id ?>";
-    var i, j, k;
-    for (i  = k = 0 ; i < dbTagList.length ; i++)
-    {
-       var t = dbTagList[i];
-       var found = false;
-
-       for (j = 0; j < memTagList.length ; j++)
-       {
-          if (memTagList[j].tag == t.tag) found = true;
-       }
-
-       if (!found) c += "&t" + (k++) + "=" + encodeURI8859(t.tag);
+    const tags = [];
+    for (const t of dbTagList) {
+        if (memTagList.find((m) => m.tag == t.tag) === undefined) {
+            tags.push(t.tag);
+        }
     }
 
     dbTagList = memTagList;
 
     dispTags();
     closeTags("tagDeletor");
-    xmlSend("taggamedelete", "tagStatusSpan", cbSaveTags, c, true);
+    jsonSend("taggamedelete", "tagStatusSpan", cbSaveTags,
+        {"id": "<?php echo $id ?>", "tags": tags}, true);
 }
 
 
@@ -2720,26 +2704,19 @@ function cbSaveTags(resp)
         alert("There was an error saving tags.");
         return;
     }
-    if (resp.querySelector("error")) {
-        alert(resp.querySelector("error").firstChild.data);
+    if (resp.error) {
+        alert(resp.error);
         return;
     }
-    var tags = resp.getElementsByTagName("tag");
-    for (var i = 0 ; i < tags.length ; ++i)
+    for (const tag of resp.tags)
     {
-        var tag = tags[i];
-        var name = tag.getElementsByTagName("name")[0].firstChild.data;
-        var gamecnt = tag.getElementsByTagName("gamecnt")[0].firstChild.data;
-        var tagcnt = tag.getElementsByTagName("tagcnt")[0].firstChild.data;
-        name = name.toLowerCase();
-
-        for (var j = 0 ; j < memTagList.length ; j++)
+        for (const memTag of memTagList)
         {
-            if (memTagList[j].tag.toLowerCase() == name)
+            if (memTag.tag.toLowerCase() == tag.name.toLowerCase())
             {
-                memTagList[j].gamecnt = parseInt(gamecnt);
-                memTagList[j].tagcnt = parseInt(tagcnt);
-                memTagList[j].isNew = false;
+                memTag.gamecnt = tag.gamecnt;
+                memTag.tagcnt = tag.tagcnt;
+                memTag.isNew = false;
                 break;
             }
         }


### PR DESCRIPTION
This updates `gametags`, `taggame`, `taggamedelete` to use JSON.

`gametags` and `taggame` are documented APIs, so they still support XML as well as JSON. However, in JSON-mode, `taggame` now requires POST, and has a different interface.

Both `taggame` and `taggamedelete` now have accept their input as JSON, and have JSON output. Since they share some code, I moved it to a different function. I think it might be nicer to keep both "tag" and "delete" functionality in the endpoint. What do you think?

The `gametags` response query was really weird, so I updated it to use a subselect - I checked it closely to confirm it's doing the same thing, but please have a look too.

After this, I'll submit updates to `ifwiki-check` and `capreq`, and remove `xmlreq.js`.