### PR TITLE
adminops: Add "recent activity by all users" tool

### DIFF
--- a/www/adminops
+++ b/www/adminops
@@ -75,6 +75,329 @@ if (isset($_REQUEST['adminemail'])) {
     exit();
 }
 
+
+//------------------ RECENT ACTIVITY BY ALL USERS --------------
+
+// For long author and title strings, cut off the 
+// string after a set number of characters and 
+// add "..." if any characters were removed.
+function shortenString($long_string) {
+    $short_string = substr($long_string,0,50);
+    if ($short_string != $long_string) {
+        $short_string .= "...";
+    }
+    return $short_string;
+}
+
+
+if (isset($_REQUEST['recentactivity'])) {
+    pageHeader("Recent activity by all users");
+    $days = 79; // how many days of recent activity to display
+    echo '<h1 id="recent-activity">Recent activity by all users</h1>';
+    echo '<p><a href="#recent-ratings">Ratings and reviews</a> | ';
+    echo '<a href="#recent-review-votes">Review votes</a> | ';
+    echo '<a href="#recent-edits">Page edits</a> | ';
+    echo '<a href="#recent-tags">Tags</a> | ';
+    echo '<a href="#recent-poll-votes">Poll votes</a>';
+    echo "</p><hr>";
+
+
+    // Find recent ratings and reviews
+    $result = mysqli_execute_query($db, 
+        'SELECT reviews.moddate AS reviewdatetime,
+                CASE WHEN reviews.createdate = reviews.moddate
+                     THEN "added"
+                     ELSE "edited"
+                     END AS action,
+                DATE_FORMAT(reviews.moddate, "%M %e, %Y") AS reviewdate,
+                reviews.userid AS reviewerid,
+                reviews.gameid,
+                reviews.rating,
+                reviews.review,
+                reviews.id as reviewid,
+                games.title AS gametitle,
+                games.author AS gameauthor,
+                users.name AS reviewername
+        FROM reviews 
+        LEFT JOIN games
+        ON reviews.gameid = games.id
+        LEFT JOIN users
+        ON reviews.userid = users.id
+        WHERE (reviews.moddate) > DATE_SUB(NOW(), INTERVAL ? DAY)
+        ORDER BY reviews.moddate', [$days]);
+
+    // Display recent ratings and reviews    
+    echo "<h2 id='recent-ratings'>Recent ratings and reviews:</h2>";
+    if ($result) {
+        $rows = mysqli_fetch_all($result, MYSQLI_ASSOC);
+        $date_heading = "";
+        foreach ($rows as $r) {
+            $review_date = $r['reviewdate'];
+            $reviewer_id = $r['reviewerid'];
+            $reviewer_name = $r['reviewername'];
+            $action = $r['action'];
+            $rating = "";
+            if ($r['rating']) {
+                $rating = $r['rating'];
+            } else {
+                $rating = "no";
+            }
+            $review_id = $r['reviewid'];
+            $rating_or_review = "";
+            if ($r['review'] != "") {
+                $rating_or_review = "review";
+            } else {
+                $rating_or_review = "rating";
+            }
+            $game_id = $r['gameid'];
+            $game_title = shortenString($r['gametitle']);
+            $game_author = shortenString($r['gameauthor']);
+            if ($review_date != $date_heading) {
+                if ($date_heading != "") {
+                    echo "</ul>";
+                }
+                $date_heading = $review_date;
+                echo "<h3>$date_heading</h3>";
+                echo "<ul>";
+            }
+            echo "<li><a href='/showuser?id=$reviewer_id'>$reviewer_name</a> ";
+            if ($action == "added") {
+                echo "added ";
+            } else if ($action == "edited") {
+                echo "edited a rating or review, now ";
+            }
+            echo "a {$rating}-star <a href='/viewgame?id={$game_id}&review={$review_id}'>$rating_or_review</a> ";
+            echo "of <i><a href='/viewgame?id={$game_id}'>$game_title</a></i> by $game_author.</li><br>";
+        }
+        echo "</ul>";
+    } else {
+        echo "<p>No ratings or reviews found from the past $days days.</p>";
+    }
+    echo '<a href="#recent-activity">Return to top</a><hr>';
+
+
+    // Find recent review helpfulness votes
+    $result = mysqli_execute_query($db, 
+    'SELECT reviewvotes.createdate AS votedatetime,
+        DATE_FORMAT(reviewvotes.create, "%M %e, %Y") AS votedate,
+        reviewvotes.userid as voterid,
+        reviewvotes.vote,
+        reviewvotes.reviewid,
+        reviews.gameid,
+        reviews.userid as reviewerid,
+        users.name AS reviewername
+    FROM reviewvotes
+    LEFT JOIN reviews
+        ON reviewvotes.reviewid = reviews.id
+    LEFT JOIN users
+        ON reviews.userid = users.id
+    WHERE (reviewvotes.createdate) > DATE_SUB(NOW(), INTERVAL ? DAY)
+    ORDER BY reviewvotes.createdate', [$days]);
+
+
+    // Display recent review helpfulness votes    
+    echo '<h2 id="recent-review-votes">Recent review helpfulness votes:</h2>';
+    if ($result) {
+        $rows = mysqli_fetch_all($result, MYSQLI_ASSOC);
+        $date_heading = "";
+        foreach ($rows as $r) {
+            $vote_date = $r['votedate'];
+            $voter_id = $r['voterid'];
+            $vote = $r['vote'];
+            $review_id = $r['reviewid'];
+            $reviewer_id = $r['reviewerid'];
+            $reviewer_name = shortenString($r['reviewername']);
+            if ($vote_date != $date_heading) {
+                if ($date_heading != "") {
+                    echo "</ul>";
+                }
+                $date_heading = $vote_date;
+                echo "<h3>$date_heading</h3>";
+                echo "<ul>";
+            }
+            echo "<li>User <a href='/showuser?id={$voter_id}'>$voter_id</a> ";
+            echo "voted $vote on a ";
+            echo "<a href='/viewgame?id={$game_id}&review={$review_id}'>review</a> ";
+            echo "by $reviewer_name.</li><br>";
+        }
+        echo "</ul>";
+    } else {
+        echo "<p>No review helpfulness votes found from the past $days days.</p>";
+    }
+    echo '<a href="#recent-activity">Return to top</a><hr>';
+
+
+    // Find recent page edits
+    $result = mysqli_execute_query($db, 
+    'SELECT games_history.moddate AS editdatetime,
+        DATE_FORMAT(games_history.moddate, "%M %e, %Y") AS editdate,
+        games_history.id as gameid,
+        games_history.editedby as editorid,
+        games.title AS gametitle,
+        games.author AS gameauthor,
+        users.name AS editorname
+    FROM games_history
+    LEFT JOIN games
+        ON games_history.id = games.id
+    LEFT JOIN users
+        ON games_history.editedby = users.id
+    WHERE (games_history.moddate) > DATE_SUB(NOW(), INTERVAL ? DAY)
+    ORDER BY games_history.moddate
+    LIMIT 100', [$days]);
+
+
+    // Display recent page edits
+    echo "<h2 id='recent-edits'>Recent page edits:</h2>";
+    if ($result) {
+        $rows = mysqli_fetch_all($result, MYSQLI_ASSOC);
+        $date_heading = "";
+        foreach ($rows as $r) {
+            $edit_date = $r['editdate'];
+            $editor_id = $r['editorid'];
+            $editor_name = $r['editorname'];
+            $game_id = $r['gameid'];
+            $game_title = shortenString($r['gametitle']);
+            $game_author = shortenString($r['gameauthor']);
+
+            if ($edit_date != $date_heading) {
+                if ($date_heading != "") {
+                    echo "</ul>";
+                }
+                $date_heading = $edit_date;
+                echo "<h3>$date_heading</h3>";
+                echo "<ul>";
+            }
+            echo "<li><a href='/showuser?id=$editor_id'>$editor_name</a> ";
+            echo "edited the page for ";
+            echo "<i><a href='/viewgame?id={$game_id}'>$game_title</a></i> ";
+            echo "by $game_author.</li></br>";
+        }
+        echo "</ul>";
+    } else {
+        echo "<p>No page edits found from the past $days days.</p>";
+    }
+    echo '<a href="#recent-activity">Return to top</a><hr>';
+
+
+    // Find recent tagging activity
+    $result = mysqli_execute_query($db, 
+    'SELECT gametags.moddate AS tagdatetime,
+        DATE_FORMAT(gametags.moddate, "%M %e, %Y") AS tagdate,
+        gametags.gameid,
+        gametags.userid as taggerid,
+        gametags.tag,
+        games.title AS gametitle,
+        games.author AS gameauthor
+      FROM gametags
+      LEFT JOIN games
+          ON gametags.gameid = games.id
+      WHERE (gametags.moddate) > DATE_SUB(NOW(), INTERVAL ? DAY)
+      ORDER BY gametags.moddate', [$days]);
+
+
+    // Display recent tagging activity
+    echo "<h2 id='recent-tags'>Recent tags:</h2>";
+    if ($result) {
+        $rows = mysqli_fetch_all($result, MYSQLI_ASSOC);
+        $date_heading = "";
+        foreach ($rows as $r) {
+            $tag_date = $r['tagdate'];
+            $tagger_id = $r['taggerid'];
+            $tag = $r['tag'];
+            $game_id = $r['gameid'];
+            $game_title = shortenString($r['gametitle']);
+            $game_author = shortenString($r['gameauthor']);
+
+            if ($tag_date != $date_heading) {
+                if ($date_heading != "") {
+                    echo "</ul>";
+                }
+                $date_heading = $tag_date;
+                echo "<h3>$date_heading</h3>";
+                echo "<ul>";
+            }
+            echo "<li>User <a href='/showuser?id=$tagger_id'>$tagger_id</a> ";
+            echo 'added the tag "' . $tag . '" to ';
+            echo "<i><a href='/viewgame?id={$game_id}'>$game_title</a></i> ";
+            echo "by $game_author.</li></br>";
+        }
+        echo "</ul>";
+    } else {
+        echo "<p>No tagging found from the past $days days.</p>";
+    }
+    echo '<a href="#recent-activity">Return to top</a><hr>';
+
+
+    // Find recent poll votes
+    $result = mysqli_execute_query($db, 
+        'SELECT pollvotes.votedate AS votedatetime,
+                DATE_FORMAT(pollvotes.votedate, "%M %e, %Y") AS votedate,
+                pollvotes.userid as voterid,
+                pollvotes.gameid,
+                pollvotes.quickquote,
+                pollvotes.notes,
+                pollvotes.pollid,
+                games.title AS gametitle,
+                games.author AS gameauthor,
+                users.name AS votername
+        FROM pollvotes
+        LEFT JOIN games
+            ON pollvotes.gameid = games.id
+        LEFT JOIN users
+            ON pollvotes.userid = users.id
+        WHERE (pollvotes.votedate) > DATE_SUB(NOW(), INTERVAL ? DAY)
+        ORDER BY pollvotes.votedate', [$days]);
+
+    // Display recent poll votes
+    echo "<h2 id='recent-poll-votes'>Recent poll votes:</h2>";
+    if ($result) {
+        $rows = mysqli_fetch_all($result, MYSQLI_ASSOC);
+        $date_heading = "";
+        foreach ($rows as $r) {
+            $vote_date = $r['votedate'];
+            $voter_id = $r['voterid'];
+            $voter_name = $r['votername'];
+            $quickquote = $r['quickquote'];
+            $notes = $r['notes'];
+            $game_id = $r['gameid'];
+            $game_title = shortenString($r['gametitle']);
+            $game_author = shortenString($r['gameauthor']);
+            $poll_id = $r['pollid'];
+            if ($vote_date != $date_heading) {
+                if ($date_heading != "") {
+                    echo "</ul>";
+                }
+                $date_heading = $vote_date;
+                echo "<h3>$date_heading</h3>";
+                echo "<ul>";
+            }
+            echo "<li><a href='/showuser?id=$voter_id'>$voter_name</a> voted for ";
+            echo "<i><a href='/viewgame?id={$game_id}'>$game_title</a></i> by $game_author ";
+            if ($quick_quote || $notes) {
+                echo 'with the comment "' ;
+                if ($quick_quote) {
+                    echo $quick_quote;
+                    if ($notes) {
+                        echo ": $notes";
+                    }
+                } else {
+                    echo $notes;
+                }
+                echo '" ';
+            }
+            echo "in poll <a href='/poll?id={$poll_id}'>$poll_id</a>.</li><br>";  
+        }
+        echo "</ul>";
+    } else {
+        echo "<p>No poll votes found from the past $days days.</p>";
+    }
+    echo '<a href="#recent-activity">Return to top</a><hr>';
+
+} // if (isset($_REQUEST['recentactivity']))
+             
+//----------------- end of recent activity -------------
+
+
 if (isset($_REQUEST['bulkaddtag'])) {
     $tag = $_POST['tag'] ?? null;
     $tag2 = $_POST['tag2'] ?? null;
@@ -2601,6 +2924,7 @@ function cleanutf8($str)
 <a href="adminops?cleanpix">Delete orphaned images</a><br>
 <a href="adminops?users&sortby=new">User list</a><br>
 <a href="adminops?finduser">User search</a><br>
+<a href="adminops?recentactivity">Recent activity by all users</a><br>
 <a href="adminops?adminemail">Send admin email</a><br>
 <a href="adminops?burygame">Bury game</a><br>
 <a href="adminops?bulkaddtag">Bulk add tags</a><br>


### PR DESCRIPTION
Fixes https://github.com/iftechfoundation/ifdb/issues/834

This PR adds a tool to the admin panel that shows recent activity for all users in five categories: ratings/reviews, poll votes, page edits, tags, and 'helpful' review votes.

When testing, please change the $days variable (line 95) to a number that corresponds to how old the most recent data is. E.g. if the newest available data is 80 days old, and you want to show three days of data, set it to 83.

Known issues:

1. Before merging, $days should be changed to 3, since that's how many days of recent activity the mods requested.
2. There's supposed to be a "no [type of activity] was found" message that displays when there is no activity of that type to show, and it doesn't always display, even if you reduce $days to the point that there's no activity to show.  I don't know why.
3. The review helpfulness votes section doesn't work, and I don't know how to test it (that voter data is not public).
4. I haven't tried to tackle or test anonymous poll votes.