### PR TITLE
Dealing with upper-case special search terms

### DIFF
--- a/www/searchutil.php
+++ b/www/searchutil.php
@@ -341,7 +341,7 @@ function doSearch($db, $term, $searchType, $sortby, $limit, $browse, $count_all_
         }
 
         // pull out this word
-        $w = substr($term, $start, $ofs - $start);
+        $w = mb_strtolower(substr($term, $start, $ofs - $start));
 
         // if it's unquoted, check for special prefixes
         if (!$quoted


### PR DESCRIPTION
Right now, typing "System:adventuron" into the search bar provides results but just searches for the words 'system' and 'adventuron'. Typing "system:adventuron" correctly returns games in the adventuron system.

This update is intended to reduce the incoming data to lowercase. I've tested it in codespace and it seems to work. I had an earlier pull request that ended up making all text input lowercase. This update only changes words in search right before they're checked if they're a special term or not.

I was worried it might mess up non-standard characters, but it seems like we have trouble with non-standard characters anyway. For instance, searching for "年" doesn't bring up 年獸文字冒險遊戲 | The Beast, Nian: A Chinese Text Adventure.

This is my first pull request in a while (I took a github class for certification and want to see if it helped make this all make more sense), so feel free to let me know if this is the wrong way to do things.