### PR TITLE
Add a create date to the playertimes table

### DIFF
--- a/sql/incoming-schema-changes.sql
+++ b/sql/incoming-schema-changes.sql
@@ -87,6 +87,7 @@ CREATE TABLE playertimes (
   userid VARCHAR(32) NOT NULL,
   time_in_minutes INT(5) unsigned not null,
   time_note VARCHAR(150),
+  createdate DATE,
   PRIMARY KEY (id),
   UNIQUE KEY `game_user` (`gameid`, `userid`)
 );

--- a/sql/incoming-schema-changes.sql
+++ b/sql/incoming-schema-changes.sql
@@ -87,7 +87,7 @@ CREATE TABLE playertimes (
   userid VARCHAR(32) NOT NULL,
   time_in_minutes INT(5) unsigned not null,
   time_note VARCHAR(150),
-  createdate DATE DEFAULT (CURRENT_DATE),
+  createdate DATETIME DEFAULT now(),
   PRIMARY KEY (id),
   UNIQUE KEY `game_user` (`gameid`, `userid`)
 );

--- a/sql/incoming-schema-changes.sql
+++ b/sql/incoming-schema-changes.sql
@@ -87,7 +87,7 @@ CREATE TABLE playertimes (
   userid VARCHAR(32) NOT NULL,
   time_in_minutes INT(5) unsigned not null,
   time_note VARCHAR(150),
-  createdate DATE,
+  createdate DATE DEFAULT (CURRENT_DATE),
   PRIMARY KEY (id),
   UNIQUE KEY `game_user` (`gameid`, `userid`)
 );

--- a/www/settime
+++ b/www/settime
@@ -84,10 +84,9 @@ if ($newtime == 0 && $rid) {
 
 } else if ($newtime != 0) {
     // there's no time there yet for this user, so insert a new one
-    $createdate = date("Y-m-d");
     $result = mysqli_execute_query($db,
-        "insert into playertimes (gameid, userid, time_in_minutes, time_note, createdate)
-         values (?, ?, ?, ?, ?)", [$game, $userid, $newtime, $timenote, $createdate]);
+        "insert into playertimes (gameid, userid, time_in_minutes, time_note)
+         values (?, ?, ?, ?)", [$game, $userid, $newtime, $timenote]);
     $ok = true;
 } else {
     $result = true;

--- a/www/settime
+++ b/www/settime
@@ -84,9 +84,10 @@ if ($newtime == 0 && $rid) {
 
 } else if ($newtime != 0) {
     // there's no time there yet for this user, so insert a new one
+    $createdate = date("Y-m-d");
     $result = mysqli_execute_query($db,
-        "insert into playertimes (gameid, userid, time_in_minutes, time_note)
-         values (?, ?, ?, ?)", [$game, $userid, $newtime, $timenote]);
+        "insert into playertimes (gameid, userid, time_in_minutes, time_note, createdate)
+         values (?, ?, ?, ?, ?)", [$game, $userid, $newtime, $timenote, $createdate]);
     $ok = true;
 } else {
     $result = true;


### PR DESCRIPTION
Add a create date column to the playertimes table, and automatically insert the date when a time is added.

(This PR includes only the two commits related to the create date.)

This addresses https://github.com/iftechfoundation/ifdb/issues/1155