### PR TITLE
searchutil.php: check for $term rather than a where clause to see if we're searching or browsing

### DIFF
--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -1113,7 +1113,7 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
     }
 
     $sql_calc_found_rows = "sql_calc_found_rows";
-    if ($searchType === "game" && $where === "1") {
+    if ($searchType === "game" && !$term) {
         // `sql_calc_found_rows` forces the query to ignore the `limit` clause in order to count all possible results.
         // But when browsing for all games, we can do a fast `count(*)` query instead
         $sql_calc_found_rows = "";


### PR DESCRIPTION
This attempts to fix a bug reported by Mathbrush at intfiction.

<h2>Before:</h2>

Do a search for 
`authorid:nufzrftl37o9rw5t`

**What should happen:** The number shown at the top of the page should match the number of games Mathbrush has written.

**What actually happens:** the search page says it is displaying results 1–100 of 14092. If I click "Next," it takes me to another page with no games on it.

I don't really understand why, but if I run this search and log the query, I see no where clause other than "where 1". So I changed the condition to check for $term instead of checking the where clause.

<h2>After:</h2>

Do a search for 
`authorid:nufzrftl37o9rw5t`

The search page says it is displaying 1–27 of 27. There is no "next" link.
