### PR TITLE
Show top 10 instead of top 4 reviewers

### DIFF
--- a/www/components/top-reviewers.php
+++ b/www/components/top-reviewers.php
@@ -8,7 +8,7 @@
       . ".top-reviewers__reviewer { padding: 0 1.5ex 0 1ex; }\n"
       . "</style>\n";
 
-   $rlst = getTopReviewers($db, 4);
+   $rlst = getTopReviewers($db, 10);
    $n = 1;
    foreach ($rlst as $r) {
       list($ruid, $runame, $rscore) = $r;


### PR DESCRIPTION
Assuming people are on board with this suggestion: https://github.com/iftechfoundation/ifdb/issues/558

Before:

![top 4 reviewers](https://github.com/user-attachments/assets/56899206-c2f7-406c-adb9-fd3c00be4de4)

After:

![top 10 reviewers](https://github.com/user-attachments/assets/d8405326-11b5-4bd4-a651-a7585ad48f23)
