### PR TITLE
Search tag popularity

### DIFF
--- a/www/api/search
+++ b/www/api/search
@@ -281,6 +281,7 @@ can get a thumbnail just as for game cover art images, by appending
   "tags": [
     {
       "id": "<i>The text of the tag</i>",
+      "numGames": <i>Number of games tagged with this tag</i>,
       "link": "<i>A link to search results for that tag</i>"
     }
   ]
@@ -510,6 +511,7 @@ URL.
 <pre>
   &lt;tag&gt;
     &lt;id&gt;<i>The text of the tag</i>&lt;/tuid&gt;
+    &lt;numGames&gt;<i>Number of games tagged with this tag</i>&lt;/tuid&gt;
     &lt;link&gt;<i>A link to search results for that tag</i>&lt;/link&gt;
   &lt;/tag&gt;
 </pre>

--- a/www/search
+++ b/www/search
@@ -1141,8 +1141,10 @@ if ($api_mode) {
 
         case "tag":
             $id = $row['tag'];
+            $gamecnt = $row['gamecnt'];
             $item = [
                 'id' => $id,
+                'numGames' => $gamecnt,
                 'link' => get_root_url() . "search?searchfor=tag:" . urlencode($id),
             ];
             break;
@@ -1601,10 +1603,12 @@ else if ($term || $browse)
             case "tag":
                 // get the row data
                 $id = $row['tag'];
+                $gamecnt = $row['gamecnt'];
+                $s = $gamecnt == 1 ? "" : "s";
 
                 // show the listing
-                echo "<p><h3 class=result><a class='$eagerness' href=\"search?searchfor=tag:".urlencode($id)."\">"
-                    . "<b>".htmlspecialchars($id)."</b></a></h3><br>";
+                echo "<div><a class='$eagerness' href=\"search?searchfor=tag:".urlencode($id)."\">"
+                    . "<b>".htmlspecialchars($id)."</b></a></h3> ($gamecnt game$s)</div>";
 
                 break;
             }

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -186,7 +186,7 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
             "mine:" => ["mine", 99],
         ];
 
-        $selectList = "gt.tag as tag";
+        $selectList = "gt.tag as tag, count(distinct gt.gameid) as gamecnt";
         $tableList = "gametags as gt";
         $groupBy = "group by gt.tag";
         $baseOrderBy = "gt.tag";

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -911,10 +911,12 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
         break;
 
     case "tag":
-        $sortList = array(
-            'name' => array('gt.tag,', 'Sort by Tag Name'),
-            'rand' => array('rand(),', 'Random Order'));
-        $defSortBy = 'name';
+        $sortList = [
+            'games' => ['gamecnt desc,', 'Most Games First'],
+            'name' => ['gt.tag,', 'Sort by Tag Name'],
+            'rand' => ['rand(),', 'Random Order']
+        ];
+        $defSortBy = 'games';
         break;
 
     default:


### PR DESCRIPTION
Fixes #1096.

While I was in there, I got rid of the `<h3>` on tag search results and made the page much more compact.