### PR TITLE
Workaround a bug in Safari `text-wrap: balance`

### DIFF
--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -1538,7 +1538,9 @@ ul.doublespace li {
 
 div.scroll-links {
     position: sticky;
-    text-wrap: balance;
+    /* ideally, we'd use text-wrap: balance, but it seems to be buggy in Safari 18.2
+    https://github.com/iftechfoundation/ifdb/issues/1208 */
+    text-wrap: pretty;
     top: 0;
     margin: 0 -0.5em 1em -0.5em;
     display: flex;


### PR DESCRIPTION
We were using `text-wrap: balance` here to handle viewports that are small enough to cause the last link to wrap to the next line as a "widow" (or "runt").

`text-wrap: balance` would prevent the widow by moving half of the links to the subsequent line, ensuring that both lines were roughly balanced.

But `text-wrap: balance` seems to be buggy in Safari 18.2; it was causing the first few links to be "orphans" all on their own line. The algorithm seemed to fix itself randomly, e.g. if I uncheck and recheck the box in Safari Dev Tools, or just scroll around a little on the page.

Safari 18.2 doesn't support `text-wrap: pretty`, causing it to fallback to `text-wrap: auto`, which is better than its broken implementation of `text-wrap: balance`.

Fixes #1208

# Before
<img width=406 src=https://github.com/user-attachments/assets/92d8d8c8-4ec3-47f7-9e62-23cd18e4cc1e>

# After
<img width=406 src=https://github.com/user-attachments/assets/98b81739-2352-4c6d-b46e-3048e24a90a9>
