### PR TITLE
Show the user's play time on the "I've played it" list

### DIFF
--- a/www/playlist
+++ b/www/playlist
@@ -87,7 +87,14 @@ if ($listtype == "reviewideas") {
     $listTable = "playedgames";
     $listName = "play list";
     $title = trim(htmlspecialcharx("$usernamePoss Played Games"));
+    $listCols = ", playertimes.time_in_minutes, playertimes.id as time_id";
     $privcode = "P";
+    $listJoin = "join playedgames"
+                .  " on playedgames.gameid = games.id"
+                .  " and playedgames.userid = '$quid'"
+                .  " left join playertimes"
+                .  " on playedgames.gameid = playertimes.gameid"
+                .  " and playertimes.userid = '$quid'"; 
 }
 
 if ($listTable && !$listJoin) {
@@ -234,6 +241,17 @@ if ($errMsg) {
             $hasart = $rec['hasart'];
             $pagevsn = $rec['pagevsn'];
             $onPlayList = ($listtype == "reviewideas" && $rec['onPlayList']);
+            $user_time = "";
+            if ($rec['time_in_minutes'] && $rec['time_id']) {
+                if ($rec['time_id'] > 388) {      
+                    // If the time is public
+                    $user_time = convertTimeToText($rec['time_in_minutes']);
+                } else if ($uid == $curuser) {
+                    // If the time is anonymous, and belongs to the current user
+                    $user_time = convertTimeToText($rec['time_in_minutes']);
+                    $user_time .= " (anonymous <a href='https://ifdb.org/news?item=152'>until December 19</a>)";
+                }
+            }
 
             if ($hasart)
                 echo "<p><table border=0 cellspacing=0 cellpadding=0>"
@@ -267,6 +285,10 @@ if ($errMsg) {
                 echo "<span class=details>Average member rating: "
                     . showStars($rating) . " ($numratings rating"
                     . ($numratings == 1 ? "" : "s") . ")</span><br>";
+            }
+
+            if ($user_time) {
+                echo "<span class=details>$usernamePoss time: $user_time</span><br>";
             }
 
             if ($hasart)

--- a/www/playlist
+++ b/www/playlist
@@ -87,7 +87,7 @@ if ($listtype == "reviewideas") {
     $listTable = "playedgames";
     $listName = "play list";
     $title = trim(htmlspecialcharx("$usernamePoss Played Games"));
-    $listCols = ", playertimes.time_in_minutes, playertimes.id as time_id";
+    $listCols = ", playertimes.time_in_minutes";
     $privcode = "P";
     $listJoin = "join playedgames"
                 .  " on playedgames.gameid = games.id"
@@ -242,15 +242,8 @@ if ($errMsg) {
             $pagevsn = $rec['pagevsn'];
             $onPlayList = ($listtype == "reviewideas" && $rec['onPlayList']);
             $user_time = "";
-            if ($rec['time_in_minutes'] && $rec['time_id']) {
-                if ($rec['time_id'] > 388) {      
-                    // If the time is public
-                    $user_time = convertTimeToText($rec['time_in_minutes']);
-                } else if ($uid == $curuser) {
-                    // If the time is anonymous, and belongs to the current user
-                    $user_time = convertTimeToText($rec['time_in_minutes']);
-                    $user_time .= " (anonymous <a href='https://ifdb.org/news?item=152'>until December 19</a>)";
-                }
+            if ($rec['time_in_minutes']) {
+                $user_time = convertTimeToText($rec['time_in_minutes']);
             }
 
             if ($hasart)


### PR DESCRIPTION
Fixes https://github.com/iftechfoundation/ifdb/issues/1080

This version shows public time votes to everyone who can view the "played" list. It shows anonymous time votes only if the list belongs to the current user, and adds a note saying the time is anonymous until December 19.

After Dec. 19, some of the code for dealing with anonymous votes can be removed.

I mostly tested looking at the user's own list. I didn't test looking at a list from the perspective of another user.