### PR TITLE
Add create date to player times

### DIFF
--- a/sql/incoming-schema-changes.sql
+++ b/sql/incoming-schema-changes.sql
@@ -87,6 +87,7 @@ CREATE TABLE playertimes (
   userid VARCHAR(32) NOT NULL,
   time_in_minutes INT(5) unsigned not null,
   time_note VARCHAR(150),
+  createdate DATE,
   PRIMARY KEY (id),
   UNIQUE KEY `game_user` (`gameid`, `userid`)
 );

--- a/sql/incoming-schema-changes.sql
+++ b/sql/incoming-schema-changes.sql
@@ -86,6 +86,7 @@ CREATE TABLE playertimes (
   gameid VARCHAR(32) NOT NULL,
   userid VARCHAR(32) NOT NULL,
   time_in_minutes INT(5) unsigned not null,
+  time_note VARCHAR(150),
   PRIMARY KEY (id),
   UNIQUE KEY `game_user` (`gameid`, `userid`)
 );
@@ -94,8 +95,8 @@ CREATE TABLE playertimes (
 insert into playertimes (gameid, userid, time_in_minutes)
 values ('59g5czw7izz7aoip', 'kaw2cas7dyiq2tmg', 63);
 
-insert into playertimes (gameid, userid, time_in_minutes)
-values ('59g5czw7izz7aoip', '0000000000000000', 128);
+insert into playertimes (gameid, userid, time_in_minutes, time_note)
+values ('59g5czw7izz7aoip', '0000000000000000', 128, 'Used a few hints');
 
 insert into playertimes (gameid, userid, time_in_minutes)
 values ('59g5czw7izz7aoip', '0000000000000001', 55);
@@ -117,15 +118,15 @@ values ('n93jonigjmva9e3g', '0000000000000001', 134);
 insert into playertimes (gameid, userid, time_in_minutes)
 values ('n93jonigjmva9e3g', '0000000000000000', 204);
 
-insert into playertimes (gameid, userid, time_in_minutes)
-values ('n93jonigjmva9e3g', 'pwamtkqtbeyc8eyn', 116);
+insert into playertimes (gameid, userid, time_in_minutes, time_note)
+values ('n93jonigjmva9e3g', 'pwamtkqtbeyc8eyn', 116, 'Solved in story mode.');
 
 -- Sample time values for Four Seconds (by Reigstad)
 insert into playertimes (gameid, userid, time_in_minutes)
 values ('bu6mmul5vxci5vqc', 'kaw2cas7dyiq2tmg', 1);
 
-insert into playertimes (gameid, userid, time_in_minutes)
-values ('bu6mmul5vxci5vqc', 'pwamtkqtbeyc8eyn', 6);
+insert into playertimes (gameid, userid, time_in_minutes, time_note)
+values ('bu6mmul5vxci5vqc', 'pwamtkqtbeyc8eyn', 6, 'without hints');
 
 
 

--- a/www/settime
+++ b/www/settime
@@ -1,4 +1,5 @@
 <?php
+// The code in this file is for saving or deleting a time vote in the database.
 
 include_once "session-start.php";
 include_once "util.php";
@@ -21,6 +22,7 @@ if ($db == false)
 // get the request parameters
 $game = get_req_data('game');
 $newtime = get_req_data('newtime');
+$timenote = get_req_data('note');
 
 // make sure there's a game
 if ($game == "")
@@ -76,15 +78,15 @@ if ($newtime == 0 && $rid) {
 } else if ($rid) {
     // there's an existing time record, and the new time is not 0, so update the record
     $result = mysqli_execute_query($db,
-        "update playertimes set time_in_minutes = ? where id=?", [$newtime, $rid]);
+        "update playertimes set time_in_minutes = ?, time_note = ? where id=?", [$newtime, $timenote, $rid]);
     if (!$result) error_log(mysql_error($db));
     $ok = true;
 
 } else if ($newtime != 0) {
     // there's no time there yet for this user, so insert a new one
     $result = mysqli_execute_query($db,
-        "insert into playertimes (gameid, userid, time_in_minutes)
-         values (?, ?, ?)", [$game, $userid, $newtime]);
+        "insert into playertimes (gameid, userid, time_in_minutes, time_note)
+         values (?, ?, ?, ?)", [$game, $userid, $newtime, $timenote]);
     $ok = true;
 } else {
     $result = true;

--- a/www/settime
+++ b/www/settime
@@ -84,9 +84,10 @@ if ($newtime == 0 && $rid) {
 
 } else if ($newtime != 0) {
     // there's no time there yet for this user, so insert a new one
+    $createdate = date("Y-m-d");
     $result = mysqli_execute_query($db,
-        "insert into playertimes (gameid, userid, time_in_minutes, time_note)
-         values (?, ?, ?, ?)", [$game, $userid, $newtime, $timenote]);
+        "insert into playertimes (gameid, userid, time_in_minutes, time_note, createdate)
+         values (?, ?, ?, ?, ?)", [$game, $userid, $newtime, $timenote, $createdate]);
     $ok = true;
 } else {
     $result = true;

--- a/www/viewgame
+++ b/www/viewgame
@@ -1521,7 +1521,7 @@ function submitTime() {
         updatePlayed();
     }
     // Submit the time.
-    jsonSend("settime?game=<?php echo $id?>&newtime=" + new_time, "timeSaveMsg", swapTimeSections);
+    jsonSend(`settime?game=<?= $id?>&newtime=${new_time}&note=${encodeURIComponent(time_note)}`, "timeSaveMsg", swapTimeSections);
 }
 // Attach the submitTime function to the "Submit Time" button.
 document.getElementById("submitTimeButton").addEventListener("click", submitTime);

--- a/www/viewgame
+++ b/www/viewgame
@@ -1488,7 +1488,7 @@ function updateUnwishList(id, stat)
 function submitTime() {
     var new_hours = document.getElementById('hours').value;
     var new_minutes = document.getElementById('minutes').value;
-    var time_note = document.getElementById('timeNote').value;
+    var time_note = document.getElementById('timeNote').value.trim();
     if (new_hours == "") {    // If the hours field was blank, interpret it as 0
         new_hours = 0;
     }

--- a/www/viewgame
+++ b/www/viewgame
@@ -1488,6 +1488,7 @@ function updateUnwishList(id, stat)
 function submitTime() {
     var new_hours = document.getElementById('hours').value;
     var new_minutes = document.getElementById('minutes').value;
+    var time_note = document.getElementById('timeNote').value;
     if (new_hours == "") {    // If the hours field was blank, interpret it as 0
         new_hours = 0;
     }

--- a/www/viewgame
+++ b/www/viewgame
@@ -459,7 +459,8 @@ $selectMemberRatings = getReviewQueryByGame(
         "and not(ifnull(`ifdb`.`reviews`.`RFlags`, 0) & 2)"
 );
 
-//-------------Finding the median play time---------------------
+
+// --------------------Finding the median play time--------------------------
 
 // Find the median of the numbers in an array
 function findMedian($array_input) {
@@ -483,8 +484,9 @@ function findMedian($array_input) {
     return $median;
 }
 
+
 // Get all of the estimated play times for this game, and put them in an array
-$result = mysqli_execute_query($db, "select playertimes.id as player_time_id, time_in_minutes, userid, name from playertimes inner join users on playertimes.userid = users.id where gameid = ?", [$id]);
+$result = mysqli_execute_query($db, "select playertimes.id as player_time_id, time_in_minutes, time_note, userid, name from playertimes inner join users on playertimes.userid = users.id where gameid = ?", [$id]);
 if (!$result) throw new Exception("Error: " . mysqli_error($db));
 $alltimes = mysqli_fetch_all($result, MYSQLI_ASSOC);
 
@@ -501,6 +503,7 @@ if ($mediantime > 60) {
     // The game is an hour or less, so round to the nearest minute.
     $rounded_median_time = round($mediantime);
 }
+
 //----------------End finding median play time------------------
 
 // User filter ordering - if we're logged in, sort by any user filter
@@ -1419,26 +1422,25 @@ function updateUnwishList(id, stat)
  
 //------------------PHP for the estimated play time control panel---------------------------------
 
-
-    // Check the database to see if the user has a "time_in_minutes" vote stored for this game.
-    // If one exists, return the stored time in minutes. If not, return 0.
+    // Check the database to see if the user has a time vote stored for this game.
+    // If one exists, get the stored time in minutes (and the time note, if present).
     $mystoredtime=0;
-
-    $result = mysqli_execute_query($db, "select time_in_minutes from playertimes where gameid = ? and userid = ?", [$id, $curuser]);
+    $mystoredtimenote="";
+    $result = mysqli_execute_query($db, "select time_in_minutes, time_note from playertimes where gameid = ? and userid = ?", [$id, $curuser]);
     if (!$result) throw new Exception("Error: " . mysqli_error($db));
-        while ($row = mysqli_fetch_assoc($result)) {     
-            // There should only be one row, at most
-            $mystoredtime = $row['time_in_minutes']; 
-        }
+    [$mystoredtime, $mystoredtimenote] = mysql_fetch_row($result);
+
     // At this point $mystoredtime should reflect the player's actual stored time for this game
     $my_time_as_text = "";
     $time_announcement = ""; // The string shown in the Estimated Play Time control panel
     if ($mystoredtime >= 1) {
-        $my_time_as_text=convertTimeToText($mystoredtime);
+        $my_time_as_text = convertTimeToText($mystoredtime);
         $time_announcement = "Your vote: " . $my_time_as_text;
+        if ($mystoredtimenote) {
+            $time_announcement .= "—\"$mystoredtimenote\"";
+        }
     }
    
-
 //-----------------------Estimated play time control panel begins----------------------------
 ?>
 
@@ -1451,8 +1453,9 @@ function updateUnwishList(id, stat)
 <details><summary>Tips</summary>
 <ul>
 <li>Vote only if you've played the game.</li>
-<li>Vote on how long it would take to get to one final ending without hints or a walkthrough.</li>
+<li>Vote on how long it takes to get to one final ending without relying extensively on a walkthrough.</li>
 <li>Time spent away from the game doesn't count.</li>
+<li>To help players gauge how long a game with puzzles might take, you can note if your time is with or without hints.</li>
 <li>Times don't need to be exact. Good-faith estimates are fine.</li>
 <li>Your vote will be publicly attributed to you.</li>
 </ul></details>
@@ -1460,6 +1463,8 @@ function updateUnwishList(id, stat)
 <input type='number' name='hours' id='hours' min=0 max=200>
 <label for='minutes'>Minutes:</label>
 <input type='number' name='minutes' id='minutes' min=0 max=59></p>
+<p><label for='timeNote'>Time Note:</label>
+<input type='text' name='timeNote' id='timeNote' maxlength='150' size='21' placeholder='Without hints.'></p>
 <button id='submitTimeButton' class='fancy-button' type='submit'>Submit Time</button>
 </div>
 
@@ -1479,7 +1484,7 @@ function updateUnwishList(id, stat)
 
 // When the user clicks the "Submit Time" button, get the input 
 // from the hours and minutes fields, validate it, convert it to 
-// minutes only, and save it to the database. 
+// minutes only, and save it to the database (with the note, if present).
 function submitTime() {
     if (document.getElementById('ckBoxckPlayed').checked==false) {
          document.getElementById("timeSaveMsg").innerHTML="Error: This game isn't on your list of played games.";
@@ -1490,7 +1495,7 @@ function submitTime() {
     if (new_hours == "") {    // If the hours field was blank, interpret it as 0
         new_hours = 0;
     }
-    if (new_minutes == "") {  //If the minutes field was blank, interpret it as 0
+    if (new_minutes == "") {  // If the minutes field was blank, interpret it as 0
         new_minutes = 0;
     }
     var hours_are_digits = isOnlyDigits(new_hours); 
@@ -1513,7 +1518,8 @@ function submitTime() {
         return;
     }
     // Time is valid, as far as we can tell
-    jsonSend("settime?game=<?php echo $id?>&newtime=" + new_time, "timeSaveMsg", swapTimeSections);
+    var time_note = document.getElementById('timeNote').value;
+    jsonSend(`settime?game=<?= $id?>&newtime=${new_time}&note=${encodeURIComponent(time_note)}`, "timeSaveMsg", swapTimeSections);
 }
 // Attach the submitTime function to the "Submit Time" button.
 document.getElementById("submitTimeButton").addEventListener("click", submitTime);
@@ -1600,7 +1606,6 @@ function prepareTimeControls() {
     }
 }
 prepareTimeControls();
-
 
 
 </script>
@@ -1979,7 +1984,9 @@ if ($curuser) {
         list($embargoID, $embargoDate) = mysql_fetch_row($result);
 }
 
+
 // --------------------PHP Function for displaying median play time--------------------------
+
 
 
 function displayMedianTime($rounded_median_time, $alltimes) {
@@ -1993,12 +2000,19 @@ function displayMedianTime($rounded_median_time, $alltimes) {
     echo "Members voted for the following times for this game:";
     echo "<ul>";
     foreach ($alltimes as $t) {
-        $time_vote_text = convertTimeToText($t['time_in_minutes']);
+        $time_vote_text = "<strong>" . convertTimeToText($t['time_in_minutes']) . "</strong>";
+        $note = htmlspecialchars($t['time_note']);
         if ($t['player_time_id'] > 388) {
-            echo "<li>$time_vote_text — <a href='showuser?id={$t['userid']}'>{$t['name']}</a></li>";
+            // For new time votes, add the note (if present) and link to the user's profile
+            if ($note != "") {
+                $time_vote_text .= ": \"$note\"";
+            }
+            $time_vote_text .= " — <a href='showuser?id={$t['userid']}'>{$t['name']}</a>";
         } else {
-            echo "<li>$time_vote_text — Anonymous <a href='https://ifdb.org/news?item=152'>until December 19</a></li>";
+            // Old time votes are attributed to "Anonymous"
+            $time_vote_text .= " — Anonymous <a href='https://ifdb.org/news?item=152'>until December 19</a>";
         }
+        echo "<li>$time_vote_text</li>";
     }
     echo "</ul></details>";
 }

--- a/www/viewgame
+++ b/www/viewgame
@@ -1464,7 +1464,7 @@ function updateUnwishList(id, stat)
 <label for='minutes'>Minutes:</label>
 <input type='number' name='minutes' id='minutes' min=0 max=59></p>
 <p><label for='timeNote'>Time Note:</label>
-<input type='text' name='timeNote' id='timeNote' maxlength='150' size='21' placeholder='Without hints.'></p>
+<input type='text' name='timeNote' id='timeNote' maxlength='150' size='21' placeholder='With/without hints.'></p>
 <button id='submitTimeButton' class='fancy-button' type='submit'>Submit Time</button>
 </div>
 


### PR DESCRIPTION
Add a create date column to the playertimes table, and automatically insert the date when a time is added.

(Only the last two commits relate to the create date. All the previous commits are from the time note PR. Which might not be the right way to do it, but I was trying to avoid more conflicts.)

This addresses https://github.com/iftechfoundation/ifdb/issues/1155