### PR TITLE
Rename "plonk" to "mute"

### DIFF
--- a/www/allreviews
+++ b/www/allreviews
@@ -2,12 +2,12 @@
 //
 // allreviews - show all reviews by a given user.
 
-// Note that we ignore the user filters (promoted, demoted, plonked) here,
+// Note that we ignore the user filters (promoted, demoted, muted) here,
 // because those are meant to sort and filter reviews by user.   Since all
 // of the reviews we show here are by a single user, there's no need to
 // sort relative to other users; and since the only purpose of this page
 // is to show a given users's reviews, it doesn't make any sense to pay
-// attention to plonking here.
+// attention to muting here.
 
 include_once "session-start.php";
 

--- a/www/components/poll-sampler.php
+++ b/www/components/poll-sampler.php
@@ -10,6 +10,15 @@ if ($curuser) {
     [$sandbox] = mysql_fetch_row($result);
 }
 
+// filter out muted users, if applicable
+$andNotMuted = "";
+if ($curuser) {
+    $andNotMuted = "and (select count(*) from userfilters "
+                        . "where userid = '$curuser' "
+                        . "and targetuserid = p.userid "
+                        . "and filtertype = 'K') = 0";
+}
+
 // set up the base query for polls
 $baseQuery = "select
                 p.pollid, p.title, p.userid, u.name
@@ -19,6 +28,7 @@ $baseQuery = "select
                 join users as u on u.id = p.userid
               where
                 sandbox in (0, ?)
+                $andNotMuted
               group by
                 p.pollid";
 

--- a/www/editprofile
+++ b/www/editprofile
@@ -915,9 +915,9 @@ captchaSupportScripts($captchaKey);
    you can "promote" that user, which makes IFDB show you that user's
    reviews first when you view game listings.  If you dislike someone's
    reviews, you can "demote" her to show her reviews last.  If you
-   <i>really</i> dislike someone, you can "plonk" him, which prevents
+   <i>really</i> dislike someone, you can "mute" him, which prevents
    you from seeing his reviews at all.</span>
-<p><span class=details>To promote, demote, or plonk someone, use the
+<p><span class=details>To promote, demote, or mute someone, use the
    controls shown below each review.</span>
 
 <p><a href="userfilter?list" target="_blank">View/Edit my filter list</a>

--- a/www/help-review-votes
+++ b/www/help-review-votes
@@ -29,13 +29,13 @@ Demote her, her reviews will move to the end of the list.
  <a href="userfilter?list">user filter
 editor</a>.)
 
-<p><a name="plonk"><b>Plonk this user:</b></a>
+<p><a name="mute"><b>Mute this user:</b></a>
 This is the nuclear option, for someone you
 find so annoying that you never again want to see anything they write.
-If you plonk a user, <b>all</b> of her reviews will be omitted when
+If you mute a user, <b>all</b> of her reviews will be omitted when
 you view game pages throughout IFDB.  This only affects you - it won't
 actually delete the user's reviews or hide them when other members
