### PR TITLE
Add play time to viewgame api

### DIFF
--- a/www/api/viewgame
+++ b/www/api/viewgame
@@ -99,6 +99,8 @@ choose whether you want to use the JSON API or the <a href="#ifiction">XML API</
     "coverart": {
       "url": "<i>URL to cover art</i>"
     },
+    "playTimeInMinutes": <i>Estimated play time in minutes</i>
+
     "downloads": {
       "links": [
         {

--- a/www/viewgame
+++ b/www/viewgame
@@ -456,6 +456,53 @@ $selectMemberRatings = getReviewQueryByGame(
         "and not(ifnull(`ifdb`.`reviews`.`RFlags`, 0) & 2)"
 );
 
+//-------------Finding the median play time---------------------
+
+// Find the median of the numbers in an array
+function findMedian($array_input) {
+    if (!is_array($array_input)) return false;
+    if (!$array_input) return 0;
+    // Sort the entries in the array
+    sort($array_input);
+    // Divide the number of entries by two
+    $total_entries = count($array_input);
+    $half = $total_entries / 2;
+    $int_half = (int) $half;                   // Find just the integer part of a number, in case it's not a whole number
+
+    // Calculate median
+    if ($total_entries % 2 != 0) {             // Dividing by 2 gives a remainder, so the array must have an odd number of entries
+        $median = $array_input[$int_half];     // Choose the middle entry
+    } else {                                   // The array has an even number of entries, so there will be two middle entries
+        $middle1 = $array_input[$int_half-1];  // Find the first middle entry
+        $middle2 = $array_input[$int_half];    // Find the second middle entry
+        $median = ($middle1 + $middle2) / 2;
+    }
+    return $median;
+}
+
+// Get all of the estimated play times for this game, and put them in an array
+$result = mysqli_execute_query($db, "select time_in_minutes from playertimes where gameid = ?", [$id]);
+if (!$result) throw new Exception("Error: " . mysqli_error($db));
+$alltimes = [];
+while ($row = mysqli_fetch_assoc($result)) {
+    $alltimes[] = $row['time_in_minutes'];
+}
+
+// Find the median play time (in minutes) for this game
+$mediantime = findMedian($alltimes);
+
+// When we display the official estimated time for a game, we want to round to the 
+// nearest 5 minutes when the game is longer than 1 hour.
+$rounded_median_time = 0;
+if ($mediantime > 60) {
+    // The game is over an hour, so round to the nearest 5 minutes. 
+    $rounded_median_time =  round( $mediantime / 5 ) * 5;
+} else {
+    // The game is an hour or less, so round to the nearest minute.
+    $rounded_median_time = round($mediantime);
+}
+//----------------End finding median play time------------------
+
 // User filter ordering - if we're logged in, sort by any user filter
 // (promotions and demotions) in effect.
 $orderByUserFilter = 'null';
@@ -654,6 +701,15 @@ if (isset($_REQUEST['ifiction']) || $json)
             'url' => get_root_url() . "coverart?id=$id&version=$pagevsn",
         ];
     }
+
+    if ($rounded_median_time >= 1) {
+        if ($json) {
+            $ifdb_section['playTimeInMinutes'] = $rounded_median_time;
+        } else {
+            $ifdb_section[] = ['playTimeInMinutes' => $rounded_median_time];
+        }
+     }
+
     if ($links) {
         // load the translation table for the file formats
         $result = mysqli_execute_query($db,
@@ -1922,52 +1978,7 @@ if ($curuser) {
         list($embargoID, $embargoDate) = mysql_fetch_row($result);
 }
 
-// --------------------PHP Functions for displaying median play time--------------------------
-
-
-// Find the median of the numbers in an array
-function findMedian($array_input) {
-    if (!is_array($array_input)) return false;
-    if (!$array_input) return 0;
-    // Sort the entries in the array
-    sort($array_input);
-    // Divide the number of entries by two
-    $total_entries = count($array_input);
-    $half = $total_entries / 2;
-    $int_half = (int) $half;                   // Find just the integer part of a number, in case it's not a whole number
-
-    // Calculate median
-    if ($total_entries % 2 != 0) {             // Dividing by 2 gives a remainder, so the array must have an odd number of entries
-        $median = $array_input[$int_half];     // Choose the middle entry
-    } else {                                   // The array has an even number of entries, so there will be two middle entries
-        $middle1 = $array_input[$int_half-1];  // Find the first middle entry
-        $middle2 = $array_input[$int_half];    // Find the second middle entry
-        $median = ($middle1 + $middle2) / 2;
-    }
-    return $median;
-}
-
-// Get all of the estimated play times for this game, and put them in an array
-$result = mysqli_execute_query($db, "select time_in_minutes from playertimes where gameid = ?", [$id]);
-if (!$result) throw new Exception("Error: " . mysqli_error($db));
-$alltimes = [];
-while ($row = mysqli_fetch_assoc($result)) {
-    $alltimes[] = $row['time_in_minutes'];
-}
-
-// Find the median play time (in minutes) for this game
-$mediantime = findMedian($alltimes);
-
-// When we display the official estimated time for a game, we want to round to the 
-// nearest 5 minutes when the game is longer than 1 hour.
-$rounded_median_time = 0;
-if ($mediantime > 60) {
-    // The game is over an hour, so round to the nearest 5 minutes. 
-    $rounded_median_time =  round( $mediantime / 5 ) * 5;
-} else {
-    // The game is an hour or less, so round to the nearest minute.
-    $rounded_median_time = round($mediantime);
-}
+// --------------------PHP Function for displaying median play time--------------------------
 
 
 function displayMedianTime($rounded_median_time, $alltimes) {


### PR DESCRIPTION
This involved

* Moving the code for finding the median so that it's earlier on the viewgame page, so that we have that info in place before the JSON section starts
* Adding the play time to the JSON section of the viewgame page

This was tested only very briefly. I wasn't sure how to test the XML variation.

Fixes https://github.com/iftechfoundation/ifdb/issues/1130

This might conflict with the PR for adding the text field to the time vote controls.