### PR TITLE
Show "No ratings" stars on viewgame only

### DIFF
--- a/www/util.php
+++ b/www/util.php
@@ -468,9 +468,13 @@ function sendImageLdesc($title, $imageID)
 // --------------------------------------------------------------------------
 // get a string for showing a rating star image
 //
-function showStars($num)
+function showStars($num, $allowEmpty = false)
 {
     global $ssdarkforce;
+
+    if (!$allowEmpty && isEmpty($num)) {
+        return "";
+    }
 
     // round to the nearest half star
     list($roundedNum, $starimg, $startxt) = roundStars($num);

--- a/www/viewgame
+++ b/www/viewgame
@@ -2003,7 +2003,7 @@ function displayMedianTime($rounded_median_time, $alltimes) {
 
 if ($ratingCntTot == 0 && $memberReviewCnt == 0) {
     displayMedianTime($rounded_median_time, $alltimes);
-    echo showStars(0) . " No reviews yet";
+    echo showStars(0, true) . " No reviews yet";
     if ($embargoCnt == 0)
         echo " - <a href=\"review?id=$id&userid=$curuser\">be the first</a>";
 } else if ($ratingAvg == 0 && $memberReviewCnt == 0) {


### PR DESCRIPTION
In #1063, we fixed the viewgame page when there are no ratings yet, to bring back an empty star rating, but this caused empty star ratings to appear all over the site, e.g. home page, off-site reviews, etc.

Now, we only show five empty stars when we opt-in to it (only on the viewgame page).

Fixes #1113