### PR TITLE
Show the number of new messages next to "Inbox" in the nav bar

### DIFF
--- a/www/commentutil.php
+++ b/www/commentutil.php
@@ -3,6 +3,12 @@
 include_once "util.php";
 include_once "login-persist.php";
 
+// Use globals for the inbox and the number of inbox messages 
+// so that once we call queryComments(), we can use the results 
+// in both pagetpl.php and check-inbox.php
+$inbox = [];
+$inboxCnt = 0;
+
 function queryComments($db, $mode, $quid, $limit, $caughtUpDate, $keepPlonked)
 {
     // get the logged-in user

--- a/www/components/check-inbox.php
+++ b/www/components/check-inbox.php
@@ -3,11 +3,11 @@
 
 // check the inbox
 if ($quid) {
-    list($inbox, $inboxCnt) =
-        queryComments($db, "inbox", $quid, "limit 0, 1", $caughtUpDate, false);
     if (!$newCaughtUp || $srow[4] > $newCaughtUp)
         $newCaughtUp = $srow[4];
 
+    // $inboxCnt is returned by the queryComments function, which is
+    // defined in commentutil.php and called in pagetpl.php
     if ($inboxCnt) {
 
         global $nonce;

--- a/www/pagetpl.php
+++ b/www/pagetpl.php
@@ -117,12 +117,12 @@ function pageHeader($title, $focusCtl = false, $extraOnLoad = false,
                     <li class="<?= ($pagescript === 'commentlog') ? 'page-active':''; ?>"><a id="topbar-inbox" href="/commentlog?mode=inbox">Inbox
                     <?php
                     // check the inbox so we can display the number of new messages
-                    $db = dbConnect();
-                    $uid = checkPersistentLogin();
-                    $quid = mysql_real_escape_string($uid, $db);
                     $inboxCnt = 0;
-                    if ($quid) {
-                        list($inbox, $inboxCnt) =
+                    $uid = checkPersistentLogin();
+                    if ($uid) {
+                        $db = dbConnect();
+                        $quid = mysql_real_escape_string($uid, $db);
+                        [$inbox, $inboxCnt] =
                         queryComments($db, "inbox", $quid, "limit 0, 1", $caughtUpDate, false);
                     }
                     if ($inboxCnt) { 

--- a/www/pagetpl.php
+++ b/www/pagetpl.php
@@ -117,14 +117,13 @@ function pageHeader($title, $focusCtl = false, $extraOnLoad = false,
                     <li class="<?= ($pagescript === 'commentlog') ? 'page-active':''; ?>"><a id="topbar-inbox" href="/commentlog?mode=inbox">Inbox
                     <?php
                     // check the inbox so we can display the number of new messages
-                    $inboxCnt = 0;
-                    $uid = checkPersistentLogin();
-                    if ($uid) {
-                        $db = dbConnect();
-                        $quid = mysql_real_escape_string($uid, $db);
-                        [$inbox, $inboxCnt] =
+                    $db = dbConnect();
+                    $result = mysqli_execute_query($db,
+                    "select caughtupdate from users where id=?", [$curuser]);
+                    $caughtUpDate = mysql_result($result, 0, "caughtupdate");
+                    $quid = mysql_real_escape_string($curuser, $db);
+                    [$inbox, $inboxCnt] =
                         queryComments($db, "inbox", $quid, "limit 0, 1", $caughtUpDate, false);
-                    }
                     if ($inboxCnt) { 
                         echo " (" . $inboxCnt . ")";
                     }

--- a/www/pagetpl.php
+++ b/www/pagetpl.php
@@ -3,6 +3,7 @@
 include_once "csp-nonce.php";
 include_once "util.php";
 include_once "login-persist.php";
+include_once "commentutil.php";
 
 header("Speculation-Rules: \"/speculation-rules\"");
 
@@ -113,7 +114,22 @@ function pageHeader($title, $focusCtl = false, $extraOnLoad = false,
                     <li class="<?= ($pagescript === 'showuser') ? 'page-active':''; ?>"><a id="topbar-profile" href="/showuser">Profile</a></li>
                     <li class="<?= ($pagescript === 'editprofile') ? 'page-active':''; ?>"><a id="topbar-edit" href="/editprofile">Settings</a></li>
                     <li class="<?= ($pagescript === 'personal') ? 'page-active':''; ?>"><a id="topbar-personal" href="/personal">My Activity</a></li>
-                    <li class="<?= ($pagescript === 'commentlog') ? 'page-active':''; ?>"><a id="topbar-inbox" href="/commentlog?mode=inbox">Inbox</a></li>
+                    <li class="<?= ($pagescript === 'commentlog') ? 'page-active':''; ?>"><a id="topbar-inbox" href="/commentlog?mode=inbox">Inbox
+                    <?php
+                    // check the inbox so we can display the number of new messages
+                    $db = dbConnect();
+                    $uid = checkPersistentLogin();
+                    $quid = mysql_real_escape_string($uid, $db);
+                    $inboxCnt = 0;
+                    if ($quid) {
+                        list($inbox, $inboxCnt) =
+                        queryComments($db, "inbox", $quid, "limit 0, 1", $caughtUpDate, false);
+                    }
+                    if ($inboxCnt) { 
+                        echo " (" . $inboxCnt . ")";
+                    }
+                    ?>
+                    </a></li>
                     <li><a id="topbar-logout" class="login-link no-prerender" href="/logout">Log Out</a></li>
                 <?php else : ?>
                     <li><a id="topbar-login" class="login-link" href="/login?dest=home">Log In</a></li>

--- a/www/pagetpl.php
+++ b/www/pagetpl.php
@@ -122,6 +122,7 @@ function pageHeader($title, $focusCtl = false, $extraOnLoad = false,
                     "select caughtupdate from users where id=?", [$curuser]);
                     $caughtUpDate = mysql_result($result, 0, "caughtupdate");
                     $quid = mysql_real_escape_string($curuser, $db);
+                    global $inbox, $inboxCnt;
                     [$inbox, $inboxCnt] =
                         queryComments($db, "inbox", $quid, "limit 0, 1", $caughtUpDate, false);
                     if ($inboxCnt) { 


### PR DESCRIPTION
This displays the number of new messages next to the word "Inbox" in the nav bar at the top of the page.

I experimented a little with trying to make the number stand out more by using red type, or white type on a red background, but I didn't find a combo that looked good to me (especially in dark mode), so this PR addresses only part of https://github.com/iftechfoundation/ifdb/issues/1213

![inbox messages](https://github.com/user-attachments/assets/9b8e7d93-b3ef-43be-af3f-0e5dea00a3a2)

(Originally I was testing this by logging in as different users, but I figured out that it also works if you comment on your own profile.)