### PR TITLE
Remove legacy mobile styles

### DIFF
--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -1296,6 +1296,14 @@ span.headlineRss {
         display: block;
     }
 
+    .rightbar {
+        display: none;
+    }
+
+    div.tipbox {
+        display: none;
+    }
+
 }
 
 /*

--- a/www/legacy-mobile-styles.css
+++ b/www/legacy-mobile-styles.css
@@ -1,9 +1,0 @@
-@import url("/ifdb.css?v=1");
-
-.rightbar {
-   display: none;
-}
-
-div.tipbox {
-   display: none;
-}

--- a/www/util.php
+++ b/www/util.php
@@ -367,12 +367,6 @@ function echoStylesheetLink()
         $mtime = strtotime($ssmodified);
         echo "<link rel=\"stylesheet\" href=\"$stylesheet?t=$mtime\">";
     }
-    // otherwise, use the mobile stylesheet if we're on mobile
-    else if (is_mobile()) {
-        $stylesheet = "/legacy-mobile-styles.css";
-        $mtime = filemtime($_SERVER['DOCUMENT_ROOT'] . $stylesheet);
-        echo "<link rel=\"stylesheet\" href=\"$stylesheet?t=$mtime\">";
-    }
     // or the regular stylesheet if we're not
     else {
         $stylesheet = "/ifdb.css";


### PR DESCRIPTION
Fixes #1041

I realized that I'd been holding off on this because I wanted to track down all the places to fix, which I did. Now there are separate filed issues for all of them, and we can just nuke the legacy file.

This improves performance, which is especially important on mobile, by saving the user an extra round trip to download `ifdb.css`.