### PR TITLE
Fix series and genre links containing non-ASCII characters

### DIFF
--- a/www/gameinfo.php
+++ b/www/gameinfo.php
@@ -198,22 +198,21 @@ function getGameInfo($db, $id, $curuser, $requestVersion, &$errMsg, &$errCode)
         $historyView = true;
     }
 
-    // massage the retrieved fields into our display formats
-    $title = htmlspecialcharx($rec["title"]);
+    $title = $rec["title"];
     $author = $rec["author"];
     $authorExt = $rec["authorExt"];
     $rawDesc = $rec["desc"];
     $desc = fixDesc($rawDesc);
     $published = $rec["published"];
     $version = $rec["version"];
-    $license = htmlspecialcharx($rec["license"]);
-    $language = htmlspecialcharx($rec["language"]);
-    $system = htmlspecialcharx($rec["system"]);
+    $license = $rec["license"];
+    $language = $rec["language"];
+    $system = $rec["system"];
     $hasart = !is_null($rec["hasart"]);
-    $genre = htmlspecialcharx($rec["genre"]);
-    $seriesname = htmlspecialcharx($rec["seriesname"]);
-    $seriesnum = htmlspecialcharx($rec["seriesnumber"]);
-    $forgiveness = htmlspecialcharx($rec["forgiveness"]);
+    $genre = $rec["genre"];
+    $seriesname = $rec["seriesname"];
+    $seriesnum = $rec["seriesnumber"];
+    $forgiveness = $rec["forgiveness"];
     $bafsid = $rec["bafsid"];
     $website = fixUrl($rec["website"]);
     $dlnotes = fixDesc($rec["downloadnotes"]);

--- a/www/showuser
+++ b/www/showuser
@@ -197,22 +197,8 @@ if ($rss == 'gamenews')
         $items[] = array($moddate, $item);
 
         // Now add news updates for the game itself.
