### PR TITLE
Sort by estimated play time when searching and browsing games

### DIFF
--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -1040,8 +1040,8 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
                       . "on userScores_mv.userid = u.id";
     }
 
-    // Is we're sorting by estimated play time, make sure we select that and 
-    // join to the gametimes materialized view
+    // If we're sorting by estimated play time, make sure we select the play time and 
+    // join the gametimes materialized view
     if ($searchType == "game" && ($sortby == "short" || $sortby == "long")) {
 
         if (!isset($specialsUsed['playtime:'])) {

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -905,8 +905,8 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
                 'auth' => array('sort_author,', 'Sort by Author'),
                 'pnew' => array('published desc,', 'Latest Publication First'),
                 'pold' => array('sort_pub,', 'Earliest Publication First'),
-                'short' => array('rounded_median_time_in_minutes,', 'Shortest Play Time First'),
-                'long'  => array('rounded_median_time_in_minutes desc,', 'Longest Play Time First'),
+                'long'  => array('rounded_median_time_in_minutes desc, starsort desc,', 'Longest First'),
+                'short' => array('-rounded_median_time_in_minutes desc, starsort desc,', 'Shortest First'),
                 'rand' => array('rand(),', 'Random Order'));
             $defSortBy = 'ratu';
         } else {
@@ -927,8 +927,8 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
                                 'Rating Deviation - Low to High'),
                 'new' => array('published desc,', 'Latest Publication First'),
                 'old' => array('sort_pub,', 'Earliest Publication First'),
-                'short' => array('rounded_median_time_in_minutes,', 'Shortest Play Time First'),
-                'long'  => array('rounded_median_time_in_minutes desc,', 'Longest Play Time First'),
+                'long'  => array('rounded_median_time_in_minutes desc, starsort desc,', 'Longest First'),
+                'short' => array('-rounded_median_time_in_minutes desc, starsort desc,', 'Shortest First'),
                 'rand' => array('rand(),', 'Random Order'));
             if (count($words)) {
                 $defSortBy = 'rel';

--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -905,6 +905,8 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
                 'auth' => array('sort_author,', 'Sort by Author'),
                 'pnew' => array('published desc,', 'Latest Publication First'),
                 'pold' => array('sort_pub,', 'Earliest Publication First'),
+                'short' => array('rounded_median_time_in_minutes,', 'Shortest Play Time First'),
+                'long'  => array('rounded_median_time_in_minutes desc,', 'Longest Play Time First'),
                 'rand' => array('rand(),', 'Random Order'));
             $defSortBy = 'ratu';
         } else {
@@ -925,6 +927,8 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
                                 'Rating Deviation - Low to High'),
                 'new' => array('published desc,', 'Latest Publication First'),
                 'old' => array('sort_pub,', 'Earliest Publication First'),
+                'short' => array('rounded_median_time_in_minutes,', 'Shortest Play Time First'),
+                'long'  => array('rounded_median_time_in_minutes desc,', 'Longest Play Time First'),
                 'rand' => array('rand(),', 'Random Order'));
             if (count($words)) {
                 $defSortBy = 'rel';
@@ -1035,6 +1039,17 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
         $tableList .= " left outer join userScores_mv "
                       . "on userScores_mv.userid = u.id";
     }
+
+    // Is we're sorting by estimated play time, make sure we select that and 
+    // join to the gametimes materialized view
+    if ($searchType == "game" && ($sortby == "short" || $sortby == "long")) {
+
+        if (!isset($specialsUsed['playtime:'])) {
+            $selectList .= ", rounded_median_time_in_minutes";
+            $tableList .= " left outer join gametimes_mv on games.id = gametimes_mv.gameid";
+        }
+    }
+    
 
     // Build tags join
     $tagsJoin = "";
@@ -1150,7 +1165,7 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
                   . "An error occurred searching the database.</span><p>";
 
 // DEBUG
-//        if (get_req_data('debug') == 'SEARCH')
+//      if (get_req_data('debug') == 'SEARCH')
 //            $errMsg = "<p><span class=errmsg>Database error:</span><p>" . mysql_error($db)
 //                      . "</p>Query:<p>" . htmlspecialcharx($sql) . "</p>";
     }


### PR DESCRIPTION
Add "longest first" and "shortest first" to the sorting controls for games. Games with no estimated play time are sorted to the end. Games with the same time are then sorted by rating.

Fixes #1051.

(Although now I'm wondering if we should sort by relevance before sorting by rating, just in case there are search terms.)

**Update:** I looked into the relevance thing and it seems a little complicated (it's handled separately from the other sorting options, and is later on in the code), so maybe it's not worth it to do that. I'm not sure if we should even use the starsort here as a tie breaker. We could just not sort the games a second time. Or if we do sort games a second time, if they could be sorted at random. (That night confuse people, though, if they run a search more than once and get different results.)