### PR TITLE
Unify appearance of game search results with/without covers

### DIFF
--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -1509,9 +1509,17 @@ hr.dots {
 }
 
 /*
-The "grid" table class is used for tables showing images along the
+The "grid" class is used for tables and flexboxes showing images along the
 right and associated text alongside to the right.
 */
+article.grid {
+    display: flex;
+    gap: 1em;
+}
+article.grid > div:first-child {
+    min-width: 80px;
+}
+
 table.grid tr td {
     vertical-align: top;
     padding-right: 1em;

--- a/www/search
+++ b/www/search
@@ -1476,49 +1476,31 @@ else if ($term || $browse)
 
                 // show the item
                 echo "<p>";
+                echo "<article class=grid><div>";
                 if ($art) {
-                    // display with art
-                    echo "<table class=grid border=0 cellspacing=0 cellpadding=0>"
-                        . "<tr><td>"
-                        . "<a class='$eagerness' href=\"viewgame?id=$id\">"
-                        . coverArtThumbnail($id, 80, $pagevsn)
-                        . "</a></td><td>"
-                        . "<h3 class=result><a href=\"viewgame?id=$id\">"
-                        . "<b>$title</b></a></h3>$xlink<br>"
-                        . "by $author<br>";
-
-                    if ($year)
-                        echo "<span class=details>$year</span>";
-
-                    // build the tags, average rating, and rating details;
-                    // if we have anything to show, and we also showed a
-                    // year, add a newline between the two
-                    $xtra = "$tagDisp$stars$ratingExtra";
-                    if ($year)
-                        $xtra = "<br>$xtra";
-
-                    // add the extra detail
-                    echo "$xtra</td></tr></table>";
-
-                    // Show estimated play time if available
-                    if ($playtime != "")
-                        echo "<span class=details>$playtime</span>";
-
-                } else {
-                    // display with no art
-                    echo "<h3 class=result><a class='$eagerness' href=\"viewgame?id=$id\">"
-                        . "<b>$title</b></a></h3>"
-                        . ", by $author";
-
-                    if ($year)
-                        echo " ($year)";
-
-                    echo "$xlink<br>$tagDisp$stars$ratingExtra";
-
-                    // Show estimated play time if available
-                    if ($playtime != "")
-                        echo "<br><span class=details>$playtime</span>";
+                    echo "<a class='$eagerness' href=\"viewgame?id=$id\">"
+                        . coverArtThumbnail($id, 80, $pagevsn) . "</a>";
                 }
+                echo "</div><div><h3 class=result><a href=\"viewgame?id=$id\">"
+                    . "<b>$title</b></a></h3>$xlink<br>"
+                    . "by $author<br>";
+
+                if ($year)
+                    echo "<span class=details>$year</span>";
+
+                // build the tags, average rating, and rating details;
+                // if we have anything to show, and we also showed a
+                // year, add a newline between the two
+                $xtra = "$tagDisp$stars$ratingExtra";
+                if ($year)
+                    $xtra = "<br>$xtra";
+
+                // add the extra detail
+                echo "$xtra</div></article>";
+
+                // Show estimated play time if available
+                if ($playtime != "")
+                    echo "<span class=details>$playtime</span>";
                 break;
             
             case "list":


### PR DESCRIPTION
Fixes #1126.

I think it's less confusing when viewing a list with mixed cover/no cover results. Should there be a placeholder cover instead of whitespace...? @alice-blue suggested placing the cover on the right, but I think in that case all the covers should be in a single column. (I haven't tried that.)

Also changed from a `<table>` to an `<article>`. Now each item is squished a bit vertically (see distance between author and year), but I think it's fine.

Search results have other issues, like using paragraphs for padding. This affects more than games, and will be fixed separately.

Before:
![before](https://github.com/user-attachments/assets/845ca068-a111-417a-960b-55eb47a00a58)

After:
![after](https://github.com/user-attachments/assets/a8cfb1aa-b706-4022-bc0e-f37adf8da1a9)

