### PR TITLE
Filter games version 3

### DIFF
--- a/sql/incoming-schema-changes.sql
+++ b/sql/incoming-schema-changes.sql
@@ -7,3 +7,7 @@ alter table reviewvotes
     add column `createdate` datetime NOT NULL DEFAULT current_timestamp(),
     add PRIMARY KEY (`reviewvoteid`)
 ;
+
+-- Add column for game search filter to the users table
+
+ALTER TABLE `users` ADD COLUMN `game_filter` VARCHAR(150) DEFAULT '';

--- a/www/components/ifdb-recommends.php
+++ b/www/components/ifdb-recommends.php
@@ -21,12 +21,13 @@ $sortby = "ratu";  // Sort the highly rated games to the top of the results.
 $maxpicks = 12;    // Get the first twelve results. (We want extras so we're not always displaying the same games.) 
 $limit = "limit 0, $maxpicks";
 $browse = 0;
+$override_game_filter = 0;
 
 
 // run the search for highly-rated games
 list($recs, $rowcnt, $sortList, $errMsg, $summaryDesc, $badges,
-    $specials, $specialsUsed, $orderBy) =
-    doSearch($db, $term, $searchType, $sortby, $limit, $browse);
+    $specials, $specialsUsed, $orderBy, $games_were_filtered) =
+    doSearch($db, $term, $searchType, $sortby, $limit, $browse, $override_game_filter);
 
 
 // show some recommendations

--- a/www/editprofile
+++ b/www/editprofile
@@ -56,6 +56,7 @@ $emailcloaked = (get_req_data('emailcloaked') != 0);
 $gender = get_req_data('gender');
 $offsite = get_req_data('offsite');
 $accessibility = (get_req_data('accessibility') ? 1 : 0);
+$game_filter = get_req_data('game_filter');
 
 if (strlen($gender) != 1 || strpos("MF", $gender) === false)
     $gender = "";
@@ -72,7 +73,7 @@ function showHiddenFields()
     global $email, $email2, $pubemail, $dname, $loc, $profile, $pic,
         $defaultOS, $mirror, $noExes,
         $playlistPub, $wishlistPub, $unwishlistPub, $gender,
-        $emailcaptcha, $emailcloaked;
+        $emailcaptcha, $emailcloaked, $game_filter;
 
     echo "<input type=hidden name=email value=\""
           . htmlspecialcharx($email) . "\">"
@@ -103,6 +104,7 @@ function showHiddenFields()
         . "<input type=hidden name=gender value=\"$gender\">"
         . "<input type=hidden name=offsite value=\"$offsite\">"
         . "<input type=hidden name=accessibility value=\"$accessibility\">"
+        . "<input type=hidden name=game_filter value=\"$game_filter\">"
         . "<input type=hidden name=mirror value=\""
         . htmlspecialcharx($mirror) . "\">"
         . "<input type=hidden name=defaultos value=\""
@@ -135,7 +137,7 @@ function init()
         $unwishlistPub, $oldUnwishlistPub, $gender, $oldGender,
         $emailcaptcha, $oldEmailcaptcha, $emailcloaked, $oldEmailcloaked,
         $mirror, $oldMirror, $actcode, $oldPicName, $offsite, $oldOffsite,
-        $accessibility, $oldAccessibility;
+        $accessibility, $oldAccessibility, $game_filter, $old_game_filter;
 
     // connect to the database
     if ($db == false) {
@@ -155,7 +157,7 @@ function init()
            acctstatus, activationcode,
            concat(defaultos, '.', ifnull(defaultosvsn,'')) as defaultos,
            noexedownloads, publiclists, gender, emailflags,
-           offsite_display, accessibility
+           offsite_display, accessibility, game_filter
         from
            users
         where
@@ -193,6 +195,7 @@ function init()
     $oldEmailcloaked = (($emailflags & EMAIL_CLOAKED) ? 1 : 0);
     $oldOffsite = mysql_result($result, 0, "offsite_display");
     $oldAccessibility = mysql_result($result, 0, "accessibility");
+    $old_game_filter = mysql_result($result, 0, "game_filter");
 
     // if we're not posting, populate the form with the current values
     // from the database
@@ -215,6 +218,7 @@ function init()
         $mirror = $oldMirror;
         $offsite = $oldOffsite;
         $accessibility = $oldAccessibility;
+        $game_filter = $old_game_filter;
     }
 
     // if the current cover art setting refers to an uploaded image
