### PR TITLE
Remove empty <a> in single-review view

### DIFF
--- a/www/viewgame
+++ b/www/viewgame
@@ -278,10 +278,13 @@ function showMemberReviewsHeader($showHisto)
             . " based on $ratingCntAvg ratings<br>"
             . "Number of Reviews Written by IFDB Members: $memberReviewCnt<br></span>";
     }
-    echo "<span class=details><a href=\"review?id=$id&userid=$curuser\">"
-        . ($currentUserReview ? "Revise your review" : ($oneReviewView ? "" : "Write a review"))
-        . "</a>"
-        . "</span>";
+
+    if ($currentUserReview || !$oneReviewView) {
+        echo "<span class=details><a href=\"review?id=$id&userid=$curuser\">"
+            . ($currentUserReview ? "Revise your review" : "Write a review")
+            . "</a>"
+            . "</span>";
+    }
 
     // finish the histogram table if applicable
     if ($showHisto) {


### PR DESCRIPTION
When viewing a [single review](https://ifdb.org/viewgame?id=yutkd9u0oeog4br1&review=82964), there's an `<a>` just before the star rating, that has no text and is invisible.

This change avoids rendering it in this situation.