### PR TITLE
Home page markup fixes

### DIFF
--- a/www/components/poll-sampler.php
+++ b/www/components/poll-sampler.php
@@ -69,16 +69,16 @@ echo "<div>New Polls: <span class='details'><a href='/search?browse&poll'>See Mo
 foreach ($recently_created as $row) {
     displayPoll($row);
 }
-echo "</p></div><div>Polls with Recent Votes: <span class='details'><a href='/search?browse&poll&sortby=newvote'>See More</a></span><p>\n";
+echo "<p></div><div>Polls with Recent Votes: <span class='details'><a href='/search?browse&poll&sortby=newvote'>See More</a></span><p>\n";
 foreach ($recently_voted as $row) {
     displayPoll($row);
 }
 
-echo "</p></div>\n<div class=\"details poll-sampler__create\">"
+echo "<p></div>\n<div class=\"details poll-sampler__create\">"
     . "<a href=\"search?browse&poll&sortby=votes\">Browse all polls</a> | "
     . "<a href=\"search?poll\">Search for polls</a> | "
     . helpWinLink("help-polls", "What are polls?")
-    . "</div></td></tr></table></div>";
+    . "</div></div>";
 
 //  ------------------------ end poll sampler box ---------------------------
 ?>

--- a/www/home
+++ b/www/home
@@ -53,7 +53,7 @@ if ($debugflag) echo "debug mode enabled...<br>";
       <div class="block">
          <details id="welcome-details" <?= $welcomeOpen ? "open" : ""?>>
          <summary>
-            <div class="headline headline1"><span><span id="welcome-disclosure"></span> <h1 class='unset'>Welcome to IFDB!</h1></a></span>
+            <div class="headline headline1"><span><span id="welcome-disclosure"></span> <h1 class='unset'>Welcome to IFDB!</h1></span>
                <span class=headlineRss>
                   <?php
                   if ($adminPriv) {
@@ -104,6 +104,7 @@ if ($debugflag) echo "debug mode enabled...<br>";
                </form>
             </div>
          </div>
+         </details>
       </div>
 
       <?php include "components/check-inbox.php"?>
@@ -115,7 +116,7 @@ if ($debugflag) echo "debug mode enabled...<br>";
                   <span class=headlineRss>
                      <a href="allnew">All Updates</a> |
                      <a href="news">Site News</a>
-                     <span class='mobile-hidden'> | <a href="allnew-rss"><img src="img/blank.gif" class="rss-icon" alt="">RSS Feed</a>
+                     <span class='mobile-hidden'> | <a href="allnew-rss"><img src="img/blank.gif" class="rss-icon" alt="">RSS Feed</a></span>
                   </span>
             </div>
             <div>
@@ -134,7 +135,6 @@ if ($debugflag) echo "debug mode enabled...<br>";
                'enableImages' => false,
             ]);
             ?>
-            </div>
             </div>
          </div>
       </div>
@@ -193,6 +193,6 @@ if ($debugflag) echo "debug mode enabled...<br>";
             <p>IFDB was originally developed by <a href="https://www.tads.org/">Mike Roberts</a>.
          </div>
       </div>
-      <?php pageFooter()?>
    </div>
 </div>
+<?php pageFooter()?>

--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -1107,7 +1107,7 @@ h1.unset {
 }
 
 #welcome-details[open] #welcome-disclosure::before {
-    content: '[-]';
+    content: '[−]';
 }
 
 #welcome-details:not([open]) #welcome-disclosure::before {


### PR DESCRIPTION
1. Fixed some markup errors spotted by Firefox's "View Source".
2. Changed the collapsible welcome section's "[-]" to a minus sign, so it's the same width as "+", and doesn't shift the headline sideways when toggled.

Fixes #990.