-        list($ifids, $title, $author, $authorExt,
-             $pubYear, $pubFull, $license,
-             $system, $desc, $rawDesc,
-             $hasart, $genre, $seriesname, $seriesnum,
-             $forgiveness, $bafsid, $version,
-             $language, $languageNameOnly,
-             $website, $links,
-             $ratingcountavg, $ratingcounttot, $ratingavg, $memberReviewCnt,
-             $currentUserRating, $currentUserReview,
-             $editedbyid, $editedbyname, $moddate, $moddate2, $pagevsn,
-             $moddatelatest,
-             $historyView,
-             $dlnotes, $extReviews, $extRevDisplayRank,
-             $ratingHisto, $xrefs, $inrefs) =
-                 getGameInfo($db, $gameid, $curuser, false,
-                             $gameErrMsg, $gameErrCode);
+        $links = getGameInfo($db, $gameid, $curuser, false,
+                        $gameErrMsg, $gameErrCode)[20];
 
         // add the RSS items for this game to the master list
         if (!$gameErrMsg) {

--- a/www/util.php
+++ b/www/util.php
@@ -169,12 +169,6 @@ function zeroWidthSpaceUnderscores($str) {
     return str_replace('/', '&#8203;/', str_replace('_', '&#8203;_', $str));
 }
 
-// URL-encode from a string that's been HTML quoted
-function urlencodeFromHTML($str)
-{
-    return urlencode(htmlspecialchars_decode($str));
-}
-
 // --------------------------------------------------------------------------
 // are we on an iPhone or Android device?
 //

--- a/www/util.php
+++ b/www/util.php
@@ -169,16 +169,10 @@ function zeroWidthSpaceUnderscores($str) {
     return str_replace('/', '&#8203;/', str_replace('_', '&#8203;_', $str));
 }
 
-// extended URL encoding, with UTF8 conversion
-function urlencodex($str)
-{
-    return urlencode(utf8_encode($str));
-}
-
 // URL-encode from a string that's been HTML quoted
 function urlencodeFromHTML($str)
 {
-    return urlencode(utf8_encode(htmlspecialchars_decode($str)));
+    return urlencode(htmlspecialchars_decode($str));
 }
 
 // --------------------------------------------------------------------------

--- a/www/viewgame
+++ b/www/viewgame
@@ -388,9 +388,6 @@ if (!$errMsg) {
     $title = htmlspecialchars($title);
     $license = htmlspecialchars($license);
     $language = htmlspecialchars($language);
-    $system = htmlspecialchars($system);
-    $genre = htmlspecialchars($genre);
-    $seriesname = htmlspecialchars($seriesname);
     $seriesnum = htmlspecialchars($seriesnum);
     $forgiveness = htmlspecialchars($forgiveness);
 
@@ -1440,8 +1437,8 @@ if (!isEmpty($seriesname)) {
         echo "Part of ";
     else
         echo "Episode $seriesnum of ";
-    echo "<a href=\"search?searchfor=series:" . urlencodeFromHTML($seriesname)
-        . "\">$seriesname</a><br>";
+    echo "<a href=\"search?searchfor=series:" . urlencode($seriesname)
+        . "\">".htmlspecialchars($seriesname)."</a><br>";
 }
                      ?>
                      <?php if (!isEmpty($pubYear)) echo "$pubYear<br>" ?>
@@ -1449,11 +1446,11 @@ if (!isEmpty($seriesname)) {
 if (!isEmpty($genre)) {
     $genres = explode(",", str_replace("/", ",", $genre));
     echo join(", ", array_map(
-        fn($genre) => "<a href=\"search?searchfor=genre:" . urlencodeFromHTML($genre) . "\">$genre</a>",
+        fn($genre) => "<a href=\"search?searchfor=genre:" . urlencode($genre) . "\">".htmlspecialchars($genre)."</a>",
         $genres)) . "<br>";
 }
                      ?>
-                     <?php if (!isEmpty($system)) echo "<div>$system</div>" ?>
+                     <?php if (!isEmpty($system)) echo "<div>".htmlspecialchars($system)."</div>" ?>
                      <?php
                         $showExternalLinksAnchor = count($links) && ($detailView || $historyView);
                         if (!isEmpty($website) || $showExternalLinksAnchor) {
@@ -2797,7 +2794,7 @@ dispTags();
                <?php if (!isEmpty($license))
                    echo "License: $license<br>" ?>
                <?php if (!isEmpty($system))
-                   echo "Development System: <a href=\"search?searchfor=system:" . urlencodeFromHTML($system) . "\">$system</a><br>" ?>
+                   echo "Development System: <a href=\"search?searchfor=system:" . urlencode($system) . "\">".htmlspecialchars($system)."</a><br>" ?>
                <?php if (!isEmpty($forgiveness))
                    echo helpWinLink("help-forgiveness", "Forgiveness Rating")
                        . ": $forgiveness<br>" ?>

--- a/www/viewgame
+++ b/www/viewgame
@@ -385,6 +385,14 @@ if (!$errMsg) {
          $dlnotes, $extReviews, $extRevDisplayRank,
          $ratingHisto, $xrefs, $inrefs, $flags) =
              getGameInfo($db, $id, $curuser, $reqVersion, $errMsg, $errCode);
+    $title = htmlspecialchars($title);
+    $license = htmlspecialchars($license);
+    $language = htmlspecialchars($language);
+    $system = htmlspecialchars($system);
+    $genre = htmlspecialchars($genre);
+    $seriesname = htmlspecialchars($seriesname);
+    $seriesnum = htmlspecialchars($seriesnum);
+    $forgiveness = htmlspecialchars($forgiveness);
 
     $should_hide = ($flags & FLAG_SHOULD_HIDE);
 


### PR DESCRIPTION
Fixes #508

EDIT (Nov 7): This PR is redone from scratch now, in three commits.

The first commit trims our use of `getGameInfo` in `showuser`; we only need `$links`, and now the code shows that.

The second commit is a tiny bit scary, security-wise. `getGameInfo` used to take care of running `htmlspecialcharx` on some but not all strings it returns. Now, it doesn't pre-run `htmlspecialcharx` at all. `showuser` doesn't care, because it was only ever using the links, but now `viewgame` calls `htmlspecialchars` itself right after destructuring the result.

(I tested this by adding `<` to the series, genre, author, and system of <http://localhost:8080/viewgame?id=i57zntqzl6fnkt5v>, viewing it in XML and regular mode.)

In the second commit, we delay `htmlspecialchars` for `$system`, `$genre`, and `$seriesname`, so we can separately `urlencode` them for searching and `htmlspecialchars` encode them for display. This strategy now matches the approach we use for `$author`.

We're also now using `urlencode` and not `urlencodeFromHTML`, which was built on the assumption that the database was storing HTML entities, and that the data would be in ISO-8859-1 (Windows-1252), which it converted using [`utf8_encode`](https://www.php.net/manual/en/function.utf8-encode.php).

> utf8_encode — Converts a string from ISO-8859-1 to UTF-8
> WARNING This function has been DEPRECATED as of PHP 8.2.0. Relying on this function is highly discouraged.
