### PR TITLE
search: Don't list negative terms in 'Tags matched'

### DIFF
--- a/www/search
+++ b/www/search
@@ -1342,6 +1342,9 @@ else if ($term || $browse)
                     $tagsMatched = array();
                     foreach ($specials as $s) {
                         if ($s[0][0] == "tags") {
+                            // Don't try to match negated terms
+                            if ($s[2] === '-')
+                                continue;
                             foreach ($tags as $t) {
                                 if (strpos(strtolower($t),
                                            strtolower($s[1])) !== false) {

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -453,7 +453,7 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
         $txt = $s[1];
         $forHaving = count($desc) >= 3 && $desc[2];
         $expr = "1";
-        $negate = (strpos($s[2], '-') !== false);
+        $negate = ($s[2] === '-');
 
         // build the appropriate expression, based on the descriptor type
         switch ($typ) {


### PR DESCRIPTION
Fixes #1200.

The term `(strpos($s[2], '-') !== false)` is a bit cryptic. I copied it from searchutil.php:
```php
 $negate = (strpos($s[2], '-') !== false);
```