### PR TITLE
Fix sorting `willplay:yes` by playtime

### DIFF
--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -656,7 +656,7 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse, $count_all_
                 }
 
                 $not = (preg_match("/^y.*/i", $txt) ? "" : "not");
-                $expr = "gameid $not in (select gameid from playedgames where userid = '$curuser')";
+                $expr = "games.id $not in (select gameid from playedgames where userid = '$curuser')";
                 break;
 
             case 'willplay':
@@ -666,7 +666,7 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse, $count_all_
                 }
 
                 $not = (preg_match("/^y.*/i", $txt) ? "" : "not");
-                $expr = "gameid $not in (select gameid from wishlists where userid = '$curuser')";
+                $expr = "games.id $not in (select gameid from wishlists where userid = '$curuser')";
                 break;
 
             case 'wontplay':
@@ -676,7 +676,7 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse, $count_all_
                 }
 
                 $not = (preg_match("/^y.*/i", $txt) ? "" : "not");
-                $expr = "gameid $not in (select gameid from unwishlists where userid = '$curuser')";
+                $expr = "games.id $not in (select gameid from unwishlists where userid = '$curuser')";
                 break;
 
 
@@ -687,7 +687,7 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse, $count_all_
                 }
 
                 $not = (preg_match("/^y.*/i", $txt) ? "" : "not");
-                $expr = "gameid $not in (select gameid from reviews where review is not null and userid = '$curuser')";
+                $expr = "games.id $not in (select gameid from reviews where review is not null and userid = '$curuser')";
                 break;
 
             case 'rated':
@@ -697,7 +697,7 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse, $count_all_
                 }
 
                 $not = (preg_match("/^y.*/i", $txt) ? "" : "not");
-                $expr = "gameid $not in (select gameid from reviews where rating is not null and userid = '$curuser')";
+                $expr = "games.id $not in (select gameid from reviews where rating is not null and userid = '$curuser')";
                 break;
 
             case 'author':


### PR DESCRIPTION
Fixes #1279

This was caused by #1265. Before that, the query did a `left join` to `wishlists wl` and added a `where wl.gameid is not null`. In #1265, I turned it into a subselect, `gameid in (select gameid from wishlists where userid = '$curuser')`.

This improved performance, and usually works, but when we join to `gametimes_mv`, `gameid` is ambiguous between `gametimes_mv.gameid` and `gameRatingsSandbox0_mv.gameid`.

Using `games.id` ensures that we're using an unambiguous field.