### PR TITLE
Suppress buried game warning on first Browse page

### DIFF
--- a/www/search
+++ b/www/search
@@ -1267,7 +1267,7 @@ else if ($term || $browse)
         echo "</div>";
 
         $showFlagged = isset($_GET['showFlagged']) && $_GET['showFlagged'];
-        if (!$showFlagged && $searchType == "game") {
+        if (!$showFlagged && $searchType == "game" && (!$browse || $pg != 1)) {
             for ($i = 0 ; $i < count($rows) ; $i++) {
                 $row = $rows[$i];
                 $flags = $row['flags'];


### PR DESCRIPTION
Fixing #1256 seems to have made some buried games appear on the first page of Browse results. Let's just suppress the warning on the first page of browse results.