### PR TITLE
Filter game searches with a custom filter

### DIFF
--- a/sql/incoming-schema-changes.sql
+++ b/sql/incoming-schema-changes.sql
@@ -82,7 +82,7 @@ ALTER TABLE `wishlists` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode
 -- Add column for game search filter to the users table
 --
 
-ALTER TABLE `users` ADD COLUMN `game_search_filter` VARCHAR(100) DEFAULT '';
+ALTER TABLE `users` ADD COLUMN `game_search_filter` VARCHAR(150) DEFAULT '';
 
 
 

--- a/sql/incoming-schema-changes.sql
+++ b/sql/incoming-schema-changes.sql
@@ -76,6 +76,16 @@ ALTER TABLE `userScores_mv` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_uni
 ALTER TABLE `wishlists` CONVERT TO CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 
+
+
+--
+-- Add column for game search filter to the users table
+--
+
+ALTER TABLE `users` ADD COLUMN `game_search_filter` VARCHAR(100) DEFAULT '';
+
+
+
 --
 -- Table structure for table `playertimes`
 --

--- a/www/editprofile
+++ b/www/editprofile
@@ -56,6 +56,7 @@ $emailcloaked = (get_req_data('emailcloaked') != 0);
 $gender = get_req_data('gender');
 $offsite = get_req_data('offsite');
 $accessibility = (get_req_data('accessibility') ? 1 : 0);
+$game_search_filter = get_req_data('game_search_filter');
 
 if (strlen($gender) != 1 || strpos("MF", $gender) === false)
     $gender = "";
@@ -72,7 +73,7 @@ function showHiddenFields()
     global $email, $email2, $pubemail, $dname, $loc, $profile, $pic,
         $defaultOS, $mirror, $noExes,
         $playlistPub, $wishlistPub, $unwishlistPub, $gender,
-        $emailcaptcha, $emailcloaked;
+        $emailcaptcha, $emailcloaked, $game_search_filter;
 
     echo "<input type=hidden name=email value=\""
           . htmlspecialcharx($email) . "\">"
@@ -103,6 +104,7 @@ function showHiddenFields()
         . "<input type=hidden name=gender value=\"$gender\">"
         . "<input type=hidden name=offsite value=\"$offsite\">"
         . "<input type=hidden name=accessibility value=\"$accessibility\">"
+        . "<input type=hidden name=game_search_filter value=\"$game_search_filter\">"
         . "<input type=hidden name=mirror value=\""
         . htmlspecialcharx($mirror) . "\">"
         . "<input type=hidden name=defaultos value=\""
@@ -135,7 +137,7 @@ function init()
         $unwishlistPub, $oldUnwishlistPub, $gender, $oldGender,
         $emailcaptcha, $oldEmailcaptcha, $emailcloaked, $oldEmailcloaked,
         $mirror, $oldMirror, $actcode, $oldPicName, $offsite, $oldOffsite,
-        $accessibility, $oldAccessibility;
+        $accessibility, $oldAccessibility, $game_search_filter, $old_game_search_filter;
 
     // connect to the database
     if ($db == false) {
@@ -155,7 +157,7 @@ function init()
            acctstatus, activationcode,
            concat(defaultos, '.', ifnull(defaultosvsn,'')) as defaultos,
            noexedownloads, publiclists, gender, emailflags,
-           offsite_display, accessibility
+           offsite_display, accessibility, game_search_filter
         from
            users
         where
@@ -193,6 +195,7 @@ function init()
     $oldEmailcloaked = (($emailflags & EMAIL_CLOAKED) ? 1 : 0);
     $oldOffsite = mysql_result($result, 0, "offsite_display");
     $oldAccessibility = mysql_result($result, 0, "accessibility");
+    $old_game_search_filter = mysql_result($result, 0, "game_search_filter");
 
     // if we're not posting, populate the form with the current values
     // from the database
@@ -215,6 +218,7 @@ function init()
         $mirror = $oldMirror;
         $offsite = $oldOffsite;
         $accessibility = $oldAccessibility;
+        $game_search_filter = $old_game_search_filter;
     }
 
     // if the current cover art setting refers to an uploaded image
@@ -237,8 +241,8 @@ function saveChanges()
         $unwishlistPub, $oldUnwishlistPub,
         $gender, $oldGender, $emailcaptcha, $oldEmailcaptcha,
         $emailcloaked, $oldEmailcloaked, $mirror, $oldMirror, $actcode,
-        $offsite, $oldOffsite, $accessibility, $oldAccessibility,
-        $captchaKey, $captchaOK, $captchaErr;
+        $offsite, $oldOffsite, $accessibility, $oldAccessibility, $game_search_filter,
+        $old_game_search_filter, $captchaKey, $captchaOK, $captchaErr;
 
     // no new picture yet
     $imgID = false;
@@ -260,7 +264,8 @@ function saveChanges()
         || $gender != $oldGender
         || $mirror != $oldMirror
         || $offsite != $oldOffsite
