### PR TITLE
incoming-schema-changes: Create "gametimes" view to track median time of each game

### DIFF
--- a/sql/incoming-schema-changes.sql
+++ b/sql/incoming-schema-changes.sql
@@ -127,3 +127,7 @@ values ('bu6mmul5vxci5vqc', 'kaw2cas7dyiq2tmg', 1);
 insert into playertimes (gameid, userid, time_in_minutes)
 values ('bu6mmul5vxci5vqc', 'pwamtkqtbeyc8eyn', 6);
 
+
+
+-- View to show the median play times of each game
+CREATE OR REPLACE VIEW gametimes AS SELECT DISTINCT gameid, ( median(time_in_minutes) OVER (PARTITION BY gameid) ) as median_time_in_minutes FROM playertimes;


### PR DESCRIPTION
This doesn't do anything else except add the view. It's meant to be a step towards being able to search by time, but I haven't been able to get searching to work.

Also, this view shows exact median time, not rounded median time. I wasn't sure which way we wanted to go with that.