### PR TITLE
Fix estimated time bugs

### DIFF
--- a/www/viewgame
+++ b/www/viewgame
@@ -1457,7 +1457,7 @@ function submitTime() {
         document.getElementById("timeSaveMsg").innerHTML="For hours, please enter a number from 0 to 200.";
         return;
     }
-    if (new_minutes >= 59) {
+    if (new_minutes > 59) {
         document.getElementById("timeSaveMsg").innerHTML="For minutes, please enter a number from 0 to 59.";
         return;
     }

--- a/www/viewgame
+++ b/www/viewgame
@@ -1935,7 +1935,7 @@ if ($curuser) {
         list($embargoID, $embargoDate) = mysql_fetch_row($result);
 }
 
-// --------------------PHP Functions for Displaying Median Play Time--------------------------
+// --------------------PHP Functions for displaying median play time--------------------------
 
 
 // Find the median of the numbers in an array
@@ -1947,14 +1947,14 @@ function findMedian($array_input) {
     // Divide the number of entries by two
     $total_entries = count($array_input);
     $half = $total_entries / 2;
-    $int_half = (int) $half;      // Find just the integer part of a number, in case it's not a whole number
+    $int_half = (int) $half;                   // Find just the integer part of a number, in case it's not a whole number
 
     // Calculate median
-    if ($total_entries % 2 != 0) {            // Dividing by 2 gives a remainder, so the array must have an odd number of entries
-        $median = $array_input[$int_half];         // Choose the middle entry
-    } else {                                  // The array has an even number of entries, so there will be two middle entries
-        $middle1 = $array_input[$int_half-1];     // Find the first middle entry
-        $middle2 = $array_input[$int_half];      // Find the second middle entry
+    if ($total_entries % 2 != 0) {             // Dividing by 2 gives a remainder, so the array must have an odd number of entries
+        $median = $array_input[$int_half];     // Choose the middle entry
+    } else {                                   // The array has an even number of entries, so there will be two middle entries
+        $middle1 = $array_input[$int_half-1];  // Find the first middle entry
+        $middle2 = $array_input[$int_half];    // Find the second middle entry
         $median = ($middle1 + $middle2) / 2;
     }
     return $median;
@@ -1968,33 +1968,30 @@ while ($row = mysqli_fetch_assoc($result)) {
     $alltimes[] = $row['time_in_minutes'];
 }
 
-// Find the median play time for this game, and separate the hous and minutes
+// Find the median play time (in minutes) for this game
 $mediantime = findMedian($alltimes);
-$median_hours_and_minutes = convertToHoursAndMinutes($mediantime);
+
+// When we display the official estimated time for a game, we want to round to the 
+// nearest 5 minutes when the game is longer than 1 hour.
+$rounded_median_time = 0;
+if ($mediantime > 60) {
+    // The game is over an hour, so round to the nearest 5 minutes. 
+    $rounded_median_time =  round( $mediantime / 5 ) * 5;
+} else {
+    // The game is an hour or less, so round to the nearest minute.
+    $rounded_median_time = round($mediantime);
+}
+
+// Separate into hours and minutes
+$median_hours_and_minutes = convertToHoursAndMinutes($rounded_median_time);
 $median_hours = $median_hours_and_minutes['hours'];
 $median_minutes = $median_hours_and_minutes['minutes'];
 
-// For the official estimated time for a game, we we want to round to the 
-// nearest 5 minutes when the game is longer than 1 hour.
-$official_estimated_time_text = "";
-if ($median_minutes != 0) {
-    if ($median_hours >= 1 ) {
-        // If the game is over an hour, round the minutes to the nearest 5 minutes. 
-        $minutes_rounded_to_five = round( $median_minutes / 5 ) * 5;
-        $official_estimated_time_text = convertTimeToText(['hours' => $median_hours, 'minutes' => $minutes_rounded_to_five]);
-    } else {
-        // If the game is under an hour, round the minutes to the nearest whole number.
-        $whole_minutes = round($median_minutes);
-        $official_estimated_time_text = convertTimeToText(['hours' => $median_hours, 'minutes' => $whole_minutes]);
-    }
-} else {
-    $official_estimated_time_text = convertTimeToText($median_hours_and_minutes);
-}
+// Turn into text for display
+$official_estimated_time_text = convertTimeToText(['hours' => $median_hours, 'minutes' => $median_minutes]);
 
-
-
-function displayMedianTime($median_hours, $median_minutes, $official_estimated_time_text, $alltimes) {
-    if (($median_hours < 1) && ($median_minutes < 1)) return;
+function displayMedianTime($rounded_median_time, $official_estimated_time_text, $alltimes) {
+    if ($rounded_median_time < 1) return;
     echo "<details><summary>Estimated play time: ";
     echo $official_estimated_time_text;
     $s = (count($alltimes) === 1) ? "" : "s";
@@ -2009,10 +2006,10 @@ function displayMedianTime($median_hours, $median_minutes, $official_estimated_t
     echo "</ul></details>";
 }
 
-//--------------------Code for Estimated Median Time Ends Here-----------------
+//--------------------End of PHP Functions for displaying median time-----------------
 
 if ($ratingCntTot == 0 && $memberReviewCnt == 0) {
-    displayMedianTime($median_hours, $median_minutes, $official_estimated_time_text, $alltimes);
+    displayMedianTime($rounded_median_time, $official_estimated_time_text, $alltimes);
     echo showStars(0) . " No reviews yet";
     if ($embargoCnt == 0)
         echo " - <a href=\"review?id=$id&userid=$curuser\">be the first</a>";
@@ -2021,7 +2018,7 @@ if ($ratingCntTot == 0 && $memberReviewCnt == 0) {
         . "title=\"View all ratings and reviews for this game\">"
         . "$ratingCntTot rating" . ($ratingCntTot != 1 ? "s" : "")
         . "</a><br>";
-    displayMedianTime($median_hours, $median_minutes, $official_estimated_time_text, $alltimes);
+    displayMedianTime($rounded_median_time, $official_estimated_time_text, $alltimes);
 } else {
     if (!$should_hide && $ratingAvg != 0) {
         echo showStars($ratingAvg)
@@ -2031,7 +2028,7 @@ if ($ratingCntTot == 0 && $memberReviewCnt == 0) {
             . "</a>)<br>";
     }
 
-    displayMedianTime($median_hours, $median_minutes, $official_estimated_time_text, $alltimes);
+    displayMedianTime($rounded_median_time, $official_estimated_time_text, $alltimes);
 
     if ($memberReviewCnt != 0) {
         $href = ($memberReviewCnt > $reviewsOnHomePage)


### PR DESCRIPTION
Before, if you went to a game with no time vote and entered 1 hour and 58 minutes, the median time for that game would be displayed as "1 hour and 60 minutes."

This PR rounds the median first before converting to hours and minutes.

Along the way, I also took out an equals sign that prevented you from entering 59 minutes.
