### PR TITLE
Fix tag editor dark mode again

### DIFF
--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -2321,7 +2321,7 @@ span.sfl-save-autodesc {
     form.edittagsform {
         background-color: #000000;
     }
-    form.edittagsform span.cklabel {
+    .cklabel {
         color: #9090ff;
     }
     input, select{
@@ -2408,10 +2408,6 @@ span.sfl-save-autodesc {
     #tagEditor .viewgame__header,
     #tagDeletor .viewgame__header {
         background: #7098a8;
-    }
-
-    #tagDeletor span.cklabel {
-        color: #9090ff;
     }
 
     .restricted {


### PR DESCRIPTION
Fixes #1090

# Before

<img width="622" alt="image" src="https://github.com/user-attachments/assets/04f731d3-7b81-49fc-b204-829febbd20b1">


# After

<img width="616" alt="image" src="https://github.com/user-attachments/assets/4232f98a-6ba5-4830-827a-66a1a6b9b28b">

