### PR TITLE
Fix combobox in 'Edit Review Link'

### DIFF
--- a/www/combobox.php
+++ b/www/combobox.php
@@ -158,18 +158,7 @@ function showComboMenu(idEdit, setWidth, idFocus)
     oEdit = document.getElementById(idEdit);
     var fldVal = oEdit.value;
     oSel = document.getElementById(idSel);
-    nTop = oEdit.offsetTop + oEdit.offsetHeight;
-    nLeft = oEdit.offsetLeft;
     nWidth = oEdit.offsetWidth;
-    while (oEdit.offsetParent != document.body
-           && oEdit.offsetParent.style.position != "absolute")
-    {
-        oEdit = oEdit.offsetParent;
-        nTop += oEdit.offsetTop;
-        nLeft += oEdit.offsetLeft;
-    }
-    oMenu.style.left = nLeft + "px";
-    oMenu.style.top = nTop + "px";
     if (setWidth)
     {
         oMenu.style.width = (nWidth + 18) + "px";

--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -1764,6 +1764,7 @@ Combo Box hidden list
 .combobox-list {
     display: none;
     position: absolute;
+    z-index: 20; /* Above star-rating */
 }
 
 :root {


### PR DESCRIPTION
Fixes #1023.

I don't know why the code attempts to position the drop-down list. The element itself is created together with the input box, and they're already in the correct position in relation to each other.

I deleted the positioning code, and now it works fine.

I also made sure it doesn't display over the star rating control.

Tested in "editgame" by clicking all the combo boxes before/after scrolling the page.