### PR TITLE
Add API link in the footer, rewrite URL to `/api/`

### DIFF
--- a/www/.htaccess
+++ b/www/.htaccess
@@ -52,6 +52,9 @@ RewriteRule ^index$ home [L]
 RewriteRule ^index\.htm$ home [L]
 RewriteRule ^index\.html$ home [L]
 
+RewriteRule ^api/$ /api/index [END]
+RewriteRule ^api/index$ /api/ [L,R=301]
+
 RewriteRule ^dla-zoom/([a-z0-9]+)/[^/]+\.signpost$ /dladviser?id=$1&xml&os=MacOSX [L]
 
 RewriteRule ^users/([a-z0-9]+)/(.+)$ /userfile?u=$1&f=$2 [L]

--- a/www/pagetpl.php
+++ b/www/pagetpl.php
@@ -170,7 +170,8 @@ function pageFooter()
 <a class="nav" id="footer-coc" href="/code-of-conduct">Code of Conduct</a> |
 <a class="nav" id="footer-tos" href="/tos">Terms of Service</a> |
 <a class="nav" id="footer-privacy" href="/privacy">Privacy</a> |
-<a class="nav" id="footer-copyright" href="/copyright">Copyrights &amp; Trademarks</a>
+<a class="nav" id="footer-copyright" href="/copyright">Copyrights &amp; Trademarks</a> |
+<a class="nav" id="footer-api" href="/api/">API</a>
 <div class="iftf-donation">
     <div>
         <a href="http://iftechfoundation.org/"><img class="iftf invert" alt="Interactive Fiction technology Foundation" src="/img/iftf-logo.svg"></a>


### PR DESCRIPTION
https://httpd.apache.org/docs/2.4/mod/mod_rewrite.html#rewriterule

I had to use `[END]` instead of `[L]` to get this to work. I'm not totally clear why that is, but I think it has something to do with "caveats" for `[L]` that didn't make sense to me reading the documentation.

It seems to work, though!
* `/api/` shows the docs
* `/api/index` redirects to `/api/`
* `/api` redirects to `/api/`