### PR TITLE
Use JSON in captcha code

### DIFF
--- a/www/capreq
+++ b/www/capreq
@@ -1,6 +1,6 @@
 <?php
 
-// Generic xml http request CAPTCHA handler.
+// Generic JSON http request CAPTCHA handler.
 //
 // This coordinates captcha handling with other scripts via the $_SESSION
 // context.  See captcha.php for an example of use.
@@ -10,27 +10,10 @@ include_once "session-start.php";
 include_once "util.php";
 include_once "captcha.php";
 
-// send an XML reply
-function replyXML($body)
-{
-    // send the XML content header, and disable caching
-    header("Content-type: text/xml");
-    header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
-    header("Cache-Control: no-store, no-cache, must-revalidate");
-
-    // send the XML
-    echo "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-        . "<captchaReply>"
-        . $body
-        . "</captchaReply>";
-
-    // that's all we need to send
-    exit();
-}
-
 function replyErr($msg)
 {
-    replyXML("<captchaError>" . htmlspecialcharx($msg) . "</captchaError>");
+    send_json_response(["error" => $msg]);
+    exit();
 }
 
 // Get the captcha key.  This identifiers the $_SESSION parameter for
@@ -46,7 +29,7 @@ if (!isset($_SESSION[$skey]))
     replyErr("The session key is invalid. "
              . "Please refresh the page and try again.");
 
-list($succReply) = $_SESSION[$skey];
+$succReply = $_SESSION[$skey];
 
 // Check to see if this is a reply with a code.  If there's a code,
 // replace the commonly confused characters with the canonical mappings.
