### PR TITLE
Switch ifwiki-check to communicate in HTTP status codes

### DIFF
--- a/www/ifwiki-check
+++ b/www/ifwiki-check
@@ -13,21 +13,11 @@ curl_exec($ch);
 $status_code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 curl_close($ch);
 
-$exists = ($status_code == 200);
-
+header("HTTP/1.1 $status_code");
 header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
 header("Cache-Control: no-store, no-cache, must-revalidate");
 header("Cache-Control: post-check=0, pre-check=0", false);
 header("Pragma: no-cache");
-header("Content-type: text/xml");
-
-echo "<?xml version=\"1.0\" encoding=\"UTF-8\" ?>"
-   . "<ifwiki-check-result>"
-   .   "<ifid>" . htmlspecialchars($ifid) . "</ifid>"
-   .   "<exists>"
-   .     ($exists ? "yes" : "no")
-   .   "</exists>"
-   . "</ifwiki-check-result>";
 
 exit();
 

--- a/www/viewgame
+++ b/www/viewgame
@@ -2846,12 +2846,9 @@ dispTags();
                         if (!$cssOverride) {
                         ?>
                         <script nonce="<?php global $nonce; echo $nonce; ?>">
-                            xmlSend("ifwiki-check?ifid=<?php echo $jifid ?>", null,
-                                function(doc) {
-                                    if (xmlChildText(doc, "exists") == "yes") {
-                                        document.getElementById("ifwiki-link").style.display = "initial";
-                                    }
-                                }, null);
+                            fetch("ifwiki-check?ifid=<?php echo $jifid ?>").then(r => { if (r.ok)
+                                document.getElementById("ifwiki-link").style.display = "initial";
+                            });
                         </script>
                         <?php
                         }


### PR DESCRIPTION
Removes another use of xmlSend.

Ideally, the browser would contact IF Wiki directly, as mentioned in #606.