### PR TITLE
util.php: fix convertTimeToText function

### DIFF
--- a/www/util.php
+++ b/www/util.php
@@ -2836,9 +2836,11 @@ function collapsedAuthors($authors) {
     return $str;
 }
 
-
+// ----------------------------------------------------------------------------
+//
 // Convert total minutes of play time into hours and minutes,
 // and then into text for display
+//
 function convertTimeToText($total_minutes) {
     // Convert total minutes of play time into hours and minutes
  	$h = floor($total_minutes/60);   
@@ -2846,7 +2848,7 @@ function convertTimeToText($total_minutes) {
     // Make a string to display the time
     $text="";
     if ($h >= 1) {
-        $text = $h . " ";
+        $text = "$h ";
         if ($h == 1) {
             $text .= "hour";
         } else {
@@ -2857,11 +2859,11 @@ function convertTimeToText($total_minutes) {
         }
     }
     if ($m >= 1) {
-        $text .= $m . " ";
+        $text .= "$m ";
         if ($m == 1) {
-            $text .= " minute";
+            $text .= "minute";
         } else {
-            $text .= " minutes";
+            $text .= "minutes";
         }
     }
     return $text;


### PR DESCRIPTION
The convertTimeToTextfunction was including an extra space between the number and the word "minutes" (e.g. "5  minutes"), but it wasn't visible unless you looked at the page source. (Do extra spaces get automatically ignored when displayed as HTML?)

To see the difference, go to for example /viewgame?id=2wbz3y8neawpd64z and view the page source.