-        || $accessibility != $oldAccessibility)
+        || $accessibility != $oldAccessibility
+        || $game_search_filter != $old_game_search_filter)
     {
         // if we're changing the email address, we'll need to reactivate
         if (strcmp($email, $oldemail) != 0) {
@@ -309,6 +314,7 @@ function saveChanges()
         $qpubemail = mysql_real_escape_string($pubemail, $db);
         $qloc = mysql_real_escape_string($loc, $db);
         $qprofile = mysql_real_escape_string($profile, $db);
+        $qgamesearchfilter = mysql_real_escape_string($game_search_filter, $db);
 
         // make sure the location doesn't contain a url
         if (preg_match("/http:/i", $loc)) {
@@ -570,7 +576,8 @@ complete the re-activation process.</b>
                    noexedownloads = '$qNoExes', publiclists = '$qPublicLists',
                    gender = '$qGender', emailflags = '$emailflags',
                    offsite_display = '$qOffsite',
-                   accessibility = '$qAccessibility'
+                   accessibility = '$qAccessibility',
+                   game_search_filter = '$qgamesearchfilter'
                    $setPic
                 where id = '$usernum'", $db) == false) {
             $errFlagged = "An error occurred updating the database. You might
@@ -923,6 +930,22 @@ captchaSupportScripts($captchaKey);
 <p><a href="userfilter?list" target="_blank">View/Edit my filter list</a>
 
 </div>
+
+<h2>5. Game Search Filtering</h2>
+
+<div class=indented>
+<p><span class=details>To include a filter in all your game searches (as long as you 
+   are logged in), you can enter that filter here, using IFDB's special search 
+   prefixes, and it will be added to the end of your search queries. For instance, 
+   if you want your game searches to exclude games that have certain tags, you can type<br>
+   <b>-tag:example1 -tag:example2</b><br>
+   replacing "example1" and "example2" with the tag names.
+</span>
+<p><label for='game_search_filter'>Filter for game searches:</label>
+<input type='text' name='game_search_filter' id='game_search_filter' maxlength=100 value="<?php echo htmlspecialcharx($game_search_filter) ?>"></span>
+
+</div>
+
 
 <br><br>
 <input type=submit value="Save Changes" name="save">

--- a/www/editprofile
+++ b/www/editprofile
@@ -944,7 +944,7 @@ captchaSupportScripts($captchaKey);
    <br><b>-language:example -genre:example -tag:example</b><br>
    (replacing "example" with the name of the language, genre, or tag). 
    While you are logged in, your saved filter will automatically be 
-   be added at the end of your search terms when you search for games.
+   be added to the end of your search terms when you search for games.
    The filter will also be applied when you browse games on the browse 
    page. At the bottom of the page of results, there will be an option 
    to search again without the filter. (Note: Game information on IFDB 

--- a/www/editprofile
+++ b/www/editprofile
@@ -944,15 +944,15 @@ captchaSupportScripts($captchaKey);
    <br><b>-language:example -genre:example -tag:example</b><br>
    (replacing "example" with the name of the language, genre, or tag). 
    While you are logged in, your saved filter will automatically be 
-   used when searching games (the filter will be added to the end of 
-   your search terms), and when browsing games on the browse page. 
-   At the bottom of the page of results, there will be an option to 
-   search again without the filter. (Note: Filter results may be 
-   inaccurate, and cannot be relied on to make sure that games are 
-   appropriate for kids.)
+   be added at the end of your search terms when you search for games.
+   The filter will also be applied when you browse games on the browse 
+   page. At the bottom of the page of results, there will be an option 
+   to search again without the filter. (Note: Game information on IFDB 
+   is incomplete and can have mistakes. A filter is not a reliable way 
+   to make sure that games are kid-friendly.)
 </span>
-<p><label for='game_search_filter'>Default filter:</label>
-<input type='text' name='game_search_filter' id='game_search_filter' maxlength=100 value="<?php echo htmlspecialcharx($game_search_filter) ?>"></span>
+<p><label for='game_search_filter'>Game filter:</label>
+<input type='text' name='game_search_filter' id='game_search_filter' maxlength=150 size=40 value="<?php echo htmlspecialcharx($game_search_filter) ?>"></span>
 
 </div>
 

--- a/www/editprofile
+++ b/www/editprofile
@@ -931,19 +931,19 @@ captchaSupportScripts($captchaKey);
 
 </div>
 
-<h2>5. Game Search Filtering</h2>
+<h2>5. Default Filter for Games</h2>
 
 <div class=indented>
-<p><span class=details>To include a filter in all your game searches, you can 
-   create a filter using IFDB's special search prefixes, and save it here. For 
-   instance, if you want your game searches to exclude games in a certain 
-   genre and games that have certain tags, you can enter
+<p><span class=details>To apply a filter to games on the search page and 
+   on the browse page, you can create a default filter using IFDB's special search 
+   prefixes, and save it here. For instance, if you want to exclude games in 
+   a certain genre and games that have certain tags, you can enter
    <br><b>-genre:example1 -tag:example2 -tag:example3</b><br>
    replacing "example1" with the name of a genre, and replacing "example2" 
-   and "example3" with names of tags. While you are logged in, your filter 
-   will automatically be added to the end of your game search queries. (Note that
-   games on IFDB are not always tagged or categorized, so filters will not have 
-   perfect results.)
+   and "example3" with names of tags. While you are logged in, your default filter 
+   will automatically be added to the end of your game search queries, and will
+   also be used to filter games on the browse page. (Note that games on IFDB 
+   are not always tagged or categorized, so filters won't be completely reliable.)
 </span>
 <p><label for='game_search_filter'>Filter for game searches:</label>
 <input type='text' name='game_search_filter' id='game_search_filter' maxlength=100 value="<?php echo htmlspecialcharx($game_search_filter) ?>"></span>

--- a/www/editprofile
+++ b/www/editprofile
@@ -931,21 +931,22 @@ captchaSupportScripts($captchaKey);
 
 </div>
 
-<h2>5. Default Filter for Games</h2>
+<h2>5. Game Filtering</h2>
 
 <div class=indented>
-<p><span class=details>To apply a filter to games on the search page and 
-   on the browse page, you can create a default filter using IFDB's special search 
-   prefixes, and save it here. For instance, if you want to exclude games in 
-   a certain genre and games that have certain tags, you can enter
+<p><span class=details>To limit what kinds of games appear on the search page and 
+   on the browse page, you can create a default filter using IFDB's special 
+   search prefixes, and save it here. For instance, if you want to exclude games 
+   in a certain genre and games that have certain tags, you can enter
    <br><b>-genre:example1 -tag:example2 -tag:example3</b><br>
    replacing "example1" with the name of a genre, and replacing "example2" 
-   and "example3" with names of tags. While you are logged in, your default filter 
-   will automatically be added to the end of your game search queries, and will
-   also be used to filter games on the browse page. (Note that games on IFDB 
-   are not always tagged or categorized, so filters won't be completely reliable.)
+   and "example3" with names of tags, and save it. While you are logged in, your 
+   default filter will automatically be added to the end of all your game search 
+   queries, and will automatically be used to filter games on the browse page. 
+   (Note that games on IFDB are not always tagged or categorized, so filtering will 
+   not have perfect results.)
 </span>
-<p><label for='game_search_filter'>Filter for game searches:</label>
+<p><label for='game_search_filter'>Default filter:</label>
 <input type='text' name='game_search_filter' id='game_search_filter' maxlength=100 value="<?php echo htmlspecialcharx($game_search_filter) ?>"></span>
 
 </div>

--- a/www/editprofile
+++ b/www/editprofile
@@ -935,18 +935,17 @@ captchaSupportScripts($captchaKey);
 
 <div class=indented>
 <p><span class=details>To limit what kinds of games appear on the search 
-   page and on the browse page, you can create a default filter using 
-   IFDB's search prefixes. For instance, to hide games in a certain 
-   language, games in a certain genre, and games with a certain tag, you 
-   can type
+   page and on the browse page, you can create a filter using IFDB's 
+   search prefixes. For instance, to hide games in a certain language, 
+   games in a certain genre, and games with a certain tag, you can type
    <br><b>-language:example -genre:example -tag:example</b><br>
    (replacing the word "example" with the name of the language, genre, or 
    tag). While you are logged in, your saved filter will automatically be 
-   used on the search page (the filter will be added to the end of your 
-   game search terms) and when browsing games on the browse page. At the 
-   bottom of the page, there will be an option to search or browse without 
-   the filter. (Note: Filter results are not reliable, so please don't 
-   depend on them to ensure kid-friendly content.)
+   used on the search page when you search games (the filter will be added 
+   to the end of your search terms) and on the browse page when you browse 
+   games. At the bottom of the page, there will be an option to search or 
+   browse without the filter. (Note: Filter results are not reliable, so 
+   please don't depend on them to ensure kid-friendly content.)
 </span>
 <p><label for='game_search_filter'>Default filter:</label>
 <input type='text' name='game_search_filter' id='game_search_filter' maxlength=100 value="<?php echo htmlspecialcharx($game_search_filter) ?>"></span>

--- a/www/editprofile
+++ b/www/editprofile
@@ -944,7 +944,7 @@ captchaSupportScripts($captchaKey);
    used when you do a game search (the filter will be added to the end of 
    your search terms), and when you browse games on the browse page. At the 
    bottom of the page of results, there will be an option to search or 
-   browse without the filter. (Note: Filter results are not reliable, so 
+   browse without the filter. (Note: Filter results may be inaccurate, so  
    please don't depend on them to ensure that games are kid-friendly.)
 </span>
 <p><label for='game_search_filter'>Default filter:</label>

--- a/www/editprofile
+++ b/www/editprofile
@@ -941,7 +941,9 @@ captchaSupportScripts($captchaKey);
    <br><b>-genre:example1 -tag:example2 -tag:example3</b><br>
    replacing "example1" with the name of a genre, and replacing "example2" 
    and "example3" with names of tags. While you are logged in, your filter 
-   will automatically be added to the end of your game search queries. 
+   will automatically be added to the end of your game search queries. (Note that
+   games on IFDB are not always tagged or categorized, so filters will not have 
+   perfect results.)
 </span>
 <p><label for='game_search_filter'>Filter for game searches:</label>
 <input type='text' name='game_search_filter' id='game_search_filter' maxlength=100 value="<?php echo htmlspecialcharx($game_search_filter) ?>"></span>

--- a/www/editprofile
+++ b/www/editprofile
@@ -934,9 +934,9 @@ captchaSupportScripts($captchaKey);
 <h2>5. Game Filtering</h2>
 
 <div class=indented>
-<p><span class=details>To limit what kinds of games appear on the search 
-   page and on the browse page, you can create a filter using IFDB's 
-   search prefixes. For instance, to hide games in a certain language, 
+<p><span class=details>To limit what kinds of games appear on the <a href="/search">search 
+   page</a> and on the /<a href="/search?browse">browse page</a>, you can create a filter using IFDB's 
+   <a href=/search">search prefixes</a>. For instance, to hide games in a certain language, 
    games in a certain genre, and games with a certain tag, you can type
    <br><b>-language:example -genre:example -tag:example</b><br>
    (replacing "example" with the name of the language, genre, or tag). 

--- a/www/editprofile
+++ b/www/editprofile
@@ -934,17 +934,19 @@ captchaSupportScripts($captchaKey);
 <h2>5. Game Filtering</h2>
 
 <div class=indented>
-<p><span class=details>To limit what kinds of games appear on the search page and 
-   on the browse page, you can create a default filter using IFDB's special 
-   search prefixes, and save it here. For instance, if you want to exclude games 
-   in a certain genre and games that have certain tags, you can enter
-   <br><b>-genre:example1 -tag:example2 -tag:example3</b><br>
-   replacing "example1" with the name of a genre, and replacing "example2" 
-   and "example3" with names of tags, and save it. While you are logged in, your 
-   default filter will automatically be added to the end of all your game search 
-   queries, and will automatically be used to filter games on the browse page. 
-   (Note that games on IFDB are not always tagged or categorized, so filtering will 
-   not have perfect results.)
+<p><span class=details>To limit what kinds of games appear on the search 
+   page and on the browse page, you can create a default filter using 
+   IFDB's special search prefixes, and save it here. For instance, to 
+   exclude games in a certain language, games in a certain genre, and 
+   games with a certain tag, you can type
+   <br><b>-language:example -genre:example -tag:example</b><br>
+   replacing the word "example" with the name of the language, genre, or 
+   tag. While you are logged in, your saved filter will automatically be 
+   added to the end of your game search queries, and will be used on the 
+   browse page. At the bottom of the search/browse page, there will be 
+   an option to search or browse again without the filter. (Note 
+   that IFDB's filters are <i>not</i> a reliable way to ensure 
+   child-friendly content.)
 </span>
 <p><label for='game_search_filter'>Default filter:</label>
 <input type='text' name='game_search_filter' id='game_search_filter' maxlength=100 value="<?php echo htmlspecialcharx($game_search_filter) ?>"></span>

--- a/www/editprofile
+++ b/www/editprofile
@@ -936,7 +936,7 @@ captchaSupportScripts($captchaKey);
 <div class=indented>
 <p><span class=details>To limit what kinds of games appear on the <a href="/search">search 
    page</a> and on the <a href="/search?browse">browse page</a>, you can create a filter using IFDB's 
-   <a href=/search">search prefixes</a>. For instance, to hide games in a certain language, 
+   <a href="/search">search prefixes</a>. For instance, to hide games in a certain language, 
    games in a certain genre, and games with a certain tag, you can type
    <br><b>-language:example -genre:example -tag:example</b><br>
    (replacing "example" with the name of the language, genre, or tag). 

--- a/www/editprofile
+++ b/www/editprofile
@@ -936,17 +936,17 @@ captchaSupportScripts($captchaKey);
 <div class=indented>
 <p><span class=details>To limit what kinds of games appear on the search 
    page and on the browse page, you can create a default filter using 
-   IFDB's special search prefixes, and save it here. For instance, to 
-   exclude games in a certain language, games in a certain genre, and 
-   games with a certain tag, you can type
+   IFDB's search prefixes. For instance, to hide games in a certain 
+   language, games in a certain genre, and games with a certain tag, you 
+   can type
    <br><b>-language:example -genre:example -tag:example</b><br>
-   replacing the word "example" with the name of the language, genre, or 
-   tag. While you are logged in, your saved filter will automatically be 
-   added to the end of your game search queries, and will be used on the 
-   browse page. At the bottom of the search/browse page, there will be 
-   an option to search or browse again without the filter. (Note 
-   that IFDB's filters are <i>not</i> a reliable way to ensure 
-   child-friendly content.)
+   (replacing the word "example" with the name of the language, genre, or 
+   tag). While you are logged in, your saved filter will automatically be 
+   used on the search page (the filter will be added to the end of your 
+   game search terms) and when browsing games on the browse page. At the 
+   bottom of the page, there will be an option to search or browse without 
+   the filter. (Note: Filter results are not reliable, so please don't 
+   depend on them to ensure kid-friendly content.)
 </span>
 <p><label for='game_search_filter'>Default filter:</label>
 <input type='text' name='game_search_filter' id='game_search_filter' maxlength=100 value="<?php echo htmlspecialcharx($game_search_filter) ?>"></span>

--- a/www/editprofile
+++ b/www/editprofile
@@ -945,7 +945,7 @@ captchaSupportScripts($captchaKey);
    your search terms), and when you browse games on the browse page. At the 
    bottom of the page of results, there will be an option to search or 
    browse without the filter. (Note: Filter results are not reliable, so 
-   please don't depend on them to ensure kid-friendly content.)
+   please don't depend on them to ensure that games are kid-friendly.)
 </span>
 <p><label for='game_search_filter'>Default filter:</label>
 <input type='text' name='game_search_filter' id='game_search_filter' maxlength=100 value="<?php echo htmlspecialcharx($game_search_filter) ?>"></span>

--- a/www/editprofile
+++ b/www/editprofile
@@ -934,18 +934,22 @@ captchaSupportScripts($captchaKey);
 <h2>5. Game Filtering</h2>
 
 <div class=indented>
-<p><span class=details>To limit what kinds of games appear on the <a href="/search">search 
-   page</a> and on the <a href="/search?browse">browse page</a>, you can create a filter using IFDB's 
-   <a href="/search">search prefixes</a>. For instance, to hide games in a certain language, 
-   games in a certain genre, and games with a certain tag, you can type
+<p><span class=details>To limit what kinds of games appear on the 
+   <a href="/search" target="_blank">search page</a> and on the 
+   <a href="/search?browse" target="_blank">browse page</a>, you can 
+   create a filter using IFDB's 
+   <a href="/search" target="_blank">search prefixes</a>. 
+   For instance, to hide games in a certain language, games in a 
+   certain genre, and games with a certain tag, you can type
    <br><b>-language:example -genre:example -tag:example</b><br>
    (replacing "example" with the name of the language, genre, or tag). 
    While you are logged in, your saved filter will automatically be 
-   used when you do a game search (the filter will be added to the end of 
-   your search terms), and when you browse games on the browse page. At the 
-   bottom of the page of results, there will be an option to search or 
-   browse without the filter. (Note: Filter results may be inaccurate, so  
-   please don't depend on them to ensure that games are kid-friendly.)
+   used when searching games (the filter will be added to the end of 
+   your search terms), and when browsing games on the browse page. 
+   At the bottom of the page of results, there will be an option to 
+   search again without the filter. (Note: Filter results may be 
+   inaccurate, and cannot be relied on to make sure that games are 
+   appropriate for kids.)
 </span>
 <p><label for='game_search_filter'>Default filter:</label>
 <input type='text' name='game_search_filter' id='game_search_filter' maxlength=100 value="<?php echo htmlspecialcharx($game_search_filter) ?>"></span>

--- a/www/editprofile
+++ b/www/editprofile
@@ -939,11 +939,11 @@ captchaSupportScripts($captchaKey);
    search prefixes. For instance, to hide games in a certain language, 
    games in a certain genre, and games with a certain tag, you can type
    <br><b>-language:example -genre:example -tag:example</b><br>
-   (replacing the word "example" with the name of the language, genre, or 
-   tag). While you are logged in, your saved filter will automatically be 
-   used on the search page when you search games (the filter will be added 
-   to the end of your search terms) and on the browse page when you browse 
-   games. At the bottom of the page, there will be an option to search or 
+   (replacing "example" with the name of the language, genre, or tag). 
+   While you are logged in, your saved filter will automatically be 
+   used when you do a game search (the filter will be added to the end of 
+   your search terms), and when you browse games on the browse page. At the 
+   bottom of the page of results, there will be an option to search or 
    browse without the filter. (Note: Filter results are not reliable, so 
    please don't depend on them to ensure kid-friendly content.)
 </span>

--- a/www/editprofile
+++ b/www/editprofile
@@ -935,7 +935,7 @@ captchaSupportScripts($captchaKey);
 
 <div class=indented>
 <p><span class=details>To limit what kinds of games appear on the <a href="/search">search 
-   page</a> and on the /<a href="/search?browse">browse page</a>, you can create a filter using IFDB's 
+   page</a> and on the <a href="/search?browse">browse page</a>, you can create a filter using IFDB's 
    <a href=/search">search prefixes</a>. For instance, to hide games in a certain language, 
    games in a certain genre, and games with a certain tag, you can type
    <br><b>-language:example -genre:example -tag:example</b><br>

--- a/www/editprofile
+++ b/www/editprofile
@@ -934,12 +934,14 @@ captchaSupportScripts($captchaKey);
 <h2>5. Game Search Filtering</h2>
 
 <div class=indented>
-<p><span class=details>To include a filter in all your game searches (as long as you 
-   are logged in), you can enter that filter here, using IFDB's special search 
-   prefixes, and it will be added to the end of your search queries. For instance, 
-   if you want your game searches to exclude games that have certain tags, you can type<br>
-   <b>-tag:example1 -tag:example2</b><br>
-   replacing "example1" and "example2" with the tag names.
+<p><span class=details>To include a filter in all your game searches, you can 
+   create a filter using IFDB's special search prefixes, and save it here. For 
+   instance, if you want your game searches to exclude games in a certain 
+   genre and games that have certain tags, you can enter
+   <br><b>-genre:example1 -tag:example2 -tag:example3</b><br>
+   replacing "example1" with the name of a genre, and replacing "example2" 
+   and "example3" with names of tags. While you are logged in, your filter 
+   will automatically be added to the end of your game search queries. 
 </span>
 <p><label for='game_search_filter'>Filter for game searches:</label>
 <input type='text' name='game_search_filter' id='game_search_filter' maxlength=100 value="<?php echo htmlspecialcharx($game_search_filter) ?>"></span>

--- a/www/search
+++ b/www/search
@@ -315,7 +315,7 @@ if ($term || $browse) {
     }
 
     // if there's exactly one row, jump directly to the result page
-    if ($rowcnt == 1 && !$browse && !$api_mode) {
+    if ($rowcnt == 1 && !$browse && !$api_mode && $games_filtered == false) {
         $redir = false;
         switch ($searchType) {
         case "game":
@@ -1671,7 +1671,7 @@ else if ($term || $browse)
 
         // Announce that the game results are filtered, if applicable
         if ($games_filtered == true) {
-            echo "<div class='search__pageCtl'>These results have been filtered. <a href='search?searchfor=' . $term . '&nofilter=1'>Click</a>To search again without the filter.</div>';
+            echo "<div class='details'>These results have been filtered. <a href='search?searchfor=" . $term . "&nofilter=1'>Click</a> to search again without the filter.</div>";
         }
     }
 

--- a/www/search
+++ b/www/search
@@ -1663,6 +1663,11 @@ else if ($term || $browse)
         // add the page controls again at the bottom, if applicable
         if ($pg != 1 || $rowcnt > $perPage)
             echo "<div class='search__pageCtl'>$pageCtl</div>";
+
+        // Announce that the results are filtered, if applicable
+        if ($filtered == true) {
+            echo "<div>These results have been filtered. To search again without the filter, <a href>click here</a>.</div>";
+        }
     }
 
 

--- a/www/search
+++ b/www/search
@@ -304,7 +304,7 @@ if ($term || $browse) {
 
     // run the search
     list($rows, $rowcnt, $sortList, $errMsg, $summaryDesc, $badges,
-         $specials, $specialsUsed, $orderBy) =
+         $specials, $specialsUsed, $orderBy, $filtered) =
         doSearch($db, $term, $searchType, $sortby, $limit, $browse);
 
     // adjust our page limits to include the whole result set if desired
@@ -1260,6 +1260,11 @@ else if ($term || $browse)
             $otherBrowse .= "</div>";
         }
 
+        $filterLabel="";
+        if ($filtered == true) {
+            $filterLabel = "Default filter • ";
+        }
+       
         if ($pgAll)
             $range = "$rowcnt Result" . ($rowcnt == 1 ? "" : "s");
         else
@@ -1270,7 +1275,7 @@ else if ($term || $browse)
             . "<div class=\"browseBar\"><span>"
             . ($term != "" ? "Results for <b>" . htmlspecialcharx($term) . "</b>" : "")
             . $otherBrowse
-            . "</span><div class=\"browseSummary\">$range</div></div>";
+            . "</span><div class=\"browseSummary\">$filterLabel$range</div></div>";
 
         // if this is a game search, show the tip boxes
         if ($searchType == "game") {

--- a/www/search
+++ b/www/search
@@ -1667,7 +1667,7 @@ else if ($term || $browse)
 
         // Announce that the results are filtered, if applicable
         if ($filtered == true) {
-            echo "<div>These results have been filtered. To search again without the filter, <a href>click here</a>.</div>";
+            echo '<div>These results have been filtered. To search again without the filter, <a href="search?searchfor=' . $term . '&filter=0">click here</a>.</div>';
         }
     }
 

--- a/www/search
+++ b/www/search
@@ -1228,7 +1228,7 @@ else if ($term || $browse)
         echo "<i>No results were found.</i>";
 
         if ($games_filtered == true) {
-            echo '<p class="details"><i>A filter was applied to your search. To search again without the filter, <a href="search?searchfor=' . $term . '&nofilter=1">click here</a>.</i></p>';
+            echo '<p><i>A filter was applied to your search. <a href="search?searchfor=' . $term . '&nofilter=1">Click</a> to search again without the filter.</i></p>';
         }
 
         if ($searchType == "game") {

--- a/www/search
+++ b/www/search
@@ -58,7 +58,7 @@ if ($api_mode && !isset($_SESSION['logged_in_as']) && isset($_SERVER['PHP_AUTH_U
 $term = get_req_data('searchfor');
 $bTerm = get_req_data('searchbar');
 $extraLink = get_req_data('xlink');
-$applyFilter = get_req_data('filter');
+$overrideFilter = get_req_data('nofilter');
 
 if ($term == "" && $bTerm != "")
     $term = $bTerm;
@@ -306,7 +306,7 @@ if ($term || $browse) {
     // run the search
     list($rows, $rowcnt, $sortList, $errMsg, $summaryDesc, $badges,
          $specials, $specialsUsed, $orderBy, $filtered) =
-        doSearch($db, $term, $searchType, $sortby, $limit, $browse, $applyFilter);
+        doSearch($db, $term, $searchType, $sortby, $limit, $browse, $overrideFilter);
 
     // adjust our page limits to include the whole result set if desired
     if ($pgAll) {
@@ -1667,7 +1667,7 @@ else if ($term || $browse)
 
         // Announce that the results are filtered, if applicable
         if ($filtered == true) {
-            echo '<div>These results have been filtered. To search again without the filter, <a href="search?searchfor=' . $term . '&filter=0">click here</a>.</div>';
+            echo '<div>These results have been filtered. To search again without the filter, <a href="search?searchfor=' . $term . '&nofilter=1">click here</a>.</div>';
         }
     }
 

--- a/www/search
+++ b/www/search
@@ -1671,7 +1671,7 @@ else if ($term || $browse)
 
         // Announce that the game results are filtered, if applicable
         if ($games_filtered == true) {
-            echo '<div class="details"><i>These results have been filtered. To search again without the filter, <a href="search?searchfor=' . $term . '&nofilter=1">click here</a>.</i></div>';
+            echo "<div class='search__pageCtl'>These results have been filtered. <a href='search?searchfor=' . $term . '&nofilter=1'>Click</a>To search again without the filter.</div>';
         }
     }
 

--- a/www/search
+++ b/www/search
@@ -58,6 +58,7 @@ if ($api_mode && !isset($_SESSION['logged_in_as']) && isset($_SERVER['PHP_AUTH_U
 $term = get_req_data('searchfor');
 $bTerm = get_req_data('searchbar');
 $extraLink = get_req_data('xlink');
+$applyFilter = get_req_data('filter');
 
 if ($term == "" && $bTerm != "")
     $term = $bTerm;
@@ -305,7 +306,7 @@ if ($term || $browse) {
     // run the search
     list($rows, $rowcnt, $sortList, $errMsg, $summaryDesc, $badges,
          $specials, $specialsUsed, $orderBy, $filtered) =
-        doSearch($db, $term, $searchType, $sortby, $limit, $browse);
+        doSearch($db, $term, $searchType, $sortby, $limit, $browse, $applyFilter);
 
     // adjust our page limits to include the whole result set if desired
     if ($pgAll) {

--- a/www/search
+++ b/www/search
@@ -1262,7 +1262,7 @@ else if ($term || $browse)
 
         $filterLabel="";
         if ($filtered == true) {
-            $filterLabel = "Default filter • ";
+            $filterLabel = "Filtered results: ";
         }
        
         if ($pgAll)

--- a/www/search
+++ b/www/search
@@ -1227,6 +1227,10 @@ else if ($term || $browse)
 
         echo "<i>No results were found.</i>";
 
+        if ($games_filtered == true) {
+            echo '<p class="details"><i>A filter was applied to your search. To search again without the filter, <a href="search?searchfor=' . $term . '&nofilter=1">click here</a>.</i></p>';
+        }
+
         if ($searchType == "game") {
             echo "<div class=inlinetip>"
                 . "<h1>Can't find the game you're looking for?</h1>"

--- a/www/search
+++ b/www/search
@@ -1259,12 +1259,7 @@ else if ($term || $browse)
             }
             $otherBrowse .= "</div>";
         }
-
-        $filterLabel="";
-        if ($filtered == true) {
-            $filterLabel = "Filtered results: ";
-        }
-       
+     
         if ($pgAll)
             $range = "$rowcnt Result" . ($rowcnt == 1 ? "" : "s");
         else
@@ -1275,7 +1270,7 @@ else if ($term || $browse)
             . "<div class=\"browseBar\"><span>"
             . ($term != "" ? "Results for <b>" . htmlspecialcharx($term) . "</b>" : "")
             . $otherBrowse
-            . "</span><div class=\"browseSummary\">$filterLabel$range</div></div>";
+            . "</span><div class=\"browseSummary\">$range</div></div>";
 
         // if this is a game search, show the tip boxes
         if ($searchType == "game") {

--- a/www/search
+++ b/www/search
@@ -58,7 +58,7 @@ if ($api_mode && !isset($_SESSION['logged_in_as']) && isset($_SERVER['PHP_AUTH_U
 $term = get_req_data('searchfor');
 $bTerm = get_req_data('searchbar');
 $extraLink = get_req_data('xlink');
-$overrideFilter = get_req_data('nofilter');
+$override_game_filter = get_req_data('nofilter');
 
 if ($term == "" && $bTerm != "")
     $term = $bTerm;
@@ -305,8 +305,8 @@ if ($term || $browse) {
 
     // run the search
     list($rows, $rowcnt, $sortList, $errMsg, $summaryDesc, $badges,
-         $specials, $specialsUsed, $orderBy, $filtered) =
-        doSearch($db, $term, $searchType, $sortby, $limit, $browse, $overrideFilter);
+         $specials, $specialsUsed, $orderBy, $games_filtered) =
+        doSearch($db, $term, $searchType, $sortby, $limit, $browse, $override_game_filter);
 
     // adjust our page limits to include the whole result set if desired
     if ($pgAll) {
@@ -1665,9 +1665,9 @@ else if ($term || $browse)
         if ($pg != 1 || $rowcnt > $perPage)
             echo "<div class='search__pageCtl'>$pageCtl</div>";
 
-        // Announce that the results are filtered, if applicable
-        if ($filtered == true) {
-            echo '<div>These results have been filtered. To search again without the filter, <a href="search?searchfor=' . $term . '&nofilter=1">click here</a>.</div>';
+        // Announce that the game results are filtered, if applicable
+        if ($games_filtered == true) {
+            echo '<div class="details"><i>These results have been filtered. To search again without the filter, <a href="search?searchfor=' . $term . '&nofilter=1">click here</a>.</i></div>';
         }
     }
 

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -43,7 +43,7 @@ function convertTimeStringToMinutes($h_m_string) {
 }
 
 
-function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
+function doSearch($db, $term, $searchType, $sortby, $limit, $browse, $applyFilter)
 {
     // we need the current user for some types of queries
     checkPersistentLogin();
@@ -301,13 +301,14 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
         $summaryDesc = "Games";
     }
 
-    // If the user has a custom game search filter, add it to the end
-
-    if ($curuser) {
+    // Handle custom search filters
+    if ($curuser && $applyFilter != 0) {
+        // We're logged in, and haven't been told to override a custom search filter, so check for one
         $result = mysqli_execute_query($db, "select game_search_filter from users where id = ?", [$curuser]);
         //if (!$result) throw new Exception("Error: " . mysqli_error($db));
         [$gameSearchFilter] = mysql_fetch_row($result);
         if ($gameSearchFilter) {
+            // We've found a filter, so add it to the end of the search term
             $filtered = true;
             $term .= " $gameSearchFilter";
         }

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -303,12 +303,12 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse, $override_g
 
     // Handle custom search filters
     if ($curuser && $override_game_filter != 1) {
-        // We're logged in, and haven't been told to override a custom search filter, so check for one
+        // We're logged in, and haven't been told to override a custom game filter, so check for one
         $result = mysqli_execute_query($db, "select game_search_filter from users where id = ?", [$curuser]);
-        //if (!$result) throw new Exception("Error: " . mysqli_error($db));
+        if (!$result) throw new Exception("Error: " . mysqli_error($db));
         [$gameSearchFilter] = mysql_fetch_row($result);
         if ($gameSearchFilter) {
-            // We've found a filter, so add it to the end of the search term
+            // We've found a custom game filter, so add it to the end of the search term
             $games_filtered = true;
             $term .= " $gameSearchFilter";
         }

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -73,6 +73,9 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
     // assume no badge info
     $badges = false;
 
+    // So far, we're not applying a custom search filter
+    $filtered = false;
+    
     // set up the parameters for the type of search we're performing
     if ($searchType == "list")
     {
@@ -299,13 +302,16 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
     }
 
     // If the user has a custom game search filter, add it to the end
-    $gameSearchFilter = "";
+
     if ($curuser) {
         $result = mysqli_execute_query($db, "select game_search_filter from users where id = ?", [$curuser]);
         //if (!$result) throw new Exception("Error: " . mysqli_error($db));
-        [$gameSearchFilter] = mysql_fetch_row($result);
-    }
-    $term .= " $gameSearchFilter";
+        $gameSearchFilter = mysql_fetch_row($result);
+        if ($gameSearchFilter) {
+            $filtered = true;
+            $term .= " $gameSearchFilter";
+        }
+    }    
 
     // parse the search
     for ($ofs = 0, $len = strlen($term), $words = array(),
@@ -1165,7 +1171,7 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
 
     // return the results
     return array($rows, $rowcnt, $sortList, $errMsg, $summaryDesc,
-                 $badges, $specials, $specialsUsed, $orderBy);
+                 $badges, $specials, $specialsUsed, $orderBy, $filtered);
 }
 
 ?>

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -306,7 +306,7 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
     if ($curuser) {
         $result = mysqli_execute_query($db, "select game_search_filter from users where id = ?", [$curuser]);
         //if (!$result) throw new Exception("Error: " . mysqli_error($db));
-        $gameSearchFilter = mysql_fetch_row($result);
+        [$gameSearchFilter] = mysql_fetch_row($result);
         if ($gameSearchFilter) {
             $filtered = true;
             $term .= " $gameSearchFilter";

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -43,7 +43,7 @@ function convertTimeStringToMinutes($h_m_string) {
 }
 
 
-function doSearch($db, $term, $searchType, $sortby, $limit, $browse, $applyFilter)
+function doSearch($db, $term, $searchType, $sortby, $limit, $browse, $override_game_filter)
 {
     // we need the current user for some types of queries
     checkPersistentLogin();
@@ -74,7 +74,7 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse, $applyFilte
     $badges = false;
 
     // So far, we're not applying a custom search filter
-    $filtered = false;
+    $games_filtered = false;
     
     // set up the parameters for the type of search we're performing
     if ($searchType == "list")
@@ -302,14 +302,14 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse, $applyFilte
     }
 
     // Handle custom search filters
-    if ($curuser && $applyFilter != 0) {
+    if ($curuser && $override_game_filter != 1) {
         // We're logged in, and haven't been told to override a custom search filter, so check for one
         $result = mysqli_execute_query($db, "select game_search_filter from users where id = ?", [$curuser]);
         //if (!$result) throw new Exception("Error: " . mysqli_error($db));
         [$gameSearchFilter] = mysql_fetch_row($result);
         if ($gameSearchFilter) {
             // We've found a filter, so add it to the end of the search term
-            $filtered = true;
+            $games_filtered = true;
             $term .= " $gameSearchFilter";
         }
     }    
@@ -1172,7 +1172,7 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse, $applyFilte
 
     // return the results
     return array($rows, $rowcnt, $sortList, $errMsg, $summaryDesc,
-                 $badges, $specials, $specialsUsed, $orderBy, $filtered);
+                 $badges, $specials, $specialsUsed, $orderBy, $games_filtered);
 }
 
 ?>

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -298,6 +298,15 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
         $summaryDesc = "Games";
     }
 
+    // If the user has a custom game search filter, add it to the end
+    $gameSearchFilter = "";
+    if ($curuser) {
+        $result = mysqli_execute_query($db, "select game_search_filter from users where id = ?", [$curuser]);
+        //if (!$result) throw new Exception("Error: " . mysqli_error($db));
+        [$gameSearchFilter] = mysql_fetch_row($result);
+    }
+    $term .= " $gameSearchFilter";
+
     // parse the search
     for ($ofs = 0, $len = strlen($term), $words = array(),
          $specials = array(), $specialsUsed = array() ; ; $ofs++)


### PR DESCRIPTION
This is a minimal version of https://github.com/iftechfoundation/ifdb/issues/719

It allows users to create a filter that will be saved to their settings and added to their search query every time they search for games. So they can, for example, filter out games with a certain tag, or filter out games in languages they don't read, or they could require all game results to be in a certain language.

I'm not sure how I feel about it. I guess this is a draft for discussion.

To test it, go to the settings page. Type "-tag:Lovecraftian" in the new field for the game search filter, save your settings, and then do a search for "Anchorhead." That game shouldn't come up. I also tested, for example, "language:German." If you make that your filter, only games in German should show up in results.