### PR TITLE
Fix header search bar appearance on mobile Safari

### DIFF
--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -222,9 +222,12 @@ div.topctl table tr td {
 
 .searchbar-wrapper > input {
     border: none;
+    padding-top: 0;
     padding-left: 0.5em;
+    padding-bottom: 0;
     border-radius: 1em 0 0 1em;
     width: 100%;
+    background: #fff;
 }
 
 .searchbar-wrapper > button {
@@ -2199,6 +2202,10 @@ span.sfl-save-autodesc {
     }
     .searchbar-wrapper { 
         border: 1.5px solid #696991;
+    }
+
+    .searchbar-wrapper > input {
+        background: #000;
     }
     #topbar-search-go-button {
         filter: invert(1);


### PR DESCRIPTION
Fixes #1209

# Before

<img width=406 src=https://github.com/user-attachments/assets/70647017-7a37-43c6-bf08-36b65c88569b>

# After

<img width=406 src=https://github.com/user-attachments/assets/13319770-041b-4270-b07e-d29ca849dca3>
