### PR TITLE
newitems: Don't show Details link on short news items

### DIFF
--- a/www/newitems.php
+++ b/www/newitems.php
@@ -633,7 +633,7 @@ function showNewItemList($db, $first, $last, $items, $options)
             $nuidOrig = $n['origUserID'];
             $nunameOrig = htmlspecialcharx($n['origUserName']);
             $nhead = htmlspecialcharx($n['headline']);
-            list($nbody, $len, $trunc) = summarizeHtml($n['body'], 210);
+            [$nbody, $len, $trunc] = summarizeHtml($n['body'], 210);
             $nbody = fixDesc($nbody);
 
             switch ($n['sourceType'])
@@ -672,8 +672,8 @@ function showNewItemList($db, $first, $last, $items, $options)
                 . "News on <a href=\"$href\">$gtitle</a>: "
                 . "<b>$nhead</b> "
                 . "<span class=notes><i>$ncre</i></span><br>"
-                . "<div class=indented><span class=details>$nbody - "
-                . "<a href=\"newslog?newsid=$nid\">Details</a>"
+                . "<div class=indented><span class=details>"
+                . ($trunc ? "$nbody - <a href=\"newslog?newsid=$nid\">Details</a>" : "$nbody")
                 . "</span></div>"
                 . "</div>";
         }

--- a/www/news.php
+++ b/www/news.php
@@ -61,7 +61,8 @@ function newsSummary($db, $sourceType, $sourceID, $maxItems,
                 . "<a href=\"newslog?newsid=$newsid&history\">History</a> | "
                 . "<a href=\"editnews?newsid=$newsid$src\">"
                 . "Edit</a> | "
-                . "<a href=\"editnews?newsid=$newsid$src&delete\">Delete</a>"
+                . "<a href=\"editnews?newsid=$newsid$src&delete\">Delete</a> | "
+                . "<a href=\"newslog?newsid=$newsid\">Direct link</a>"
                 . "</span>"
                 . "</details>";
         }

--- a/www/newslog
+++ b/www/newslog
@@ -297,6 +297,8 @@ if ($errMsg) {
                 . "&source=$sourceID&delete\">Delete</a>";
         }
 
+        echo " | <a href=\"newslog?newsid=$nid\">Direct link</a>";
+
         echo "</div></div>";
 
     } else {
@@ -389,6 +391,8 @@ if ($errMsg) {
                     . " | <a href=\"editnews?newsid=$nid&type=$sourceType"
                     . "&source=$sourceID&delete\">Delete</a>";
             }
+
+            echo " | <a href=\"newslog?newsid=$nid\">Direct link</a>";
 
             echo "</div></div>";
         }


### PR DESCRIPTION
Try creating a very short competition news item like this one: https://ifdb.org/newslog?newsid=608

The home page (or <https://ifdb.org/allnew>) will display it with a "- Details" link, but all the important information is already visible, and the news item itself already links to the competition (or game, if there's game news); there's no need for a link.