### PR TITLE
Prevent logo from overlapping navbar

### DIFF
--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -1367,7 +1367,7 @@ span.headlineRss {
         top: calc(55px + 2.5em);
         right: 0;
         background-color: #e8e8e8;
-        z-index: 1;
+        z-index: 2;
     }
 
     .mobile-menu ul a{
@@ -1551,6 +1551,7 @@ div.scroll-links {
     width: revert;
     justify-content: center;
     padding: 0.5em 0;
+    z-index: 1;
 }
 
 .scroll-links ul {


### PR DESCRIPTION
Fixes #1247. The logo's `filter` property was causing it to render over the navbar. So I gave the navbar a z-index of 1. But the mobile menu already had a z-index of 1, so I bumped that up to 2.