### PR TITLE
Search by estimated play time

### DIFF
--- a/sql/incoming-schema-changes.sql
+++ b/sql/incoming-schema-changes.sql
@@ -127,3 +127,97 @@ values ('bu6mmul5vxci5vqc', 'kaw2cas7dyiq2tmg', 1);
 insert into playertimes (gameid, userid, time_in_minutes)
 values ('bu6mmul5vxci5vqc', 'pwamtkqtbeyc8eyn', 6);
 
+
+
+-- The roundMedianTime function takes the exact median time in minutes
+-- and rounds it. If the time is over an hour, round to the nearest 5 minutes.
+-- Otherwise, round to the nearest minute.
+
+DELIMITER $$
+
+CREATE FUNCTION roundMedianTime(
+    exact_median_in_minutes INT(5)
+)
+RETURNS INT(5)
+DETERMINISTIC
+BEGIN
+    DECLARE rounded_median_in_minutes INT(5);
+    IF exact_median_in_minutes > 60 THEN
+        SET rounded_median_in_minutes = (round(exact_median_in_minutes/5))*5;
+    ELSE
+        SET rounded_median_in_minutes = round(exact_median_in_minutes);
+    END IF;
+    RETURN (rounded_median_in_minutes);
+END $$
+
+DELIMITER ;
+
+
+-- View to calculate the estimated play time (the rounded median time) of each game
+CREATE VIEW `gametimes` AS 
+    SELECT 
+        DISTINCT gameid, 
+        roundMedianTime( median(time_in_minutes) OVER (PARTITION BY gameid) )  as `rounded_median_time_in_minutes`
+    FROM playertimes;
+
+
+-- Create a materialized view to store the data from the gametimes view
+CREATE TABLE gametimes_mv (
+  gameid VARCHAR(32) NOT NULL,
+  rounded_median_time_in_minutes INT(5) unsigned not null,
+  PRIMARY KEY (gameid)
+);
+
+
+
+-- Populate the gametimes_mv materialized view from the gametimes view
+lock tables gametimes_mv write, gametimes read;
+truncate table gametimes_mv;
+insert into gametimes_mv select * from gametimes;
+unlock tables;
+
+
+-- Procedure to update one row of the gametimes_mv materialized view
+DROP PROCEDURE IF EXISTS refresh_gametimes_mv;
+DELIMITER $$
+
+CREATE PROCEDURE refresh_gametimes_mv (
+    IN new_gameid varchar(32) COLLATE latin1_german2_ci
+)
+BEGIN
+select *
+from gametimes
+where gameid = new_gameid
+into @gameid,
+    @rounded_median_time_in_minutes;
+if @gameid is null then
+    delete from gametimes_mv where gameid = new_gameid;
+else
+insert into gametimes_mv
+values (
+        @gameid,
+        @rounded_median_time_in_minutes
+    ) on duplicate key
+update gameid = @gameid,
+    rounded_median_time_in_minutes = @rounded_median_time_in_minutes;
+END IF;
+END;
+$$
+
+DELIMITER ;
+
+
+-- Create triggers so that when an individual player time in the playertimes table is
+-- updated, the rounded median time for that game (in the gametimes_mv materialized view)
+-- will also be updated.
+CREATE TRIGGER playertime_insert
+AFTER INSERT ON playertimes FOR EACH ROW
+call refresh_gametimes_mv(NEW.gameid);
+
+CREATE TRIGGER playertime_update
+AFTER UPDATE ON playertimes FOR EACH ROW
+call refresh_gametimes_mv(NEW.gameid);
+
+CREATE TRIGGER playertime_delete
+AFTER DELETE ON playertimes FOR EACH ROW
+call refresh_gametimes_mv(OLD.gameid);

--- a/sql/incoming-schema-changes.sql
+++ b/sql/incoming-schema-changes.sql
@@ -165,7 +165,8 @@ CREATE VIEW `gametimes` AS
 CREATE TABLE gametimes_mv (
   gameid VARCHAR(32) NOT NULL,
   rounded_median_time_in_minutes INT(5) unsigned not null,
-  PRIMARY KEY (gameid)
+  PRIMARY KEY (gameid),
+  KEY (rounded_median_time_in_minutes)
 );
 
 

