### PR TITLE
Dark mode tag editor header again

### DIFF
--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -2411,6 +2411,10 @@ span.sfl-save-autodesc {
         color: #000040;
     }
 
+    .viewgame__tagEditorHeader a {
+        color: #0000c0;
+    }
+
     .restricted {
         background: #444;
     }

--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -2405,9 +2405,10 @@ span.sfl-save-autodesc {
         border-color: #7098a8;
     }
 
-    #tagEditor .viewgame__header,
-    #tagDeletor .viewgame__header {
+    #tagEditor .viewgame__tagEditorHeader,
+    #tagDeletor .viewgame__tagEditorHeader {
         background: #7098a8;
+        color: #000040;
     }
 
     .restricted {


### PR DESCRIPTION
32d653998040bbb72a700c1728de6fe37273d858 also affected the tag editor header in dark mode

# Before

<img width="617" alt="image" src="https://github.com/user-attachments/assets/9ef6e272-5462-4591-a82a-8939b4493a4f">


# After

<img width="624" alt="image" src="https://github.com/user-attachments/assets/11bd1fcc-c057-4dcb-ab34-d35802d52c0c">
