### PR TITLE
Change type from INT to DECIMAL for exact median

### DIFF
--- a/sql/incoming-schema-changes.sql
+++ b/sql/incoming-schema-changes.sql
@@ -136,7 +136,7 @@ values ('bu6mmul5vxci5vqc', 'pwamtkqtbeyc8eyn', 6);
 DELIMITER $$
 
 CREATE FUNCTION roundMedianTime(
-    exact_median_in_minutes INT(5)
+    exact_median_in_minutes DECIMAL(6, 1)
 )
 RETURNS INT(5)
 DETERMINISTIC


### PR DESCRIPTION
Before: If a game had two time votes--15 minutes and 30 minutes--the exact median would be 22.5 minutes. This was supposed to be rounded up to 23 minutes, but in search results, the estimated play time was showing as 22 minutes. (On the viewgame page, the estimated time was showing as 23 minutes.) I am guessing the roundMedianTime SQL function was immediately turning the 22.5 into an integer (by cutting off the .5) before any rounding happened.

This PR changes the roundMedianTime function to use DECIMAL instead of INT for the value that's being passed into it. That should mean that the estimated play time for a game with a 15 minute vote and a 30 minute vote should show as 23 minutes in search results.


This addresses https://github.com/iftechfoundation/ifdb/issues/1143