--- a/www/search
+++ b/www/search
@@ -910,6 +910,22 @@ else {  // ...default is searching games
           are/are not downloadable.  A downloadable game is one that has
           at least one story file or application download link.
 
+       <p><b>minutes:<i>minimum-maximum</i></b> lists games with an estimated 
+          play time in the given range. For example, <b>minutes:15-45</b> 
+          shows games with an estimated playing time of anywhere from  15 to 
+          45 minutes. <b>minutes:30</b> lists only games with an estimated play 
+          time of 30 minutes. <b>minutes:10-</b> lists games with an estimated 
+          play time of at least 10 minutes. <b>minutes:-90</b> lists games 
+          with an estimated play time of 90 minutes or less.
+
+       <p><b>hours:<i>minimum-maximum</i></b> lists games with an estimated 
+          play time in the given range. For example, <b>hours:0.5-2</b> 
+          shows games with an estimated playing time of anywhere from half an 
+          hour to 2 hours. <b>hours:4</b> lists only games with an estimated play time 
+          of 4 hours. <b>hours:6.5-</b> lists games with an estimated 
+          play time of at least 6 and a half hours. <b>hours:-8</b> lists games 
+          with an estimated play time of 8 hours or less.
+
        <p><b>bafs:<i>id</i></b> searches for the game with the given
           Baf's Guide ID.
        (<?php

--- a/www/search
+++ b/www/search
@@ -910,13 +910,16 @@ else {  // ...default is searching games
           are/are not downloadable.  A downloadable game is one that has
           at least one story file or application download link.
 
-       <p><b>minutes:<i>minimum-maximum</i></b> lists games with an estimated 
-          play time in the given range. For example, <b>minutes:15-45</b> 
-          shows games with an estimated playing time of anywhere from  15 to 
-          45 minutes. <b>minutes:30</b> lists only games with an estimated play 
-          time of 30 minutes. <b>minutes:10-</b> lists games with an estimated 
-          play time of at least 10 minutes. <b>minutes:-90</b> lists games 
-          with an estimated play time of 90 minutes or less.
+       <p><b>playtime:<i>minimum-maximum</i></b> lists games with an estimated 
+          play time in the given range. Use <b>h</b> for hours and <b>m</b> 
+          for minutes. Hours may include decimals (for example, <b>3.5h</b>).
+          For example, <b>playtime:2h15m-3h</b> shows games with an estimated play 
+          time of anywhere from 2 hours and 15 minutes to 3 hours. To give only a 
+          minimum time, include the hyphen after it. <b>playtime:1.5h-</b> lists games 
+          with an estimated play time of at least 1 and a half hours. To give only a 
+          maximum time, include the hyphen before it. <b>hours:-45m</b> lists games 
+          with an estimated play time of 45 minutes or less. <b>playtime:1h</b> 
+          searches for games with an estimated play time of 1 hour.
 
        <p><b>hours:<i>minimum-maximum</i></b> lists games with an estimated 
           play time in the given range. For example, <b>hours:0.5-2</b> 

--- a/www/search
+++ b/www/search
@@ -916,7 +916,7 @@ else {  // ...default is searching games
           with an estimated play time of anywhere from 2 hours and 15 minutes to 3 
           hours. Hours may include decimals (for example, <b>3.5h</b>). 
           <b>playtime:1.5h-</b> lists games with an estimated play time of at least 1 
-          and a half hours. <b>hours:-45m</b> lists games with an estimated play time 
+          and a half hours. <b>playtime:-45m</b> lists games with an estimated play time 
           of 45 minutes or less. <b>playtime:1h</b> searches for games with an 
           estimated play time of 1 hour. <b>playtime:</b> with no text after it searches 
           for games with no estimated play time.

--- a/www/search
+++ b/www/search
@@ -911,23 +911,17 @@ else {  // ...default is searching games
           at least one story file or application download link.
 
        <p><b>playtime:<i>minimum-maximum</i></b> lists games with an estimated 
-          play time in the given range. Use <b>h</b> for hours and <b>m</b> 
-          for minutes. Hours may include decimals (for example, <b>3.5h</b>).
-          For example, <b>playtime:2h15m-3h</b> shows games with an estimated play 
-          time of anywhere from 2 hours and 15 minutes to 3 hours. To give only a 
-          minimum time, include the hyphen after it. <b>playtime:1.5h-</b> lists games 
-          with an estimated play time of at least 1 and a half hours. To give only a 
-          maximum time, include the hyphen before it. <b>hours:-45m</b> lists games 
-          with an estimated play time of 45 minutes or less. <b>playtime:1h</b> 
-          searches for games with an estimated play time of 1 hour.
+          play time in the given range. After each number, use <b>h</b> for hours 
+          or <b>m</b> for minutes. For example, <b>playtime:2h15m-3h</b> shows games 
+          with an estimated play time of anywhere from 2 hours and 15 minutes to 3 
+          hours. Hours may include decimals (for example, <b>3.5h</b>). 
+          <b>playtime:1.5h-</b> lists games with an estimated play time of at least 1 
+          and a half hours. <b>hours:-45m</b> lists games with an estimated play time 
+          of 45 minutes or less. <b>playtime:1h</b> searches for games with an 
+          estimated play time of 1 hour. <b>playtime:</b> with no text after it searches 
+          for games with no estimated play time.
 
-       <p><b>hours:<i>minimum-maximum</i></b> lists games with an estimated 
-          play time in the given range. For example, <b>hours:0.5-2</b> 
-          shows games with an estimated playing time of anywhere from half an 
-          hour to 2 hours. <b>hours:4</b> lists only games with an estimated play time 
-          of 4 hours. <b>hours:6.5-</b> lists games with an estimated 
-          play time of at least 6 and a half hours. <b>hours:-8</b> lists games 
-          with an estimated play time of 8 hours or less.
+
 
        <p><b>bafs:<i>id</i></b> searches for the game with the given
           Baf's Guide ID.

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -574,7 +574,7 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
                 // we need to join the gametimes mv table for this query    
                 if (!isset($extraJoins[$col])) {
                     $extraJoins[$col] = true;
-                    $tableList .= " inner join gametimes_mv "
+                    $tableList .= " left outer join gametimes_mv "
                                   . "on games.id = gametimes_mv.gameid";
                 }
 
@@ -597,7 +597,7 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
                 // we need to join the gametimes mv table for this query    
                 if (!isset($extraJoins[$col])) {
                     $extraJoins[$col] = true;
-                    $tableList .= " inner join gametimes_mv "
+                    $tableList .= " left outer join gametimes_mv "
                                   . "on games.id = gametimes_mv.gameid";
                 }
 

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -217,6 +217,8 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
             "ifid:" => array("/ifid/", 99),
             "tuid:" => array("/tuid/", 99),
             "downloadable:" => array("/downloadable/", 99),
+            "minutes:" => array("rounded_median_time_in_minutes", 99),
+            "hours:" => array("rounded_median_time_in_minutes/60", 99),
             "played:" => array("played", 99),
             "willplay:" => array("willplay", 99),
             "wontplay:" => array("wontplay", 99),
@@ -567,6 +569,52 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
                                   . "and compgames.compid = '$txt'";
                 }
                 break;
+
+            case 'rounded_median_time_in_minutes':
+                // we need to join the gametimes mv table for this query    
+                if (!isset($extraJoins[$col])) {
+                    $extraJoins[$col] = true;
+                    $tableList .= " inner join gametimes_mv "
+                                  . "on games.id = gametimes_mv.gameid";
+                }
+
+                // numeric range match
+                if ($txt == "")
+                    $expr = "$col is null";
+                else if (preg_match("/^([0-9.]+)-([0-9.]+)$/", $txt, $m))
+                    $expr = "$col >= '{$m[1]}' AND $col <= '{$m[2]}'";
+                else if (preg_match("/^([0-9.]+)[+-]$/", $txt, $m))
+                    $expr = "$col >= '{$m[1]}'";
+                else if (preg_match("/^-([0-9.]+)$/", $txt, $m))
+                    $expr = "$col <= '{$m[1]}'";
+                else if (preg_match("/^[0-9.]+$/", $txt))
+                    $expr = "$col = '$txt'";
+                else
+                    $expr = "$col = '" . mysql_real_escape_string($txt, $db) . "'";
+                break;  
+
+            case 'rounded_median_time_in_minutes/60':
+                // we need to join the gametimes mv table for this query    
+                if (!isset($extraJoins[$col])) {
+                    $extraJoins[$col] = true;
+                    $tableList .= " inner join gametimes_mv "
+                                  . "on games.id = gametimes_mv.gameid";
+                }
+
+                // numeric range match
+                if ($txt == "")
+                    $expr = "$col is null";
+                else if (preg_match("/^([0-9.]+)-([0-9.]+)$/", $txt, $m))
+                    $expr = "$col >= '{$m[1]}' AND $col <= '{$m[2]}'";
+                else if (preg_match("/^([0-9.]+)[+-]$/", $txt, $m))
+                    $expr = "$col >= '{$m[1]}'";
+                else if (preg_match("/^-([0-9.]+)$/", $txt, $m))
+                    $expr = "$col <= '{$m[1]}'";
+                else if (preg_match("/^[0-9.]+$/", $txt))
+                    $expr = "$col = '$txt'";
+                else
+                    $expr = "$col = '" . mysql_real_escape_string($txt, $db) . "'";
+                break;  
 
             case 'played':
                 // Only use this query when the user is logged in

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -635,7 +635,7 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
                     // No hyphen was entered, so it's an exact time.
                     $exact_time = convertTimeStringToMinutes($txt);
                     if ($exact_time != "") {
-                        $expr = "$col == '$exact_time'";
+                        $expr = "$col == '{$exact_time}'";
                     } else {
                         // The time didn't convert to a valid pattern, so ignore the whole thing
                         $expr = "";

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -635,7 +635,7 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
                     // No hyphen was entered, so it's an exact time.
                     $exact_time = convertTimeStringToMinutes($txt);
                     if ($exact_time != "") {
-                        $expr = "$col == '{$exact_time}'";
+                        $expr = "$col = '$exact_time'";
                     } else {
                         // The time didn't convert to a valid pattern, so ignore the whole thing
                         $expr = "";

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -571,28 +571,6 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
                 break;
 
             case 'rounded_median_time_in_minutes':
-                // we need to join the gametimes mv table for this query    
-                if (!isset($extraJoins[$col])) {
-                    $extraJoins[$col] = true;
-                    $tableList .= " left outer join gametimes_mv "
-                                  . "on games.id = gametimes_mv.gameid";
-                }
-
-                // numeric range match
-                if ($txt == "")
-                    $expr = "$col is null";
-                else if (preg_match("/^([0-9.]+)-([0-9.]+)$/", $txt, $m))
-                    $expr = "$col >= '{$m[1]}' AND $col <= '{$m[2]}'";
-                else if (preg_match("/^([0-9.]+)[+-]$/", $txt, $m))
-                    $expr = "$col >= '{$m[1]}'";
-                else if (preg_match("/^-([0-9.]+)$/", $txt, $m))
-                    $expr = "$col <= '{$m[1]}'";
-                else if (preg_match("/^[0-9.]+$/", $txt))
-                    $expr = "$col = '$txt'";
-                else
-                    $expr = "$col = '" . mysql_real_escape_string($txt, $db) . "'";
-                break;  
-
             case 'rounded_median_time_in_minutes/60':
                 // we need to join the gametimes mv table for this query    
                 if (!isset($extraJoins[$col])) {

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -628,8 +628,9 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
                         // There's only a maximum.
                         $expr = "$col <= '{$maximum}'";
                     } else {
-                        Neither minimum nor maximum time is valid, so ignore the whole thing.
+                        // Neither minimum nor maximum time is valid, so ignore the whole thing.
                         $expr = "";
+                    }
                 } else if (count($array_of_times) == 1) {
                     // No hyphen was entered, so it's an exact time.
                     $exact_time = convertTimeStringToMinutes($txt);

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -570,6 +570,7 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
                 }
                 break;
 
+            // The minutes and hours searches are very similar; fall through
             case 'rounded_median_time_in_minutes':
             case 'rounded_median_time_in_minutes/60':
                 // we need to join the gametimes mv table for this query    


### PR DESCRIPTION
Allow searching <s>by "minutes:" and "hours:"</s>  to find games with an estimated play time in the given range, for example,  `playtime:30m-4h`. As part of that, this PR adds a new gametimes view, a new gametimes_mv materialized view, code to populate the materialized view, and triggers to update the materialized view. (All of that is in the upcominig schema changes file, which--I'm not sure if that's where it goes.)

This PR does not attempt to actually _display_ the estimated times in the search results--just to show results that correctly match the search terms.

Fixes https://github.com/iftechfoundation/ifdb/issues/1050