@@ -237,8 +241,8 @@ function saveChanges()
         $unwishlistPub, $oldUnwishlistPub,
         $gender, $oldGender, $emailcaptcha, $oldEmailcaptcha,
         $emailcloaked, $oldEmailcloaked, $mirror, $oldMirror, $actcode,
-        $offsite, $oldOffsite, $accessibility, $oldAccessibility,
-        $captchaKey, $captchaOK, $captchaErr;
+        $offsite, $oldOffsite, $accessibility, $oldAccessibility, $game_filter,
+        $old_game_filter, $captchaKey, $captchaOK, $captchaErr;
 
     // no new picture yet
     $imgID = false;
@@ -260,7 +264,8 @@ function saveChanges()
         || $gender != $oldGender
         || $mirror != $oldMirror
         || $offsite != $oldOffsite
-        || $accessibility != $oldAccessibility)
+        || $accessibility != $oldAccessibility
+        || $game_filter != $old_game_filter)
     {
         // if we're changing the email address, we'll need to reactivate
         if (strcmp($email, $oldemail) != 0) {
@@ -309,6 +314,7 @@ function saveChanges()
         $qpubemail = mysql_real_escape_string($pubemail, $db);
         $qloc = mysql_real_escape_string($loc, $db);
         $qprofile = mysql_real_escape_string($profile, $db);
+        $qgamefilter = mysql_real_escape_string($game_filter, $db);
 
         // make sure the location doesn't contain a url
         if (preg_match("/http:/i", $loc)) {
@@ -570,7 +576,8 @@ complete the re-activation process.</b>
                    noexedownloads = '$qNoExes', publiclists = '$qPublicLists',
                    gender = '$qGender', emailflags = '$emailflags',
                    offsite_display = '$qOffsite',
-                   accessibility = '$qAccessibility'
+                   accessibility = '$qAccessibility',
+                   game_filter = '$qgamefilter'
                    $setPic
                 where id = '$usernum'", $db) == false) {
             $errFlagged = "An error occurred updating the database. You might
@@ -923,6 +930,32 @@ captchaSupportScripts($captchaKey);
 <p><a href="userfilter?list" target="_blank">View/Edit my filter list</a>
 
 </div>
+
+<h2>5. Game Filtering</h2>
+
+<div class=indented>
+<p><span class=details>To limit what kinds of games appear on the 
+   <a href="/search" target="_blank">search page</a> and on the 
+   <a href="/search?browse" target="_blank">browse page</a>, you can 
+   create a filter using IFDB's 
+   <a href="/search" target="_blank">search prefixes</a>. 
+   For instance, to hide games in a certain language, games in a 
+   certain genre, and games with a certain tag, you can type
+   <br><b>-language:example -genre:example -tag:example</b><br>
+   (replacing "example" with the name of the language, genre, or tag). 
+   While you are logged in, your saved filter will automatically be 
+   be added to the end of your search terms when you search for games.
+   The filter will also be applied when you browse games on the browse 
+   page. At the bottom of the page of results, there will be an option 
+   to search again without the filter. (Note: Game information on IFDB 
+   is incomplete and can have mistakes. A filter is not a reliable way 
+   to make sure that games are kid-friendly.)
+</span>
+<p><label for='game_filter'>Game filter:</label>
+<input type='text' name='game_filter' id='game_filter' maxlength=150 size=40 value="<?php echo htmlspecialcharx($game_filter) ?>"></span>
+
+</div>
+
 
 <br><br>
 <input type=submit value="Save Changes" name="save">

--- a/www/search
+++ b/www/search
@@ -1135,7 +1135,7 @@ else if ($term || $browse)
         echo "<i>No results were found.</i>";
 
         if ($games_were_filtered) {
-            echo '<p><i>You have configured your account to filter game results by default. You can ';
+            echo '<p><i>You have set up your account to filter game results by default. You can ';
             if (!$browse) {
                 echo '<a href="search?searchfor=' . $term . '&nogamefilter=1">search again</a>';
             } else if ($browse) {
@@ -1568,13 +1568,13 @@ else if ($term || $browse)
 
         // Announce that the game results are filtered, if applicable
         if ($games_were_filtered) {
-            echo '<br><div class="details">You have configured your account to filter game results by default. You can ';
+            echo '<p class="details">You have set up your account to filter game results by default. You can ';
             if (!$browse) {
-                echo '<a href="search?searchfor=' . $term . '&nogamefilter=1">search again.</a>';
+                echo '<a href="search?searchfor=' . $term . '&nogamefilter=1">search again</a>';
             } else if ($browse) {
                 echo 'also <a href="search?browse&nogamefilter=1">browse</a>';
             }
-            echo ' without the filter</div>';
+            echo ' without the filter.</p>';
         }
     }
 

--- a/www/search
+++ b/www/search
@@ -58,6 +58,7 @@ if ($api_mode && !isset($_SESSION['logged_in_as']) && isset($_SERVER['PHP_AUTH_U
 $term = get_req_data('searchfor');
 $bTerm = get_req_data('searchbar');
 $extraLink = get_req_data('xlink');
+$override_game_filter = get_req_data('nogamefilter');
 
 if ($term == "" && $bTerm != "")
     $term = $bTerm;
@@ -294,8 +295,8 @@ if ($term || $browse) {
 
     // run the search
     list($rows, $rowcnt, $sortList, $errMsg, $summaryDesc, $badges,
-         $specials, $specialsUsed, $orderBy) =
-        doSearch($db, $term, $searchType, $sortby, $limit, $browse);
+         $specials, $specialsUsed, $orderBy, $games_were_filtered) =
+        doSearch($db, $term, $searchType, $sortby, $limit, $browse, $override_game_filter);
 
     // adjust our page limits to include the whole result set if desired
     if ($pgAll) {
@@ -304,7 +305,7 @@ if ($term || $browse) {
     }
 
     // if there's exactly one row, jump directly to the result page
-    if ($rowcnt == 1 && !$browse && !$api_mode) {
+    if ($rowcnt == 1 && !$browse && !$api_mode && !$games_were_filtered) {
         $redir = false;
         switch ($searchType) {
         case "game":
@@ -998,7 +999,7 @@ if ($api_mode) {
                 $item['coverArtLink'] =
                     get_root_url() . "coverart?id=$id&version={$row['pagevsn']}";
             }
-            if (isset($row['rounded_median_time_in_minutes'])) {
+            if ($row['rounded_median_time_in_minutes']) {
                 $item['playTimeInMinutes'] = $row['rounded_median_time_in_minutes'];
             }
 
@@ -1132,6 +1133,16 @@ else if ($term || $browse)
     if ($rowcnt == 0) {
 
         echo "<i>No results were found.</i>";
+
+        if ($games_were_filtered) {
+            echo '<p><i>You have configured your account to filter game results by default. You can ';
+            if (!$browse) {
+                echo '<a href="search?searchfor=' . $term . '&nogamefilter=1">search again</a>';
+            } else if ($browse) {
+                echo 'also <a href="search?browse&nogamefilter=1">browse</a>';
+            }
+            echo ' without the filter.</i></p>';
+        }
 
         if ($searchType == "game") {
             echo "<div class=inlinetip>"
@@ -1554,6 +1565,17 @@ else if ($term || $browse)
         // add the page controls again at the bottom, if applicable
         if ($pg != 1 || $rowcnt > $perPage)
             echo "<div class='search__pageCtl'>$pageCtl</div>";
+
+        // Announce that the game results are filtered, if applicable
+        if ($games_were_filtered) {
+            echo '<br><div class="details">You have configured your account to filter game results by default. You can ';
+            if (!$browse) {
+                echo '<a href="search?searchfor=' . $term . '&nogamefilter=1">search again.</a>';
+            } else if ($browse) {
+                echo 'also <a href="search?browse&nogamefilter=1">browse</a>';
+            }
+            echo ' without the filter</div>';
+        }
     }
 
 

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -305,7 +305,7 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse, $override_g
         // Handle custom game filters
         if ($curuser && $override_game_filter != 1) {
             // We're logged in, and haven't been told to override a custom game filter, so check for one
-            $result = mysqli_execute_query($db, "select game_search_filter from users where id = ?", [$curuser]);
+            $result = mysqli_execute_query($db, "select game_filter from users where id = ?", [$curuser]);
             if (!$result) throw new Exception("Error: " . mysqli_error($db));
             [$gameFilter] = mysql_fetch_row($result);
             if ($gameFilter) {


### PR DESCRIPTION
Slightly more verbose message. Fixed the spacing before the message (by using `<p>`) so that the spacing is about the same whether there is one result or multiple results. Changed some variable names to be clearer (taking out "search" since the game results aren't always the result of obvious searches). Also, the formatting doesn't look so strange anymore (I never figured out the cause).  There's now a default value for the $override_game_filter parameter (though I don't know if it'll help much).