### PR TITLE
Fix missing gap after external links in viewgame

### DIFF
--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -601,6 +601,13 @@ The "downloadfloat" division is for the Download box on a game's
 main listing page.  This is a floating box on the right side of
 the page.
 */
+
+.downloadfloat {
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+}
+
 @media (min-width: 60rem) {
     div.downloadfloat {
         float: right;


### PR DESCRIPTION
#1084 removed a `<p>` that was used for important spacing.

This change turns the sidebar into a flexbox with a gap between items.