### PR TITLE
Hide time vote controls when JavaScript is disabled

### DIFF
--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -657,6 +657,20 @@ the page.
 }
 
 /*
+The time vote controls in the "Have you played this game?" box
+on the viewgame page 
+*/
+#submitTimeSection {
+    display: none;
+}
+#removeTimeSection {
+    display: none;
+}
+#timeSavedSection {
+    display: none;
+}
+
+/*
 The "downloads" section is for external links.
 */
 #externalLinks {

--- a/www/viewgame
+++ b/www/viewgame
@@ -1447,6 +1447,7 @@ function updateUnwishList(id, stat)
 <div class=indented>
 <div id='timeVoteControls' class='viewgame__playedSection'><?php // There's an event listener attached to "timeVoteControls" ?>
 <span id="timeVoteControlsCaption"><b>Estimated play time:</b></span>
+<noscript><i>To use this feature, please enable JavaScript in your browser.</i></noscript>
 
 <div id='submitTimeSection'>
 <span id='howLong'>Vote on how long it takes to finish this game.</span><br>

--- a/www/viewgame
+++ b/www/viewgame
@@ -1447,7 +1447,7 @@ function updateUnwishList(id, stat)
 <div class=indented>
 <div id='timeVoteControls' class='viewgame__playedSection'><?php // There's an event listener attached to "timeVoteControls" ?>
 <span id="timeVoteControlsCaption"><b>Estimated play time:</b></span>
-<noscript><i>To use this feature, please enable JavaScript in your browser.</i></noscript>
+<noscript>To use this feature, please enable JavaScript in your browser.</noscript>
 
 <div id='submitTimeSection'>
 <span id='howLong'>Vote on how long it takes to finish this game.</span><br>


### PR DESCRIPTION
The time vote controls rely on JS to hide and show the correct sections. This PR hides the sections by default in the CSS, because otherwise, if JS is disabled, all the controls will show simultaneously in a way that doesn't make sense.

This also adds a message that JS is required.

Fixes https://github.com/iftechfoundation/ifdb/issues/1034