### PR TITLE
Use the convert time to text function for displaying the estimated median time

### DIFF
--- a/www/util.php
+++ b/www/util.php
@@ -2846,21 +2846,21 @@ function collapsedAuthors($authors) {
     return $str;
 }
 
-//Convert total minutes of play time to hours and minutes for display
-function convertToHoursAndMinutes($total_minutes) {
-	$hours = floor($total_minutes/60);
-	$remaining_minutes = $total_minutes - ($hours * 60);
-	return (['hours' => $hours, 'minutes' => $remaining_minutes]);
-}
 
-
-// When we have a time in minutes, convert it into hours and minutes,
-// and then add the words "hours" and "minutes" as needed
-function convertTimeToText($time) {
+// Convert total minutes of play time to an array of hours and minutes
+ function convertToHoursAndMinutes($total_minutes) {
+ 	$hours = floor($total_minutes/60);
+ 	$remaining_minutes = $total_minutes - ($hours * 60);
+ 	return (['hours' => $hours, 'minutes' => $remaining_minutes]);
+ }
+ 
+ 
+// Using an array of hours and minutes, make a string to display the time,
+// adding the words "hours" and "minutes" as needed
+function convertTimeToText($hours_and_minutes_array) {
     $text="";
-    $hours_and_minutes=convertToHoursAndMinutes($time);
-    $h=$hours_and_minutes['hours'];
-    $m=$hours_and_minutes['minutes'];
+    $h=$hours_and_minutes_array['hours'];
+    $m=$hours_and_minutes_array['minutes'];
     if ($h >= 1) {
         $text = $h . " ";
         if ($h == 1) {

--- a/www/viewgame
+++ b/www/viewgame
@@ -1972,23 +1972,30 @@ while ($row = mysqli_fetch_assoc($result)) {
     $alltimes[]=$time;
 }
 
-
-// Find the median play time for this game, and round the minutes if necessary
-$estimated_hours = 0;
-$estimated_minutes = 0;
+// Find the median play time for this game, and separate the hous and minutes
 $mediantime=findMedian($alltimes);
 $median_hours_and_minutes=convertToHoursAndMinutes($mediantime);
-$estimated_hours=$median_hours_and_minutes['hours'];
+$median_hours=$median_hours_and_minutes['hours'];
 $median_minutes=$median_hours_and_minutes['minutes'];
+
+// For the official estimated time for a game, we we want to round to the 
+// nearest 5 minutes when the game is longer than 1 hour.
+$official_estimated_time_in_text="";
 if ($median_minutes != 0) {
-    if ($estimated_hours >= 1 ) {
+    if ($median_hours >= 1 ) {
         // If the game is over an hour, round the minutes to the nearest 5 minutes. 
-        $estimated_minutes = round( $median_minutes / 5 ) * 5;
+	$minutes_rounded_to_five = round( $median_minutes / 5 ) * 5;
+        $official_estimated_time_in_text = convertTimeToText(['hours' => $median_hours, 'minutes' => $minutes_rounded_to_five]);
     } else {
         // If the game is under an hour, round the minutes to the nearest whole number.
-        $estimated_minutes = round($median_minutes);  
+        $whole_minutes = round($median_minutes);
+        $official_estimated_time_in_text = convertTimeToText(['hours' => $median_hours, 'minutes' => $whole_minutes]);
     }
+} else {
+    $official_estimated_time=convertTimeToText($median_hours_and_minutes);
 }
+
+
 
 function displayMedian($estimated_hours, $estimated_minutes, $alltimes) {
     // If there is an estimated play time, display it. Note that this does not

--- a/www/viewgame
+++ b/www/viewgame
@@ -1997,7 +1997,7 @@ if ($median_minutes != 0) {
 
 
 
-function displayMedianTime($median_hours, $median_minutes, $alltimes) {
+function displayMedianTime($median_hours, $median_minutes, $official_estimated_time_text, $alltimes) {
     if (($median_hours >= 1) or ($median_minutes >= 1)) {
         echo "<details><summary>Estimated play time: ";
         echo $official_estimated_time_text;
@@ -2017,7 +2017,7 @@ function displayMedianTime($median_hours, $median_minutes, $alltimes) {
 //--------------------Code for Estimated Median Time Ends Here-----------------
 
 if ($ratingCntTot == 0 && $memberReviewCnt == 0) {
-    displayMedianTime($median_hours, $median_minutes, $alltimes);
+    displayMedianTime($median_hours, $median_minutes, $official_estimated_time_text, $alltimes);
     echo "<img src=\"/img/blank.gif\" class=\"star0\" title=\"No Ratings\">
        No reviews yet";
     if ($embargoCnt == 0)
@@ -2027,7 +2027,7 @@ if ($ratingCntTot == 0 && $memberReviewCnt == 0) {
         . "title=\"View all ratings and reviews for this game\">"
         . "$ratingCntTot rating" . ($ratingCntTot != 1 ? "s" : "")
         . "</a><br>";
-    displayMedianTime($median_hours, $median_minutes, $alltimes);
+    displayMedianTime($median_hours, $median_minutes, $official_estimated_time_text, $alltimes);
 } else {
     if (!$should_hide && $ratingAvg != 0) {
         echo showStars($ratingAvg)
@@ -2039,7 +2039,7 @@ if ($ratingCntTot == 0 && $memberReviewCnt == 0) {
 
     echo "</p>";
 
-    displayMedianTime($median_hours, $median_minutes, $alltimes);
+    displayMedianTime($median_hours, $median_minutes, $official_estimated_time_text, $alltimes);
 
     if ($memberReviewCnt != 0) {
         $href = ($memberReviewCnt > $reviewsOnHomePage)

--- a/www/viewgame
+++ b/www/viewgame
@@ -1386,9 +1386,10 @@ function updateUnwishList(id, stat)
         }
     // At this point $mystoredtime should reflect the player's actual stored time for this game
     $my_time_as_text = "";
-    $time_announcement = ""; // The string shown in the How Long Is Ths Game panel
+    $time_announcement = ""; // The string shown in the Estimated Play Time control panel
     if ($mystoredtime >= 1) {
-        $my_time_as_text=convertTimeToText($mystoredtime);
+        $hours_and_minutes = convertToHoursAndMinutes($mystoredtime);
+        $my_time_as_text=convertTimeToText($hours_and_minutes);
         $time_announcement = "Your vote: " . $my_time_as_text;
     }
    

--- a/www/viewgame
+++ b/www/viewgame
@@ -1980,46 +1980,30 @@ $median_minutes=$median_hours_and_minutes['minutes'];
 
 // For the official estimated time for a game, we we want to round to the 
 // nearest 5 minutes when the game is longer than 1 hour.
-$official_estimated_time_in_text="";
+$official_estimated_time_text="";
 if ($median_minutes != 0) {
     if ($median_hours >= 1 ) {
         // If the game is over an hour, round the minutes to the nearest 5 minutes. 
 	$minutes_rounded_to_five = round( $median_minutes / 5 ) * 5;
-        $official_estimated_time_in_text = convertTimeToText(['hours' => $median_hours, 'minutes' => $minutes_rounded_to_five]);
+        $official_estimated_time_text = convertTimeToText(['hours' => $median_hours, 'minutes' => $minutes_rounded_to_five]);
     } else {
         // If the game is under an hour, round the minutes to the nearest whole number.
         $whole_minutes = round($median_minutes);
-        $official_estimated_time_in_text = convertTimeToText(['hours' => $median_hours, 'minutes' => $whole_minutes]);
+        $official_estimated_time_text = convertTimeToText(['hours' => $median_hours, 'minutes' => $whole_minutes]);
     }
 } else {
-    $official_estimated_time=convertTimeToText($median_hours_and_minutes);
+    $official_estimated_time_text=convertTimeToText($median_hours_and_minutes);
 }
 
 
 
-function displayMedian($estimated_hours, $estimated_minutes, $alltimes) {
-    // If there is an estimated play time, display it. Note that this does not
-    // use the convertTimeToText function because in this case, we are displaying
-    // the official estimated time for a game, and so we we want to round to the 
-    // nearest 5 minutes when the game is longer than 1 hour.
+function displayMedianTime($estimated_hours, $estimated_minutes, $alltimes) {
     if (($estimated_hours >= 1) or ($estimated_minutes >= 1)) {
         echo "<details><summary>Estimated play time: ";
-        if ($estimated_hours >= 1) {
-            if ($estimated_hours == 1) {
-                echo $estimated_hours . " hour ";
-            } else if ($estimated_hours > 1) {
-                echo $estimated_hours . " hours ";
-            }
-            if ($estimated_minutes >= 1)
-            echo "and ";
-        }
-        if ($estimated_minutes == 1) {
-            echo $estimated_minutes . " minute ";
-        } else if ($estimated_minutes > 1) {
-            echo $estimated_minutes . " minutes ";
-        }
+        echo "<details><summary>Estimated play time: ";
+        echo $official_estimated_time_text;
         $s = (count($alltimes) === 1) ? "" : "s";
-        echo "(based on " . count($alltimes) . " vote$s)</span></summary><br>";
+        echo " (based on " . count($alltimes) . " vote$s)</span></summary><br>";
         echo "Members voted for the following times for this game:";
         echo "<ul>";
         foreach ($alltimes as $t) {
@@ -2033,7 +2017,7 @@ function displayMedian($estimated_hours, $estimated_minutes, $alltimes) {
 //--------------------Code for Estimated Median Time Ends Here-----------------
 
 if ($ratingCntTot == 0 && $memberReviewCnt == 0) {
-    displayMedian($estimated_hours, $estimated_minutes, $alltimes);
+    displayMedianTime($estimated_hours, $estimated_minutes, $alltimes);
     echo "<img src=\"/img/blank.gif\" class=\"star0\" title=\"No Ratings\">
        No reviews yet";
     if ($embargoCnt == 0)

--- a/www/viewgame
+++ b/www/viewgame
@@ -1997,18 +1997,18 @@ if ($median_minutes != 0) {
 
 
 
-function displayMedianTime($estimated_hours, $estimated_minutes, $alltimes) {
-    if (($estimated_hours >= 1) or ($estimated_minutes >= 1)) {
-        echo "<details><summary>Estimated play time: ";
+function displayMedianTime($median_hours, $median_minutes, $alltimes) {
+    if (($median_hours >= 1) or ($median_minutes >= 1)) {
         echo "<details><summary>Estimated play time: ";
         echo $official_estimated_time_text;
         $s = (count($alltimes) === 1) ? "" : "s";
         echo " (based on " . count($alltimes) . " vote$s)</span></summary><br>";
         echo "Members voted for the following times for this game:";
         echo "<ul>";
-        foreach ($alltimes as $t) {
-            $t = convertTimeToText($t);
-            echo "<li>$t</li>";
+        foreach ($alltimes as $timevote) {
+            $hours_and_minutes = convertToHoursAndMinutes($timevote); 
+            $time_vote_text = convertTimeToText($hours_and_minutes);
+            echo "<li>$time_vote_text</li>";
         }
         echo "</ul></details>";
     }
@@ -2017,7 +2017,7 @@ function displayMedianTime($estimated_hours, $estimated_minutes, $alltimes) {
 //--------------------Code for Estimated Median Time Ends Here-----------------
 
 if ($ratingCntTot == 0 && $memberReviewCnt == 0) {
-    displayMedianTime($estimated_hours, $estimated_minutes, $alltimes);
+    displayMedianTime($median_hours, $median_minutes, $alltimes);
     echo "<img src=\"/img/blank.gif\" class=\"star0\" title=\"No Ratings\">
        No reviews yet";
     if ($embargoCnt == 0)
@@ -2027,7 +2027,7 @@ if ($ratingCntTot == 0 && $memberReviewCnt == 0) {
         . "title=\"View all ratings and reviews for this game\">"
         . "$ratingCntTot rating" . ($ratingCntTot != 1 ? "s" : "")
         . "</a><br>";
-    displayMedian($estimated_hours, $estimated_minutes, $alltimes);
+    displayMedianTime($median_hours, $median_minutes, $alltimes);
 } else {
     if (!$should_hide && $ratingAvg != 0) {
         echo showStars($ratingAvg)
@@ -2039,7 +2039,7 @@ if ($ratingCntTot == 0 && $memberReviewCnt == 0) {
 
     echo "</p>";
 
-    displayMedian($estimated_hours, $estimated_minutes, $alltimes);
+    displayMedianTime($median_hours, $median_minutes, $alltimes);
 
     if ($memberReviewCnt != 0) {
         $href = ($memberReviewCnt > $reviewsOnHomePage)


### PR DESCRIPTION
I tried to separate the parts of the convert time to text function so that it could also be used in displaying the estimated median time.

However, this might have introduced a bug where the reviews line ends up having too much indentation.