### PR TITLE
Improve viewgame layout in standards mode

### DIFF
--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -84,6 +84,11 @@ body {
     margin: 0px 0px 1.5em 0px;
 }
 
+:root {
+    /* The width of the main sections of a page, without any sidebars. */
+    --paragraph-width: 60ch;
+}
+
 /*
 The style for <form> areas - this is the style used for areas of the
 page where there are data entry fields, buttons, and so on.  We use
@@ -526,12 +531,25 @@ td.coverart {
     padding-left: 1em;
 }
 
-#viewgame__header, #viewgame__header tbody,
-#viewgame__header tr, #viewgame__header td {
-    display:block;
+.viewgame__mainSummary {
+    margin: 0;
+    padding: 0;
+    order: -1;
+    display: flow-root;
 }
 
-#viewgame__header td.coverart {
+@media (max-width: 60rem) {
+    #viewgame-body {
+        display: flex;
+        flex-direction: column;
+    }
+}
+
+#viewgame__header {
+    max-width: var(--paragraph-width);
+}
+
+#viewgame__header .coverart {
     float: right;
 }
 
@@ -1038,7 +1056,7 @@ p.nosp {
 }
 
 p, ul, ol {
-    max-width: 60ch;
+    max-width: var(--paragraph-width);
 }
 
 /*

--- a/www/viewgame
+++ b/www/viewgame
@@ -905,15 +905,6 @@ echo helpWinLink("help-ifid", "IFID");
     }
 
 ?>
-<style nonce="<?php global $nonce; echo $nonce; ?>">
-    .viewgame__mainSummary { margin: 0; padding: 0; order: -1; display: flow-root; }
-    @media (max-width: 60rem) {
-        #viewgame-body {
-            display: flex;
-            flex-direction: column;
-        }
-    }
-</style>
 <div id='viewgame-body'>
 <?php
     // ------------------------ DOWNLOADS -------------------------------
@@ -1232,7 +1223,6 @@ if (count($links) == 0 && $dlnotes == "") {
    if (!$downloadsView) {
    ?>
 
-   <p>
    <table class=gamerightbar>
       <tr>
          <td>
@@ -1567,28 +1557,27 @@ prepareTimeControls();
             }
         ?>
          <p>
-         <table id="viewgame__header" cellspacing=0 cellpadding=0 border=0>
-            <tr valign=top>
+         <section id="viewgame__header" cellspacing=0 cellpadding=0 border=0>
                <?php
 if ($hasart) {
     $arthref = "{$_SERVER['PHP_SELF']}?coverart&id=$id";
     if (isset($_REQUEST['version']))
         $arthref .= "&version=" . $_REQUEST['version'];
                ?>
-               <td class=coverart>
+           <div class=coverart>
 
-                  <a href="<?php echo $arthref ?>&ldesc">
-                     <?php echo coverArtThumbnail($id, 175, isset($_REQUEST['version']) ? $_REQUEST['version'] : $pagevsn); ?>
-                  </a>
-               </td>
+              <a href="<?php echo $arthref ?>&ldesc">
+                 <?php echo coverArtThumbnail($id, 175, isset($_REQUEST['version']) ? $_REQUEST['version'] : $pagevsn); ?>
+              </a>
+           </div>
                <?php
 } // if ($hasart)
                ?>
 
-               <td>
-                  <h1><?php echo $title ?></h1>
+           <div>
+              <h1><?php echo $title ?></h1>
 
-                  <b>by <?php
+              <b>by <?php
 
 // build the list of authors - hyperlink each one in the list to a
 // search for that author's name (using the "author:" search modifier)
@@ -1655,7 +1644,7 @@ if (!isEmpty($genre)) {
         $genres)) . "<br>";
 }
                      ?>
-                     <?php if (!isEmpty($system)) echo "<div>".htmlspecialchars($system)."</div>" ?>
+                     <?php if (!isEmpty($system)) echo htmlspecialchars($system)."<br>" ?>
                      <?php
                         $showExternalLinksAnchor = count($links) && ($detailView || $historyView);
                         if (!isEmpty($website) || $showExternalLinksAnchor) {
@@ -1678,10 +1667,9 @@ if (!isEmpty($genre)) {
                                 }
                             }                        }
                      ?>
-                  </span>
-               </td>
-            </tr>
-         </table>
+              </span>
+           </div>
+         </section>
 
          <?php
 
@@ -2564,7 +2552,7 @@ if ($embargoCnt > 0)
             #myTagList { margin-right: 1ex; }
             #tagStatusSpan { margin-left: 1ex; }
             .viewgame__tagEditorContainer { position:relative;height:0px; }
-            .viewgame__header {
+            .viewgame__tagEditorHeader {
                 position:relative;
                 padding:2px;
                 font-size:80%;
@@ -2638,7 +2626,7 @@ if ($embargoCnt > 0)
 
         <div class="viewgame__tagEditorContainer">
            <div id="tagEditor">
-              <div class='viewgame__header'>
+              <div class='viewgame__tagEditorHeader'>
                  <div>
                     <b>Edit Tags</b>
                  </div>
@@ -2699,7 +2687,7 @@ if ($embargoCnt > 0)
 
 <div class="viewgame__tagEditorContainer">
      <div id="tagDeletor">
-        <div class='viewgame__header'>
+        <div class='viewgame__tagEditorHeader'>
            <div>
               <b>Delete Tags</b>
            </div>


### PR DESCRIPTION
Fixes the cover art issue mentioned here https://github.com/iftechfoundation/ifdb/issues/646#issuecomment-2466082560, setting the game page header with an explicit width, instead of placing it inside a `<p>`, which is not supported.

I checked both the main page view, and specific modes like `&reviews`. It looks fine in both.

The header is now a `<section>`. Semantically, I think the review counts and playtime rows should be part of it, but the current code structure makes it difficult/less readable.