### PR TITLE
`#ratings:` search should use `numRatingsInAvg` not `numRatingsTotal`

### DIFF
--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -234,7 +234,7 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
             "rating:" => array("avgRating", 1, true),
             "#reviews:" => array("numMemberReviews",1, true),
             "ratingdev:" => array("stdDevRating", 1, true),
-            "#ratings:" => array("numRatingsTotal", 1, true),
+            "#ratings:" => array("numRatingsInAvg", 1, true),
             "forgiveness:" => array("forgiveness", 0),
             "language:" => array("language", 99),
             "author:" => array("author", 99),


### PR DESCRIPTION
`numRatingsInAvg` is what we display in search results. Querying a different number from what we display made the search results look wrong.

Fixes #1252