### PR TITLE
Add view transitions to coverart on game details pages

### DIFF
--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -60,6 +60,16 @@ html {
     scroll-behavior: smooth;
 }
 
+@view-transition {
+    navigation: auto;
+}
+
+@media (prefers-reduced-motion: reduce) {
+    @view-transition {
+        navigation: none;
+    }
+}
+
 *, *:before, *:after {
   box-sizing: inherit;
 }

--- a/www/ifdbutil.js
+++ b/www/ifdbutil.js
@@ -279,3 +279,50 @@ async function check_ifid_in_ifwiki(ifid) {
     } catch (e) {}
     return false;
 }
+
+async function setTemporaryViewTransitionNames(entries, vtPromise) {
+    for (const [$el, name] of entries) {
+        if ($el) $el.style.viewTransitionName = name;
+    }
+
+    await vtPromise;
+
+    for (const [$el, name] of entries) {
+        if ($el) $el.style.viewTransitionName = '';
+    }
+}
+
+window.addEventListener('pageswap', async (e) => {
+    if (e.viewTransition) {
+        const targetUrl = new URL(e.activation.entry.url);
+
+        // Navigating to a game details page
+        if (targetUrl.pathname === '/viewgame') {
+            const id = targetUrl.searchParams.get('id');
+
+            // Set view-transition-name values on the clicked row
+            // Clean up after the page got replaced
+            setTemporaryViewTransitionNames([
+                [document.querySelector(`#coverart-${id}`), 'coverart'],
+            ], e.viewTransition.finished);
+        }
+    }
+});
+
+window.addEventListener('pagereveal', async (e) => {
+    if (e.viewTransition && window.navigation) {
+        const fromURL = new URL(navigation.activation.from.url);
+        const currentURL = new URL(navigation.activation.entry.url);
+
+        // Navigating from a profile page back to the homepage
+        if (fromURL.pathname === '/viewgame') {
+            const id = fromURL.searchParams.get('id');
+
+            // Set view-transition-name values on the elements in the list
+            // Clean up after the snapshots have been taken
+            setTemporaryViewTransitionNames([
+                [document.querySelector(`#coverart-${id}`), 'coverart'],
+            ], e.viewTransition.ready);
+        }
+    }
+});

--- a/www/util.php
+++ b/www/util.php
@@ -2810,7 +2810,7 @@ function coverArtThumbnail($id, $size, $version, $params = "") {
     }
     global $nonce;
     return "<style nonce='$nonce'>.coverart__img { max-width: 35vw; height: auto; }</style>"
-        ."<img class='coverart__img' loading='lazy' srcset=\"$thumbnail{$size}x$size$params, $thumbnail{$x15}x$x15$params 1.5x, $thumbnail{$x2}x$x2$params 2x, $thumbnail{$x3}x$x3$params 3x\" src=\"$thumbnail{$size}x$size$params\" height=$size width=$size border=0 alt=\"\">";
+        ."<img id='coverart-$id' class='coverart__img' loading='lazy' srcset=\"$thumbnail{$size}x$size$params, $thumbnail{$x15}x$x15$params 1.5x, $thumbnail{$x2}x$x2$params 2x, $thumbnail{$x3}x$x3$params 3x\" src=\"$thumbnail{$size}x$size$params\" height=$size width=$size border=0 alt=\"\">";
 }
 
 // ----------------------------------------------------------------------------

--- a/www/viewgame
+++ b/www/viewgame
@@ -1719,6 +1719,11 @@ if ($hasart) {
            <div class=coverart>
 
               <a href="<?php echo $arthref ?>&ldesc">
+                 <style nonce="<?php global $nonce; echo $nonce; ?>">
+                    #coverart-<?= $id ?> {
+                        view-transition-name: coverart;
+                    }
+                 </style>
                  <?php echo coverArtThumbnail($id, 175, isset($_REQUEST['version']) ? $_REQUEST['version'] : $pagevsn); ?>
               </a>
            </div>


### PR DESCRIPTION
The view transition API is brand new in 2024. It released just a couple weeks ago in Safari 18.2 and in June in Chrome 126. It's not available in Firefox yet, but that's fine, because it's a progressive enhancement.

(I'm not even sure this is a good idea to implement, but I wanted to play around with this API, so, here we are.)

https://github.com/user-attachments/assets/1b24e445-7524-4323-9def-133d7e60cfa1

