### PR TITLE
Don't autofocus fields in IFDB forms

### DIFF
--- a/www/editcomp
+++ b/www/editcomp
@@ -1042,7 +1042,7 @@ if ($show == "divform") {
 else if ($show == "form") {
 
     // showing the form - set up the form page
-    pageHeader($pageTitle, "editcomp.title",
+    pageHeader($pageTitle, false,
                "initGrids();\ndocument.body.addEventListener('mousedown', function (event) { checkClosePopup(event, true); });",
                scriptSrc('/gridform.js'),
                false);

--- a/www/editgame
+++ b/www/editgame
@@ -35,7 +35,7 @@ if (!check_editing_privileges($db))
 // if we're doing an Edit/Search, show a search box
 if (isset($_REQUEST['search']))
 {
-    pageHeader("Edit a Game Listing", "editSearchForm.searchFor");
+    pageHeader("Edit a Game Listing", false);
     echo "<h1>Edit a Game Listing</h1>";
 
     $searchFor = get_req_data("searchFor");
@@ -512,7 +512,7 @@ if ($errMsg) {
     // if we decided to show the form, proceed
     if ($showform) {
         // start the page
-        pageHeader($pagetitle, "editgame.title",
+        pageHeader($pagetitle, false,
                    "gfGenForm('linkModel');gfGenForm('reviewModel');"
                    . "gfGenForm('xrefModel');"
                    . "\ndocument.body.addEventListener('mousedown', function (event) { checkClosePopup(event, true); });",

--- a/www/editlist
+++ b/www/editlist
@@ -723,7 +723,7 @@ for ($i = 0 ; $i < count($listItems) ; $i++) {
     $listItems[$i] = $item;
 }
 
-pageHeader($pagetitle, $errMsg ? false : "editlist.title",
+pageHeader($pagetitle, false,
            "gfGenForm('listModel');",
            scriptSrc('/gridform.js'));
 echo "<h1>$pagetitle</h1>";

--- a/www/gamelink
+++ b/www/gamelink
@@ -51,7 +51,7 @@ if (isset($_REQUEST['id'])) {
 
     if ($rowcnt == 0) {
 
-        smallPageHeader("Hyperlink to a Game", "pickGame.title");
+        smallPageHeader("Hyperlink to a Game");
         echo "<h1>Hyperlink to a Game</h1>
              The title you entered didn't match any games in the
              database.  Please check the title and try again.";
@@ -77,7 +77,7 @@ if (isset($_REQUEST['id'])) {
 
     } else {
 
-        smallPageHeader("Hyperlink to a Game", "pickGame.title");
+        smallPageHeader("Hyperlink to a Game");
         echo "<h1>Hyperlink to a Game</h1>
              The title you entered matches multiple games.  Select
              the game you're looking for:
@@ -101,7 +101,7 @@ if (isset($_REQUEST['id'])) {
 } else {
 
     $title = htmlspecialcharx(get_req_data('title'));
-    smallPageHeader("Hyperlink to a Game", "pickGame.title");
+    smallPageHeader("Hyperlink to a Game");
 
 ?>
 

--- a/www/login
+++ b/www/login
@@ -163,15 +163,8 @@ function login()
 if (!login())
     exit();
 
-// Figure the initial focus: if this is a GET with a user ID but no
-// password, assume the user ID field was pre-populated by the referring
-// page, so start in the password field.  Otherwise start in the user ID
-// field.
-$initField = (($_SERVER['REQUEST_METHOD'] == 'GET'
-               && $username && !$psw) ? "login.password" : "login.userid");
-
 // start the page
-varPageHeader("Log in", $initField, $smallPage);
+varPageHeader("Log in", false, $smallPage);
 
 if ($smallPage) {
 ?>

--- a/www/lostact
+++ b/www/lostact
@@ -26,7 +26,7 @@ if (!$showForm)
 //
 // Main form display
 //
-pageHeader("Missing Activation Email", "lostact.userid", false);
+pageHeader("Missing Activation Email", false, false);
 
 ?>
 

--- a/www/lostpass
+++ b/www/lostpass
@@ -26,7 +26,7 @@ if (!$showForm)
 //
 // Main form display
 //
-pageHeader("Lost Password", "lostpass.userid", false);
+pageHeader("Lost Password", false, false);
 
 ?>
 

--- a/www/newuser
+++ b/www/newuser
@@ -28,7 +28,7 @@ if (!$showForm)
 // Main form display
 //
 
-pageHeader("New User Registration", "newuser.userid", false,
+pageHeader("New User Registration", false, false,
            scriptSrc('/passwords.js'));
 ?>
 

--- a/www/opsys
+++ b/www/opsys
@@ -423,7 +423,7 @@ if ($geticon) {
     if ($editPriv && isset($_REQUEST['editvsn'])) {
     // -------------------------  EDIT VERSION -------------------------------
 
-        pageHeader("Edit OS/Interpreter Version", "editvsn.browserid");
+        pageHeader("Edit OS/Interpreter Version", false);
 
         if ($saveErrMsg)
             echo "<p><span class=errmsg>$saveErrMsg</span><p>";
@@ -489,7 +489,7 @@ if ($geticon) {
     // ------------------------- EDIT OS ENTRY -------------------------------
 
         // we can edit it - show the editing form
-        pageHeader("Edit OS/Interpreter", "editos.osname",
+        pageHeader("Edit OS/Interpreter", false,
                    "gfGenForm('vsnGridModel');",
                    scriptSrc('/gridform.js'));
 

--- a/www/poll
+++ b/www/poll
@@ -624,7 +624,7 @@ if ($userid && $id && isset($_REQUEST['addVote'])) {
             $noChangeMsg = "without submitting a vote";
         }
 
-        pageHeader("Vote for $gameTitle", "voteForm.quickQuote");
+        pageHeader("Vote for $gameTitle");
         echo "<h1>Vote for $gameTitle</h1>";
 
         if ($formErrMsg) {
@@ -716,7 +716,7 @@ if ($userid && $id && isset($_REQUEST['addVote'])) {
         // and confirmation
         $cnt = count($matches);
 
-        pageHeader("Vote for a game", "addVoteForm.addTitle");
+        pageHeader("Vote for a game");
         echo "<h1>Vote for a game</h1>";
         echo "<b>Poll: " . htmlspecialcharx($title) . "</b><p>";
 
@@ -889,7 +889,7 @@ if ($userid && isset($_REQUEST['comment'])) {
 if ($id == 'new') {
 
     // Create a new poll
-    pageHeader("Create a New Poll", "newPollForm.title");
+    pageHeader("Create a New Poll");
 ?>
 
 <div class="tipbox"><h1>Ask a question</h1>

--- a/www/resetpsw
+++ b/www/resetpsw
@@ -114,7 +114,7 @@ function verify() {
         }
 
         // all is well - start the page
-        pageHeader("Password Reset", "resetpsw.userid");
+        pageHeader("Password Reset");
 ?>
 
 <h1>Password Changed</h1>

--- a/www/review
+++ b/www/review
@@ -42,7 +42,7 @@ echo "<style nonce='$nonce'>\n"
 //
 if (isset($_REQUEST['browse']))
 {
-    pageHeader("Review a Game", "editSearchForm.searchFor");
+    pageHeader("Review a Game");
     echo "<h1>Review a Game</h1>";
 
     // get the search term from a previous iteration, if present
@@ -680,7 +680,7 @@ up your existing review for further editing.
 }
 
 // show the page header
-pageHeader("Write a Review", "review.summary");
+pageHeader("Write a Review");
 ?>
 
 <div class=title><?php echo $title ?></div>


### PR DESCRIPTION
In many pages on the site, we try to guess which field you want to edit most, and autofocus it.

I find it mildly annoying on desktop; it's super obnoxious on mobile, because it can cause the screen to scroll and the keyboard to popup, obscuring half the screen.

Now, we don't do that.

Fixes #397