### PR TITLE
Always generate a 16-digit TUID

### DIFF
--- a/www/util.php
+++ b/www/util.php
@@ -293,13 +293,11 @@ function generateTUID($db, $tableCol, $maxtries)
     // try up to $maxtries times
     for ($tries = 0, $result = 1 ; $result && $tries < $maxtries ; $tries++)
     {
+        $tuid = "";
         // generate a random ID
-        $tuid = base_convert(strval(rand(0, 46655)), 10, 36)
-                . base_convert(strval(rand(0, 46655)), 10, 36)
-                . base_convert(strval(rand(0, 46655)), 10, 36)
-                . base_convert(strval(rand(0, 46655)), 10, 36)
-                . base_convert(strval(rand(0, 46655)), 10, 36)
-                . base_convert(strval(rand(0, 35)), 10, 36);
+        for ($i = 0; $i < 16; $i++) {
+            $tuid .= base_convert(strval(rand(0, 35)), 10, 36);
+        }
 
         if (!$tableCol)
             return $tuid;


### PR DESCRIPTION
Fixes #1270

The old version of this code was trying to compute three base-36 digits five times in a row, and then appending one last random base 36 digit. In this implementation, I'm just generating 16 random digits, one at a time.

But, this kinda creeps me out, because I don't understand why the old algorithm was doing what it did.

I _do_ understand the bug in the old code, I think. If `rand(0, 46655)` returned 0, `base_convert` wouldn't return `000`, it would just return `0`. If `rand()` returned 36, it wouldn't generate `010`, it would just generate `10`. Thus, the generated TUID could wind up too short if we get unlucky numbers from the randomizer.

Initially, I tried fixing the old algorithm by padding the result with `0`s if `base_convert(rand())` generated fewer than three digits. But then I asked myself: wait, why is it generating _three_ digits at a time _five_ times in a row? And then tossing on one last digit at the end?

I couldn't think of a good reason. Was it trying to minimize calls to `rand()`? (Why? Performance…?? But how would that even help???)

Anyway, I still think this is worth merging, even if we can't come up with any reason why the old code was written that way, but it's always creepy to "fix" code when you don't know why it was written weird in the first place.