### PR TITLE
Use review creation date for display and sorting

### DIFF
--- a/www/allreviews
+++ b/www/allreviews
@@ -41,8 +41,8 @@ $pg = get_req_data('pg');
 $sortReq = get_req_data('sortby');
 
 $sortList = array(
-    'new' => array('moddate desc', 'Newest First'),
-    'old' => array('moddate', 'Oldest First'),
+    'new' => array('createdate desc', 'Newest First'),
+    'old' => array('createdate', 'Oldest First'),
     'hlp' => array('netHelpful desc', 'Most Helpful First'),
     'unh' => array('netHelpful', 'Least Helpful First'),
     'hi' => array('rating desc', 'Highest Ratings First'),
@@ -195,12 +195,12 @@ if ($errMsg) {
            reviews.rating as rating,
            reviews.summary as summary,
            reviews.review as review,
-           reviews.moddate as moddate,
+           reviews.createdate as createdate,
            if (reviews.embargodate > now(),
              date_format(reviews.embargodate, '%M %e, %Y'),
              null) as embargodate,
            reviews.special as special,
-           date_format(reviews.moddate, '%M %e, %Y') as moddatefmt,
+           date_format(reviews.createdate, '%M %e, %Y') as createdatefmt,
            sum(reviewvotes.vote = 'Y' and ifnull(rvu.sandbox, 0) in $sandbox) as helpful,
            sum(reviewvotes.vote = 'N' and ifnull(rvu.sandbox, 0) in $sandbox) as unhelpful,
            ifnull(sum(reviewvotes.vote = 'Y'), 0)

--- a/www/game-rss.php
+++ b/www/game-rss.php
@@ -42,7 +42,7 @@ function getGameRssItems($db, $id, $feedType, $gameTitle, $links, $extFeed)
 
         // query the reviews
         $result = mysql_query(
-            "$selectMemberReviews order by moddate desc", $db);
+            "$selectMemberReviews order by createdate desc", $db);
 
         // build the item
         for ($i = 0 ; $i < mysql_num_rows($result) ; $i++) {
@@ -55,7 +55,7 @@ function getGameRssItems($db, $id, $feedType, $gameTitle, $links, $extFeed)
             $rid = $r['reviewid'];
             $rlink = htmlspecialcharx(
                 get_root_url() . "viewgame?id=$id&review=$rid");
-            $rdate = date("D, j M Y H:i:s ", strtotime($r['moddate'])) . 'UT';
+            $rdate = date("D, j M Y H:i:s ", strtotime($r['createdate'])) . 'UT';
             list($rdesc, $len, $trunc) = summarizeHtml($r['review'], 210);
             $rdesc = htmlspecialcharx(fixDesc($rdesc));
             $rauth = htmlspecialcharx($r['username']);
@@ -83,7 +83,7 @@ function getGameRssItems($db, $id, $feedType, $gameTitle, $links, $extFeed)
                     . "</item>";
 
             // add it to the master list
-            $items[] = array($r['moddate'], $item);
+            $items[] = [$r['createdate'], $item];
         }
     }
 

