### PR TITLE
Lower caps

### DIFF
--- a/www/util.php
+++ b/www/util.php
@@ -239,7 +239,7 @@ function get_req_data($id)
     $val = (isset($_POST[$id]) && $_POST[$id]) ? $_POST[$id] :
            (isset($_REQUEST[$id]) ? $_REQUEST[$id] : "");
     //Convert to lowercase
-    $val = $val.toLowerCase();    
+    $val = strtolower($val);    
     // return the result    
     return $val;
 }

--- a/www/util.php
+++ b/www/util.php
@@ -238,8 +238,10 @@ function get_req_data($id)
     // get the raw value from the posted data
     $val = (isset($_POST[$id]) && $_POST[$id]) ? $_POST[$id] :
            (isset($_REQUEST[$id]) ? $_REQUEST[$id] : "");
-    //Convert to lowercase
-    $val = strtolower($val);    
+   
+    // convert to lowercase
+    $val = mb_strtolower($val, 'UTF-8');
+   
     // return the result    
     return $val;
 }

--- a/www/util.php
+++ b/www/util.php
@@ -238,8 +238,9 @@ function get_req_data($id)
     // get the raw value from the posted data
     $val = (isset($_POST[$id]) && $_POST[$id]) ? $_POST[$id] :
            (isset($_REQUEST[$id]) ? $_REQUEST[$id] : "");
-
-    // return the result
+    //Convert to lowercase
+    $val = $val.toLowerCase();    
+    // return the result    
     return $val;
 }
 


### PR DESCRIPTION
Right now, typing "System:adventuron" into the search bar provides results but just searches for the words 'system' and 'adventuron'. Typing "system:adventuron" correctly returns games in the adventuron system.

This update is intended to reduce the incoming data to lowercase. I've tested it in codespace and it seems to work. 

I was worried it might mess up non-standard characters, but it seems like we have trouble with non-standard characters anyway. For instance, searching for "年" doesn't bring up 年獸文字冒險遊戲 | The Beast, Nian: A Chinese Text Adventure.

This is my first pull request in a while (I took a gihub class for certification and want to see if it helped make this all make more sense), so feel free to let me know if this is the wrong way to do things.