### PR TITLE
Fix slow query for game tags

### DIFF
--- a/www/viewgame
+++ b/www/viewgame
@@ -2743,8 +2743,8 @@ var dbTagList = [
                count(distinct gameid) as gamecnt,
                $isMine as isMine
              from gametags
+             where tag in (select tag from gametags where gameid = '$qid')
              group by tag
-             having tagcnt != 0
              order by tag", $db);
         $cnt = mysql_num_rows($result);
 


### PR DESCRIPTION
Fixes #1203

it turns out that we'd already fixed this in the API version of this query; I copied and pasted the `where` clause from https://github.com/iftechfoundation/ifdb/blob/d79d4b30f3c84172bafee5d0e551b1ffdc06e6fb/www/viewgame#L767

# Before

```
MariaDB [ifdb]> explain select
    ->   tag,
    ->   sum(gameid = 'aearuuxv83plclpl') as tagcnt,
    ->   count(distinct gameid) as gamecnt,
    ->   sum(userid = 'oyrrw74upu8n2dds' and gameid = 'aearuuxv83plclpl') as isMine
    -> from gametags
    -> group by tag
    -> having tagcnt != 0
    -> order by tag;
+------+-------------+----------+------+---------------+------+---------+------+-------+----------------+
| id   | select_type | table    | type | possible_keys | key  | key_len | ref  | rows  | Extra          |
+------+-------------+----------+------+---------------+------+---------+------+-------+----------------+
|    1 | SIMPLE      | gametags | ALL  | NULL          | NULL | NULL    | NULL | 80543 | Using filesort |
+------+-------------+----------+------+---------------+------+---------+------+-------+----------------+
```

# After

```
MariaDB [ifdb]> explain select
    ->   tag,
    ->   sum(gameid = 'aearuuxv83plclpl') as tagcnt,
    ->   count(distinct gameid) as gamecnt,
    ->   sum(userid = 'oyrrw74upu8n2dds' and gameid = 'aearuuxv83plclpl') as isMine
    -> from gametags
    -> where tag in (select tag from gametags where gameid = 'aearuuxv83plclpl')
    -> group by tag
    -> order by tag;
+------+--------------+-------------+------+---------------+--------+---------+-------------------+------+---------------------------------+
| id   | select_type  | table       | type | possible_keys | key    | key_len | ref               | rows | Extra                           |
+------+--------------+-------------+------+---------------+--------+---------+-------------------+------+---------------------------------+
|    1 | PRIMARY      | <subquery2> | ALL  | distinct_key  | NULL   | NULL    | NULL              | 67   | Using temporary; Using filesort |
|    1 | PRIMARY      | gametags    | ref  | tag           | tag    | 1002    | ifdb.gametags.tag | 15   | Using where                     |
|    2 | MATERIALIZED | gametags    | ref  | gameid,tag    | gameid | 130     | const             | 67   | Using index condition           |
+------+--------------+-------------+------+---------------+--------+---------+-------------------+------+---------------------------------+
```