--- a/www/personal
+++ b/www/personal
@@ -87,17 +87,16 @@ if ($fullReviewCnt == 0) {
 } else {
     $result = mysql_query(
         "select reviews.id, games.id, title, author,
-           date_format(reviews.moddate, '%M %e, %Y'),
            if (reviews.embargodate > now(),
              date_format(reviews.embargodate, '%M %e, %Y'), null)
         from reviews, games
         where userid = '$quid' and games.id = reviews.gameid
           and review is not null
-        order by reviews.moddate desc
+        order by reviews.createdate desc
         limit 0, $maxreviews", $db);
 
     for ($i = 0 ; $i < mysql_num_rows($result) ; $i++) {
-        list($reviewid, $gameid, $title, $author, $date, $embargoDate) =
+        [$reviewid, $gameid, $title, $author, $embargoDate] =
             mysql_fetch_row($result);
         $title = htmlspecialcharx($title);
         $author = htmlspecialcharx($author);

--- a/www/reviews.php
+++ b/www/reviews.php
@@ -63,6 +63,7 @@ function getReviewQuery($db, $where)
         "select sql_calc_found_rows
            reviews.id as reviewid, rating, summary, review,
            moddate, date_format(moddate, '%M %e, %Y') as moddatefmt,
+           createdate, date_format(createdate, '%M %e, %Y') as createdatefmt,
            users.id as userid, users.name as username,
            users.location as location, special,
            sum(reviewvotes.vote = 'Y' and ifnull(rvu.sandbox, 0) in $sandbox) as helpful,
@@ -269,7 +270,11 @@ function showReview($db, $gameid, $rec, $specialNames, $optionFlags = 0)
     $rating = $rec['rating'];
     $summary = htmlspecialcharx($rec['summary']);
     $review = fixDesc($rec['review'], FixDescSpoiler);
+    $createdate = $rec['createdatefmt'];
     $moddate = $rec['moddatefmt'];
+    if ($moddate && $createdate != $moddate) {
+        $createdate .= " (edited: $moddate)";
+    }
     $specialName = isset($rec['specialname']) ? $rec['specialname'] : false;
     $specialID = $rec['special'];
     $userid = $rec['userid'];
@@ -313,7 +318,7 @@ function showReview($db, $gameid, $rec, $specialNames, $optionFlags = 0)
         echo "<p>" . showStars($rating)
             . " - <a href=\"showuser?id=$userid\">$username</a>"
             . (!isEmpty($location) ? " ($location)" : "")
-            . ", $moddate<p>";
+            . "<span class=details>, $createdate</span><p>";
         return;
     }
 
@@ -370,7 +375,7 @@ function showReview($db, $gameid, $rec, $specialNames, $optionFlags = 0)
 
     } else {
         // not special - show the headline and author
-        echo " <b>$summary</b><span class=details>, $moddate</span><br>"
+        echo " <b>$summary</b><span class=details>, $createdate</span><br>"
             . "<div class=smallhead><div class=details>"
             .   "by <a href=\"showuser?id=$userid\">$username</a>"
             . (!isEmpty($location) ? " ($location)" : "")

--- a/www/showuser
+++ b/www/showuser
@@ -579,36 +579,41 @@ if ($errMsg) {
                 . "See all ratings by this member</a></span>";
         }
     } else {
-        $result = mysql_query(
+        $result = mysqli_execute_query($db,
             "select
                games.id, games.title, games.author,
                reviews.id, reviews.rating, reviews.summary,
-               reviews.review, date_format(reviews.moddate, '%M %e, %Y')
+               reviews.review,
+               date_format(reviews.createdate, '%M %e, %Y'),
+               date_format(reviews.moddate, '%M %e, %Y')
              from
                games, reviews
              where
-               reviews.userid = '$quid'
+               reviews.userid = ?
                and reviews.review is not null
                and games.id = reviews.gameid
                and ifnull(now() >= reviews.embargodate, 1)
-             order by reviews.moddate desc", $db);
+             order by reviews.createdate desc limit 6", [$uid]);
 
         for ($i = 0 ; $i < 5 && $i < mysql_num_rows($result) ; $i++) {
             // retrieve the result
-            list($gameid, $title, $author, $revid, $rating,
-                 $summary, $review, $moddate) = mysql_fetch_row($result);
+            [$gameid, $title, $author, $revid, $rating,
+             $summary, $review, $createdate, $moddate] = mysql_fetch_row($result);
 
             // fix up fields for display
             $title = htmlspecialcharx($title);
             $author = htmlspecialcharx($author);
             $author = collapsedAuthors($author);
             $summary = htmlspecialcharx($summary);
-            list($review, $revlen, $revtrunc) = summarizeHtml($review, 140);
+            [$review, $revlen, $revtrunc] = summarizeHtml($review, 140);
             $review = fixDesc($review);
+            if ($moddate && $createdate != $moddate) {
+                $createdate .= " (edited: $moddate)";
+            }
 
             // show the summary
             echo "<a href=\"viewgame?id=$gameid\">$title</a>, by $author"
-                . " &nbsp; <span class=details><i>$moddate</i></span><br>"
+                . " &nbsp; <span class=details><i>$createdate</i></span><br>"
                 . "<div class=indented><span class=details>"
                 . ($rating ? showStars($rating) . " " : "")
                 . ($revlen ? "<i>\"$review\"</i>" : "");
@@ -622,8 +627,7 @@ if ($errMsg) {
 
         if (mysql_num_rows($result) > 5) {
             echo "<p><span class=details><a href=\"allreviews?id=$uid\">"
-                . "See all " . mysql_num_rows($result)
-                . " reviews by $username</a></span>";
+                . "See all $revcnt reviews by $username</a></span>";
 
             echo "<br><span class=details>"
                 . "<a href=\"allreviews?id=$uid&ratings=yes\">"


### PR DESCRIPTION
Fixes #565, and addresses #1117.

For reviews where the edit date is a different day than the creation date, there's an "(edited: Mon, DD, YYYY)" addition. It's long, so if you have better ideas on how to display it, please share.

The personal page didn't display the date, so I removed it from the query.

Not shown, but I also checked that the RSS of game reviews is correct.

Game page:
![game_page](https://github.com/user-attachments/assets/6d285c89-b254-4d6f-bdd5-11caf0ee10ab)

Game page `&ratings` view:
![gamepage_ratings_view](https://github.com/user-attachments/assets/f0de429e-501e-4505-b27b-2a51d9f2839b)

User page:
![showuser](https://github.com/user-attachments/assets/4e414527-c8a5-4d9b-814a-9ad6dae87cff)
