### PR TITLE
Use CSS to set search box button image

### DIFF
--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -230,6 +230,11 @@ div.topctl table tr td {
     border-radius: 0 1em 1em 0;
     background-color: #FFFFFF;
     padding: 0.1em;
+    height: 21px;
+    width: 21px;
+    background-image: url('/img/search_small.svg');
+    background-repeat: no-repeat;
+    background-position: center;
 }
 
 .searchbar-wrapper > button:hover, button:focus {

--- a/www/pagetpl.php
+++ b/www/pagetpl.php
@@ -103,9 +103,7 @@ function pageHeader($title, $focusCtl = false, $extraOnLoad = false,
                 <a id="topbar-browse" href="/search?browse">Browse</a>
                 <form class= "searchbar-wrapper" method="get" action="/search" name="search">
                         <input id="topbar-searchbar" type="text" name="searchbar" placeholder="Search for games...">
-                        <button class="" id="topbar-search-go-button" aria-label="Search">
-                            <img src="/img/search_small.svg" alt="">
-                        </button>
+                        <button id="topbar-search-go-button" aria-label="Search"></button>
                 </form>
             </div>
             <div class="nav-right">

--- a/www/pagetpl.php
+++ b/www/pagetpl.php
@@ -101,8 +101,8 @@ function pageHeader($title, $focusCtl = false, $extraOnLoad = false,
             <div class="nav-left">
                 <a id="topbar-home" href="/">Home</a>
                 <a id="topbar-browse" href="/search?browse">Browse</a>
-                <form class= "searchbar-wrapper" method="get" action="/search" name="search">
-                        <input id="topbar-searchbar" type="text" name="searchbar" placeholder="Search for games...">
+                <form class= "searchbar-wrapper" method="get" action="/search" name="search" role="search">
+                        <input id="topbar-searchbar" type="search" name="searchbar" placeholder="Search for games...">
                         <button id="topbar-search-go-button" aria-label="Search"></button>
                 </form>
             </div>

--- a/www/search
+++ b/www/search
@@ -468,8 +468,8 @@ else if ($term || $browse) {
     if (!$browse) {
     ?>
 
-    <form name="advsearch" method="get" action="search">
-       <input type="text" name="searchfor" id="searchfor" size=70
+    <form name="advsearch" method="get" action="search" role="search">
+       <input type="search" name="searchfor" id="searchfor" size=70
               value="<?php echo htmlspecialcharx($term) ?>">
        <input type="submit" name="searchgo"
              value="<?php echo $searchButton ?>">
@@ -485,12 +485,12 @@ else if ($searchType == "list") {
 
     ?>
 
-    <form name="advsearch" method="get" action="search">
+    <form name="advsearch" method="get" action="search" role="search">
        <!-- <h2>Search Recommended Lists</h2> -->
        <table cellspacing=0 cellpadding=0 border=0>
           <tr>
              <td>
-                <input type="text" name="searchfor" id="searchfor" size=70
+                <input type="search" name="searchfor" id="searchfor" size=70
                       value="<?php echo htmlspecialcharx($tTerm) ?>">
                 <input type="submit" name="searchgo" value="Search Lists">
              </td>


### PR DESCRIPTION
This replace the `<img>` tag on the header search box with a background image on the button. (The image caused issues in Standards mode because it changed from being `display: block` to `inline`, and I thought this was a cleaner approach).

There's a slight shift of a few pixels sideways but I think it's fine.

It also changes various search boxes into `type=search`. In Firefox they look the same, but Chrome adds an "x" to clear it when you enter text, and clears it when pressing the Escape key.

Also added `role=search` to the search boxes in the search page.