@@ -55,11 +38,15 @@ if ($answer)
 {
     // it's a response - validate it
     $resp = recaptcha_check_answer(RECAPTCHA_PRIVATE_KEY, $_SERVER["REMOTE_ADDR"], $answer);
-    if ($resp->is_valid)
-        replyXML("<ok/>$succReply");
-    else {
-        $errTab = array(
-            "incorrect-captcha-sol" => "Incorrect entry - please try again.");
+    if ($resp->is_valid) {
+        header("Content-Type: application/json");
+        header("Expires: Mon, 26 Jul 1997 05:00:00 GMT");
+        header("Cache-Control: no-store, no-cache, must-revalidate");
+        echo "{\"reply\": $succReply}";
+        exit();
+    } else {
+        $errTab = [
+            "incorrect-captcha-sol" => "Incorrect entry - please try again."];
         if (isset($errTab[$resp->error]))
             replyErr($errTab[$resp->error]);
         else

--- a/www/captcha.php
+++ b/www/captcha.php
@@ -6,17 +6,14 @@ include_once "dbconnect.php";
 //
 // This module has two main uses:
 //
-//   A. Email masker (AJAX; in-line javascript and XML requests)
+//   A. Email masker (AJAX; in-line javascript and JSON requests)
 //   B. Submitted form protector (adds captcha to a regular POST form)
 //
 // General instructions for all functions:
 //
 //   1. Include this file in your php file
 //
-//   2. In your pageHeader() extra header text, include
-//       scriptSrc('/xmlreq.js')
-//
-//   3. Generate a "key" for the captcha session (see below).  This is
+//   2. Generate a "key" for the captcha session (see below).  This is
 //      a unique key for the $_SESSION array to identify this captcha
 //      interaction.  A good formula is to use the name of the page
 //      plus the object key that's used to generate the page.  It's
@@ -25,7 +22,7 @@ include_once "dbconnect.php";
 //      anything else that will change on refresh, since the session
 //      key has to survive the POST.
 //
-//   4. Call captchaSupportScripts($key) to generate support scripts
+//   3. Call captchaSupportScripts($key) to generate support scripts
 //      This can go almost anywhere - it just echoes some in-line
 //      <script> code.
 //
@@ -39,10 +36,10 @@ include_once "dbconnect.php";
 //    masked email is a link; clicking the link displays a hidden CAPTCHA
 //    form.  The form is AJAX-driven - if the user enters a code and
 //    presses Return or clicks Submit, the form doesn't do a POST, but
-//    simply sends an xml http request to the server, passing along
+//    simply sends a JSON http request to the server, passing along
 //    the code the user entered and asking the server for the missing
 //    email information.  The server verifies the code and sends back
-//    the full emails via XML; the page hides the CAPTCHA form and
+//    the full emails via JSON; the page hides the CAPTCHA form and
 //    replaces the masked emails with the real addresses, hyperlinked
 //    with mailto: links.  The emails aren't included anywhere in the
 //    initial page load - they're only on the server, so there's no way
@@ -56,7 +53,7 @@ include_once "dbconnect.php";
 //   2. To mask an email: Use captchaMaskEmail($email, $msg) to generate
 //      the masked display string.  Display this string at the spot where
 //      you want the email to appear.  The form will automatically
-//      rewrite it with the correct email on receiving the xml reply.
+//      rewrite it with the correct email on receiving the json reply.
 //
 //   3. AFTER generating all masked emails, call captchaFinish($key) to
 //      set up the session information.
@@ -193,46 +190,6 @@ function hideCaptchaForm()
     document.getElementById("captchaFormDiv").style.display = "none";
     captchaFormStatus("", "");
 }
-function submitCaptchaForm()
-{
-    var val = Recaptcha.get_response();
-    var chal = Recaptcha.get_challenge();
-    if (val == "")
-    {
-        hideCaptchaForm();
-        return;
-    }
-    var url = "capreq?id=<?php echo $sessionKey ?>&code="
-              + encodeURIComponent(val)
-              + "&chal=" + encodeURIComponent(chal);
-    xmlSend(url, null, function(resp) {
-
-        var err = resp.getElementsByTagName("captchaError");
-        if (err && err.length && err[0].firstChild)
-        {
-            captchaFormStatus(err[0].firstChild.data, "errmsg");
-            Recaptcha.reload();
-            return;
-        }
-        var emails = resp.getElementsByTagName("email");
-        if (emails && emails.length)
-        {
-            for (var i = 0 ; i < emails.length ; i++)
-            {
-                var e = emails[i].firstChild.data;
-                var ele = document.getElementById("emailMasker" + i);
-                ele.innerHTML = "<a href=\"mailto:" + e + "\">"
-                    + encodeHTML(e) + "</a>";
-            }
-            hideCaptchaForm();
-        }
-        <?php if ($okcb) echo "$okcb(resp);" ?>
-    }, null);
-}
-function newCaptchaImage()
-{
-    Recaptcha.reload();
-}
 function captchaFormStatus(msg, cls)
 {
     var ele = document.getElementById("captchaStatusMsg");
@@ -243,29 +200,27 @@ function captchaSolved(response)
 {
     var url = "capreq?id=<?php echo $sessionKey ?>&code="
         + encodeURIComponent(response);
-    xmlSend(url, null, function(resp) {
+    jsonSend(url, null, function(resp) {
 
-        var err = resp.getElementsByTagName("captchaError");
-        if (err && err.length && err[0].firstChild)
+        if (resp.error)
         {
-            captchaFormStatus(err[0].firstChild.data, "errmsg");
-            Recaptcha.reload();
+            captchaFormStatus(resp.error, "errmsg");
+            grecaptcha.reset();
             return;
         }
-        var emails = resp.getElementsByTagName("email");
+        const emails = resp.reply;
         if (emails && emails.length)
         {
-            for (var i = 0 ; i < emails.length ; i++)
+            for (const [i, e] of emails.entries())
             {
-                var e = emails[i].firstChild.data;
-                var ele = document.getElementById("emailMasker" + i);
+                const ele = document.getElementById("emailMasker" + i);
                 ele.innerHTML = "<a href=\"mailto:" + e + "\">"
                     + encodeHTML(e) + "</a>";
             }
             hideCaptchaForm();
         }
         <?php if ($okcb) echo "$okcb(resp);" ?>
-    }, null);
+    }, null, true);
 }
 //-->
 </script>
@@ -280,8 +235,6 @@ function captchaAjaxForm($sessionKey)
 {
     echo "<div id='captchaFormDiv' class='hidden'>"
         . "<form name='captchaAjaxForm'>"
-        . addEventListener('submit', 'submitCaptchaForm();return false;')
-//        . getCaptchaSubForm($sessionKey, false, false)
         . "<div id='captchaFormCont'></div>"
         . "<div><span id='captchaStatusMsg'></span></div>"
         . "<div class=\"g-recaptcha\" data-callback=\"captchaSolved\" data-sitekey=\"" . RECAPTCHA_PUBLIC_KEY . "\"></div>"
@@ -298,26 +251,7 @@ function captchaFinish($sessionKey)
 {
     global $captchaEmailList;
 
-    // start with an empty XML reply
-    $xml = "";
-
-    // generate the reply with all the emails
-    if ($captchaEmailList)
-    {
-        // make the list of <email> tags
-        for ($i = 0, $xml = false ; $i < count($captchaEmailList) ; $i++)
-        {
-            $xml[] = "<email>"
-                     . htmlspecialcharx($captchaEmailList[$i])
-                     . "</email>";
-        }
-
-        // wrap the list in an <emails> section and add it to the result
-        $xml .= "<emails>" . implode("", $xml) . "</emails>";
-    }
-
-    // set the XML in the session
-    $_SESSION["CAPTCHA.$sessionKey"] = array($xml);
+    $_SESSION["CAPTCHA.$sessionKey"] = $captchaEmailList ? json_encode($captchaEmailList) : "[]";
 }
 
 // ------------------------------------------------------------------------

--- a/www/ifdbutil.js
+++ b/www/ifdbutil.js
@@ -237,12 +237,13 @@ async function jsonSend(url, statusSpanID, cbFunc, content, silentMode)
     }
 
     let jsonResponse = null;
+    let msgspan = null;
     try {
         const response = await fetch(url, options);
         jsonResponse = await response.json();
-        const msgspan = (statusSpanID
-                       ? document.getElementById(statusSpanID)
-                       : null);
+        msgspan = (statusSpanID
+                ? document.getElementById(statusSpanID)
+                : null);
 
         if (!response || !response.ok)
             throw new Error();
@@ -254,7 +255,7 @@ async function jsonSend(url, statusSpanID, cbFunc, content, silentMode)
         }
 
         const errmsg = jsonResponse.error;
-        if (errmsg)
+        if (errmsg && !silentMode)
             alert(errmsg);
     } catch (e) {
         if (msgspan)


### PR DESCRIPTION
Also fixed issues in `jsonSend` error handling.

To test the captcha, you can use [the keys from here](https://developers.google.com/recaptcha/docs/faq#id-like-to-run-automated-tests-with-recaptcha.-what-should-i-do). I suggest including them in the development environment for everyone, if there's such a settings file.

Then you want to remove admin privs from the admin account, and add an email to the user. Captchas are also shown for yourself in `/showuser`, so this will do:
```mysql
update users set privileges='A' where id='0000000000000000';
update users
set email="test@example.com", publicemail="foobar@test.com", emailflags=1
where id='0000000000000000';
```

I also fixed an issue with `Recaptcha.reload()` not being defined - I think it's now `reset()`, and the canonical name of the object is now `grecaptcha`.

Finally, I deleted `submitCaptchaForm()`. I'm not sure what's it for. It shares code with `captchaSolved`. Both are in the form, but `submitCaptchaForm()` is in a "submit" event that's never triggered, because there's no submit button. Am I missing something? Maybe it's for an older version of reCAPTCHA?

```html
<form name='captchaAjaxForm'><script nonce='XXw5d8kB'>
document.currentScript.parentElement.addEventListener('submit', function (event) {
var result = (function(){ submitCaptchaForm();return false; }).apply(event.target);
if (result === false) event.preventDefault();
});
</script>
<div id='captchaFormCont'></div><div><span id='captchaStatusMsg'></span></div>
<div class="g-recaptcha" data-callback="captchaSolved" data-sitekey=""></div>
</form>
```