### PR TITLE
Correctly exclude sandboxed ratings from `gameRatingsSandbox0`

### DIFF
--- a/sql/unscrub-ifarchive.sql
+++ b/sql/unscrub-ifarchive.sql
@@ -436,10 +436,7 @@ from (
                     1
                   )
                   and `ifdb`.`reviews`.`special` is null
-                )
-                left outer join `ifdb`.`users` on (
-                  `ifdb`.`reviews`.`userid` = `ifdb`.`users`.`id`
-                  and ifnull(`ifdb`.`users`.`Sandbox`, 0) = 0
+                  and `ifdb`.`reviews`.`userid` not in (select `ifdb`.`users`.`id` from `ifdb`.`users` where `ifdb`.`users`.`Sandbox` = 1)
                 )
               )
             group by `ifdb`.`reviews`.`rating`,
@@ -607,9 +604,6 @@ from (
                     1
                   )
                   and `ifdb`.`reviews`.`special` is null
-                )
-                left outer join `ifdb`.`users` on (
-                  `ifdb`.`reviews`.`userid` = `ifdb`.`users`.`id`
                 )
               )
             group by `ifdb`.`reviews`.`rating`,


### PR DESCRIPTION
Prior to https://github.com/iftechfoundation/ifdb/pull/1256, we were excluding special reviews, embargoed reviews, and sandboxed reviews with a `where` clause, but this meant that some games were missing from `gameRatingsSandbox0`, when all of a game's reviews were special reviews. In https://github.com/iftechfoundation/ifdb/pull/1256, I removed the `where` clause and turned them into criteria on the `join` clauses.

This worked fine for special reviews and embargoed reviews, but it didn't work for sandboxed reviews. We did a left join to the `users` table, excluding sandboxed users there, but we didn't use the results of that join. We never used `users.userid` for anything, and we never excluded any sandboxed reviews in the criteria for the `reviews` table.

I've removed the join to `users` and replaced it with another criterion on the join to the `reviews` table, excluding reviews where the `userid` is sandboxed.

I've confirmed that this still excludes special and embargoed reviews, and now it excludes sandboxed reviews, too. Also, I've confirmed that the number of rows matches the number of rows in the games table, so every game has a matching row in `gameRatingsSandbox0`.

Fixes https://github.com/iftechfoundation/ifdb/issues/1263

This is impossible-ish to test for folks who don't have access to the prod database (containing the actual sandboxed users), but:

# before

```
MariaDB [ifdb]> select * from gameRatingsSandbox0_mv where gameid = 'aearuuxv83plclpl' \G
*************************** 1. row ***************************
          gameid: aearuuxv83plclpl
          rated1: 4
          rated2: 0
          rated3: 6
          rated4: 35
          rated5: 211
 numRatingsInAvg: 256
 numRatingsTotal: 257
numMemberReviews: 25
       avgRating: 4.75390625
    stdDevRating: 0.6480020186781346
        starsort: 4.647653112791922
         updated: 2025-01-18
```

# after

```
MariaDB [ifdb]> select * from gameRatingsSandbox0_mv where gameid = 'aearuuxv83plclpl' \G
*************************** 1. row ***************************
          gameid: aearuuxv83plclpl
          rated1: 0
          rated2: 0
          rated3: 6
          rated4: 34
          rated5: 211
 numRatingsInAvg: 251
 numRatingsTotal: 251
numMemberReviews: 23
       avgRating: 4.816733067
    stdDevRating: 0.44439726455859596
        starsort: 4.725262803850697
         updated: 2025-01-19
```