### PR TITLE
Ensure all games appear in `gameRatingsSandbox0` view

### DIFF
--- a/sql/unscrub-ifarchive.sql
+++ b/sql/unscrub-ifarchive.sql
@@ -429,15 +429,19 @@ from (
               `ifdb`.`reviews`.`review` is not null AS `hasReview`
             from (
                 `ifdb`.`games`
-                left outer join `ifdb`.`reviews` on (`ifdb`.`games`.`id` = `ifdb`.`reviews`.`gameid`)
-                left outer join `ifdb`.`users` on(`ifdb`.`reviews`.`userid` = `ifdb`.`users`.`id`)
+                left outer join `ifdb`.`reviews` on (
+                  `ifdb`.`games`.`id` = `ifdb`.`reviews`.`gameid`
+                  and ifnull(
+                    current_timestamp() > `ifdb`.`reviews`.`embargodate`,
+                    1
+                  )
+                  and `ifdb`.`reviews`.`special` is null
+                )
+                left outer join `ifdb`.`users` on (
+                  `ifdb`.`reviews`.`userid` = `ifdb`.`users`.`id`
+                  and ifnull(`ifdb`.`users`.`Sandbox`, 0) = 0
+                )
               )
-            where ifnull(`ifdb`.`users`.`Sandbox`, 0) = 0
-              and ifnull(
-                current_timestamp() > `ifdb`.`reviews`.`embargodate`,
-                1
-              )
-              and `ifdb`.`reviews`.`special` is null
             group by `ifdb`.`reviews`.`rating`,
               `ifdb`.`games`.`id`,
               ifnull(`ifdb`.`reviews`.`RFlags`, 0) & 2,
@@ -596,15 +600,18 @@ from (
               `ifdb`.`reviews`.`review` is not null AS `hasReview`
             from (
                 `ifdb`.`games`
-                left outer join `ifdb`.`reviews` on (`ifdb`.`games`.`id` = `ifdb`.`reviews`.`gameid`)
-                left outer join `ifdb`.`users` on(`ifdb`.`reviews`.`userid` = `ifdb`.`users`.`id`)
+                left outer join `ifdb`.`reviews` on (
+                  `ifdb`.`games`.`id` = `ifdb`.`reviews`.`gameid`
+                  and ifnull(
+                    current_timestamp() > `ifdb`.`reviews`.`embargodate`,
+                    1
+                  )
+                  and `ifdb`.`reviews`.`special` is null
+                )
+                left outer join `ifdb`.`users` on (
+                  `ifdb`.`reviews`.`userid` = `ifdb`.`users`.`id`
+                )
               )
-            where ifnull(`ifdb`.`users`.`Sandbox`, 0) in (0, 1)
-              and ifnull(
-                current_timestamp() > `ifdb`.`reviews`.`embargodate`,
-                1
-              )
-              and `ifdb`.`reviews`.`special` is null
             group by `ifdb`.`reviews`.`rating`,
               `ifdb`.`games`.`id`,
               ifnull(`ifdb`.`reviews`.`RFlags`, 0) & 2,


### PR DESCRIPTION
We were filtering out special reviews, embargoed reviews, and sandboxed reviews with the `where` clause, but this meant that games that had reviews but _only_ special reviews were excluded from the view completely.

Now, we've moved the filters into the criteria for the `left outer join`s. If there happen to be no rows that match those criteria, that's fine, it's an outer join, so we'll still have at least one row per game in the `grouped` query results.

For example, zz69axowzyl0htmh "Murder Mansion" had just one special review. Previously, the `grouped` query returned 0 rows for this game, now it returns one row with `count: 0` `rating: NULL`.

Fixes #1255