-view the same game pages.  (You can change your mind and un-plonk
+view the same game pages.  (You can change your mind and un-mute
 someone later via the <a href="userfilter?list">user filter editor</a>.)
 
 <p><b>Flag spoilers:</b> Mark this review as containing

--- a/www/newitems.php
+++ b/www/newitems.php
@@ -28,10 +28,10 @@ function getNewItems($db, $limit, $itemTypes = NEWITEMS_ALLITEMS, $options = [])
     checkPersistentLogin();
     $curuser = $_SESSION['logged_in_as'] ?? null;
 
-    // filter out plonked users, if applicable
-    $andNotPlonked = "";
+    // filter out muted users, if applicable
+    $andNotMuted = "";
     if ($curuser) {
-        $andNotPlonked = "and (select count(*) from userfilters "
+        $andNotMuted = "and (select count(*) from userfilters "
                          . "where userid = '$curuser' "
                          . "and targetuserid = #USERID# "
                          . "and filtertype = 'K') = 0";
@@ -104,8 +104,8 @@ function getNewItems($db, $limit, $itemTypes = NEWITEMS_ALLITEMS, $options = [])
     if ($itemTypes & NEWITEMS_LISTS) {
         $lists_limit = $options['lists_limit'] ?? $limit;
         if ($days) $dayWhere = "reclists.createdate > date_sub(now(), interval $days day)";
-        // query the recent recommended lists (minus plonked users)
-        $anp = str_replace('#USERID#', 'reclists.userid', $andNotPlonked);
+        // query the recent recommended lists (minus muted users)
+        $anm = str_replace('#USERID#', 'reclists.userid', $andNotMuted);
         $result = mysql_query(
             "select
                reclists.id as id, reclists.title as title,
@@ -121,7 +121,7 @@ function getNewItems($db, $limit, $itemTypes = NEWITEMS_ALLITEMS, $options = [])
              where
                users.sandbox in $sandbox
                and $dayWhere
-               $anp
+               $anm
              group by reclists.id
              order by reclists.createdate desc
              limit $lists_limit", $db);
@@ -135,8 +135,8 @@ function getNewItems($db, $limit, $itemTypes = NEWITEMS_ALLITEMS, $options = [])
     if ($itemTypes & NEWITEMS_POLLS) {
         $polls_limit = $options['polls_limit'] ?? $limit;
         if ($days) $dayWhere = "p.created > date_sub(now(), interval $days day)";
-        // query the recent polls (minus plonked users)
-        $anp = str_replace('#USERID#', 'p.userid', $andNotPlonked);
+        // query the recent polls (minus muted users)
+        $anm = str_replace('#USERID#', 'p.userid', $andNotMuted);
         $result = mysql_query(
             "select
                p.pollid as pollid, p.title as title, p.`desc` as `desc`,
@@ -152,7 +152,7 @@ function getNewItems($db, $limit, $itemTypes = NEWITEMS_ALLITEMS, $options = [])
              where
                u.sandbox in $sandbox
                and $dayWhere
-               $anp
+               $anm
              group by
                p.pollid
              order by
@@ -168,8 +168,8 @@ function getNewItems($db, $limit, $itemTypes = NEWITEMS_ALLITEMS, $options = [])
     if ($itemTypes & NEWITEMS_REVIEWS) {
         $reviews_limit = $options['reviews_limit'] ?? $limit;
         if ($days) $dayWhere = "greatest(reviews.createdate, ifnull(reviews.embargodate, '0000-00-00')) > date_sub(now(), interval $days day)";
-        // query the recent reviews (minus plonks)
-        $anp = str_replace('#USERID#', 'reviews.userid', $andNotPlonked);
+        // query the recent reviews (minus mutes)
+        $anm = str_replace('#USERID#', 'reviews.userid', $andNotMuted);
         $result = mysql_query(
             "select
                reviews.id as id, gameid, summary, review, rating, special,
@@ -197,7 +197,7 @@ function getNewItems($db, $limit, $itemTypes = NEWITEMS_ALLITEMS, $options = [])
                and ifnull(specialreviewers.code, '') <> 'external'
                and users.sandbox in $sandbox
                and $dayWhere
-               $anp
+               $anm
              order by d desc, id desc
              limit $reviews_limit", $db);
         $revcnt = mysql_num_rows($result);
@@ -282,10 +282,10 @@ function queryNewNews(&$items, $db, $limit, $sourceType,
     checkPersistentLogin();
     $curuser = $_SESSION['logged_in_as'] ?? null;
 
-    // filter out plonked users, if applicable
-    $andNotPlonked = "";
+    // filter out muted users, if applicable
+    $andNotMuted = "";
     if ($curuser) {
-        $andNotPlonked = "and (select count(*) from userfilters "
+        $andNotMuted = "and (select count(*) from userfilters "
                          . "where userid = '$curuser' "
                          . "and targetuserid = n.userid "
                          . "and filtertype = 'K') = 0";
@@ -333,7 +333,7 @@ function queryNewNews(&$items, $db, $limit, $sourceType,
            and nsuper.newsid is null
            and uorig.sandbox in $sandbox
            and $dayWhere
-           $andNotPlonked
+           $andNotMuted
          order by
            n.created desc
          limit $limit", $db);

--- a/www/news.php
+++ b/www/news.php
@@ -147,10 +147,10 @@ function queryNews($db, $sourceType, $sourceID, $includeDeletions,
     checkPersistentLogin();
     $curuser = $_SESSION['logged_in_as'] ?? null;
 
-    // filter out plonked users, if applicable
-    $andNotPlonked = "";
+    // filter out muted users, if applicable
+    $andNotMuted = "";
     if ($curuser) {
-        $andNotPlonked = "and (select count(*) from userfilters "
+        $andNotMuted = "and (select count(*) from userfilters "
                          . "where userid = '$curuser' "
                          . "and targetuserid = n.userid "
                          . "and filtertype = 'K') = 0";
@@ -210,7 +210,7 @@ function queryNews($db, $sourceType, $sourceID, $includeDeletions,
            n.source = '$sourceType' and n.sourceid = '$sourceID'
            and n.status in $statusList
            and nsuper.newsid is null
-           $andNotPlonked
+           $andNotMuted
            and u.sandbox in $sandbox
          order by
            n.created desc

--- a/www/reviews.php
+++ b/www/reviews.php
@@ -22,12 +22,12 @@ function getReviewQuery($db, $where)
     // check for a logged-in user
     $curuser = checkPersistentLogin();
 
-    // If we're logged in, set up the review query modifiers for plonking
+    // If we're logged in, set up the review query modifiers for muting
     // and promotions and demotions.
-    $notPlonked = '1';
+    $notMuted = '1';
     $joinUserFilter = '';
     if ($curuser) {
-        $notPlonked = "(ifnull(userfilters.filtertype, '*') <> 'K')";
+        $notMuted = "(ifnull(userfilters.filtertype, '*') <> 'K')";
         $joinUserFilter = "left outer join userfilters "
                           . "on userfilters.targetuserid = reviews.userid "
                           . "and userfilters.userid = '$curuser'";
@@ -85,7 +85,7 @@ function getReviewQuery($db, $where)
          where
            ($where)
            and ifnull(now() >= reviews.embargodate, 1)
-           and $notPlonked
+           and $notMuted
            and ifnull(users.sandbox, 0) in $sandbox
          group by
            reviews.id";
@@ -539,9 +539,9 @@ function showReview($db, $gameid, $rec, $specialNames, $optionFlags = 0)
             . "(this will only be visible to you)\"><nobr>"
             . "Demote this user</nobr></a>"
             . "</td></tr>"
-            . "<tr><td><a href=\"userfilter?user=$userid&action=plonk\" "
+            . "<tr><td><a href=\"userfilter?user=$userid&action=mute\" "
             . "title=\"Never show me this user's "
-            . "reviews at all\"><nobr>Plonk this user</nobr></a>"
+            . "reviews at all\"><nobr>Mute this user</nobr></a>"
             . "</td></tr>"
             . "<tr><td><a href=\"reviewflag?review=$reviewid&type=spoilers\" "
             . "title=\"Warn other users that this review "

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -49,10 +49,10 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
     checkPersistentLogin();
     $curuser = mysql_real_escape_string($_SESSION['logged_in_as'] ?? '', $db);
 
-    // set up the plonk filter
-    $andNotPlonked = "";
+    // set up the mute filter
+    $andNotMuted = "";
     if ($curuser) {
-        $andNotPlonked = " and (select count(*) from userfilters "
+        $andNotMuted = " and (select count(*) from userfilters "
                          . "where userid = '$curuser' "
                          . "and targetuserid = #USERID# "
                          . "and filtertype = 'K') = 0";
@@ -107,7 +107,7 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
         $baseWhere = "and reclists.userid = users.id "
                      . "and users.sandbox in ($sandbox) "
                      . str_replace('#USERID#', 'reclists.userid',
-                                   $andNotPlonked);
+                                   $andNotMuted);
         $groupBy = "group by reclistitems.listid";
         $baseOrderBy = "title";
         $matchCols = "title, keywords";
@@ -136,7 +136,7 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
                       left outer join pollvotes as v on v.pollid = p.pollid
                       join users as u on u.id = p.userid";
         $baseWhere = "and u.sandbox in $sandbox "
-                     . str_replace('#USERID#', 'p.userid', $andNotPlonked);
+                     . str_replace('#USERID#', 'p.userid', $andNotMuted);
         $groupBy = "group by p.pollid";
         $baseOrderBy = "title";
         $matchCols = "title, keywords";
@@ -162,7 +162,7 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
         $baseWhere = "and u.acctstatus = 'A' "
                      . "and u.sandbox in $sandbox "
                      . "and (ifnull(u.profilestatus, ' ') != 'R' $orCurUser)"
-                     . str_replace('#USERID#', 'u.id', $andNotPlonked);
+                     . str_replace('#USERID#', 'u.id', $andNotMuted);
         $groupBy = "";
         $baseOrderBy = "name";
         $matchCols = "name, profile";

--- a/www/showuser
+++ b/www/showuser
@@ -38,8 +38,8 @@ if ($uid == "")
 $quid = mysql_real_escape_string($uid, $db);
 $errMsg = false;
 
-// check for plonking
-$plonked = false;
+// check for muting
+$muted = false;
 if ($curuser) {
     $result = mysql_query(
         "select 1
@@ -48,17 +48,17 @@ if ($curuser) {
            userid = '$curuser'
            and targetuserid = '$quid'
            and filtertype = 'K'", $db);
-    $plonked = (mysql_num_rows($result) > 0);
-    if ($plonked)
+    $muted = (mysql_num_rows($result) > 0);
+    if ($muted)
     {
-        // check for a plonk override
-        $plonkOverride = isset($_REQUEST['plonkOverride']);
-        if (!$plonkOverride) {
-            $errMsg = "You've plonked this member, which means that you've "
+        // check for a mute override
+        $muteOverride = isset($_REQUEST['muteOverride']);
+        if (!$muteOverride) {
+            $errMsg = "You've muted this member, which means that you've "
                       . "asked for IFDB to hide all of this user's reviews, "
                       . "comments, and other information. If you'd like to "
                       . "view this profile anyway, <a href=\"showuser?"
-                      . "id=$uid&plonkOverride\">click here</a>.";
+                      . "id=$uid&muteOverride\">click here</a>.";
         }
     }
 }

--- a/www/userfilter
+++ b/www/userfilter
@@ -49,7 +49,7 @@ $result = mysql_query(
     "select filtertype from userfilters
      where userid = '$curuser' and targetuserid = '$qTargetUser'", $db);
 list($oldFilter) = mysql_fetch_row($result);
-$filterNames = array('P' => "promote", 'D' => "demote", 'K' => "plonk");
+$filterNames = array('P' => "promote", 'D' => "demote", 'K' => "mute");
 $oldFilterName = ($oldFilter ? $filterNames[$oldFilter] : false);
 
 $userl = "<a href=\"showuser?id=$targetUser\">$targetUserName</a>";
@@ -92,12 +92,12 @@ if ($showList) {
             . "<p>Note that this is a personal customization that only "
             . "affects you (and only when you're logged in).  It won't "
             . "affect the order of reviews that other users see.";
-} else if ($action == 'plonk') {
-    $title = "$targetUserName - Plonk User";
+} else if ($action == 'mute') {
+    $title = "$targetUserName - Mute User";
     $newFilter = 'K';
-    $newFilterName = 'plonk';
-    $newFiltered = "plonked";
-    $expl = "Plonking $userl means that you'll <b>never</b> see $his "
+    $newFilterName = 'mute';
+    $newFiltered = "muted";
+    $expl = "Muting $userl means that you'll <b>never</b> see $his "
             . "reviews again, for this game or any other game.  They'll "
             . "be completely hidden from your view - IFDB won't even "
             . "mention that they exist.  This is the nuclear option, "
@@ -234,7 +234,7 @@ if ($showList) {
             .    "first when you view game pages"
             .  "<li>Demote members you don't find helpful, so their "
             .    "reviews go to the end of the list"
-            .  "<li>\"Plonk\" members who especially annoy you, hiding "
+            .  "<li>\"Mute\" members who especially annoy you, hiding "
             .    "their reviews from you entirely"
             . "</ul>"
             . "<p>Your filter list is currently empty.  You can add a "
@@ -246,7 +246,7 @@ if ($showList) {
 
         $typeMap = array('P' => 'Promoted',
                          'D' => 'Demoted',
-                         'K' => 'Plonked');
+                         'K' => 'Muted');
         for ($i = 0 ; $i < $rowcnt ; $i++) {
             list($fuid, $funame, $ftype) = mysql_fetch_row($result);
             $funame = htmlspecialcharx($funame);
@@ -262,8 +262,8 @@ if ($showList) {
                 echo "<a href=\"userfilter?user=$fuid&action=demote$from\""
                     . ">Demote</a> &nbsp; ";
             if ($ftype != 'K')
-                echo "<a href=\"userfilter?user=$fuid&action=plonk$from\""
-                    . ">Plonk</a> &nbsp; ";
+                echo "<a href=\"userfilter?user=$fuid&action=mute$from\""
+                    . ">Mute</a> &nbsp; ";
 
             echo "<a href=\"userfilter?user=$fuid&action=remove$from\""
                 . ">Remove filter</a></span></div>";

--- a/www/viewgame
+++ b/www/viewgame
@@ -3282,7 +3282,7 @@ if (count($inrefs) != 0 && !$historyView) {
             "$query order by $orderBy, moddate desc $limit", $db);
 
         // get the query total - it might differ from the overall total
-        // due to plonking or other filters
+        // due to muting or other filters
         $realtotcnt = ($ratingsView ? $ratingCntTot : $memberReviewCnt);
         $result2 = mysql_query("select found_rows()", $db);
         list($totcnt) = mysql_fetch_row($result2);


### PR DESCRIPTION
Fixes #455

I tested this by logging in as test@ifdb.org (Test Tester) and:
* Commenting on Admin's profile at `/showuser?id=0000000000000000`
* Posting a review
* Posting game news on the same game
* Creating a recommended list
* Creating a poll

Then, I logged in as ifdbadmin@ifdb.org and muted Test Tester.
* There was no sign of Test Tester on the home page
* There was no sign of Test Tester on the viewgame page where Test Tester posted a review and news
* The list and the poll didn't show up in search/browse pages sorted by Newest
* On Admin's profile page, the comment was counted, but hidden with italics, and Inbox didn't the comment at all

In the course of investigating this, I discovered that the home page "Polls" section wasn't honoring plonking/muting, so I fixed that in this PR, too.