### PR TITLE
Make game searches do an inner join to `gameRatingsSandbox0_mv`

### DIFF
--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -285,15 +285,8 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse)
         $baseWhere = "";
         $groupBy = "";
         $baseOrderBy = "";
-        if ($browse && ($sortby == "" || $sortby == "ratu" || $sortby == "ratd" || $sortby == "rcu")) {
-            // when sorting by highest/lowest/most ratings, we can optimize by
-            // fetching the top N from the gameRatingsView
-            $tableList = "games
-                          join ".getGameRatingsView($db)." on games.id = gameid";
-        } else {
-            $tableList = "games
-                          left join ".getGameRatingsView($db)." on games.id = gameid";
-        }
+        $tableList = "games
+                      join ".getGameRatingsView($db)." on games.id = gameid";
         $matchCols = "title, author, `desc`, tags";
         $likeCol = "title";
         $summaryDesc = "Games";


### PR DESCRIPTION
The code was doing a `left join` (aka a `left outer join`) to `gameRatingsSandbox0_mv` unless `$browse` mode is enabled and you're using one of the specified sort orders, in which case it does a simple `join` (an `inner join`).

I wrote this code in PR #270, specifically in 3bd2c7a5d026beeba2380ad4adc325dc42631bf8. But… why did I write that? Why didn't I just do an inner join in all cases?

To be quite honest, I can't remember. I bet the issue was that `gameRatingsSandbox0_mv` didn't have exactly as many rows as the `games` table. (And I bet I was misusing `$browse` … it probably should have been `!$term`.)

I believe that `gameRatingsSandbox0_mv` will always have a row for every game in the games table, now that we've merged #1266, and so it should be safe to do an inner join in all cases.