### PR TITLE
Show tag search results in a grid

### DIFF
--- a/www/search
+++ b/www/search
@@ -1371,6 +1371,15 @@ else if ($term || $browse)
             }
         }
 
+        if ($searchType === "tag") {
+            global $nonce;
+            echo "<style nonce='$nonce'>\n"
+                . ".search__tags { display: grid; grid-template-columns: repeat(auto-fill, 20ch); }\n"
+                . "</style>\n"
+                . "<div class='search__tags'>\n";
+
+        }
+
         for ($i = 0 ; $i < count($rows) ; $i++) {
             // retrieve the row
             $row = $rows[$i];
@@ -1635,10 +1644,14 @@ else if ($term || $browse)
 
                 // show the listing
                 echo "<div><a class='$eagerness' href=\"search?searchfor=tag:".urlencode($id)."\">"
-                    . "<b>".htmlspecialchars($id)."</b></a></h3> ($gamecnt game$s)</div>";
+                    . htmlspecialchars($id)."</a></h3> ($gamecnt game$s)</div>";
 
                 break;
             }
+        }
+
+        if ($searchType == "tag") {
+            echo "</div>"; // search__tags
         }
 
         // add the page controls again at the bottom, if applicable

--- a/www/search
+++ b/www/search
@@ -262,6 +262,9 @@ $pg = isset($_REQUEST['pg']) ? $_REQUEST['pg'] : "";
 $pgAll = false;
 $perPage = 100;
 $showAllMaxRows = 500;
+if ($searchType == "tag") {
+    $showAllMaxRows = 10000;
+}
 $sortby = isset($_REQUEST['sortby']) ? $_REQUEST['sortby'] : "";
 
 $browse = isset($_REQUEST['browse']);


### PR DESCRIPTION
@alice-blue 

I figure if it's good for https://ifdb.org/showtags to show tags in a grid, it's probably good for https://ifdb.org/search?browse&tag to do the same, and for tag search results to appear in a grid, too.

If we merge this, we might not need the `showtags` table view any more.

Open question: should we make the font smaller, like we do on `showtags`?