### PR TITLE
Remove limit from helpfulness votes.

### DIFF
--- a/www/adminops
+++ b/www/adminops
@@ -208,7 +208,7 @@ if (isset($_REQUEST['recentactivity'])) {
         LEFT JOIN users
             ON reviews.userid = users.id
         WHERE (reviewvotes.createdate) > DATE_SUB(NOW(), INTERVAL ? DAY)
-        ORDER BY reviewvotes.createdate DESC LIMIT 100', [$recent_days]);
+        ORDER BY reviewvotes.createdate DESC', [$recent_days]);
 
 
     // Display recent review helpfulness votes    


### PR DESCRIPTION
In the [PR for the mod recent activity tool (#1284)](https://github.com/iftechfoundation/ifdb/pull/1284), I wrote

> The limit on the reviewvotes query (currently in line 211)
>         `ORDER BY reviewvotes.createdate DESC LIMIT 100', [$recent_days]);`
> exists only because of https://github.com/iftechfoundation/ifdb/issues/1286. The limit should probably be removed after the createdate column in the reviewvotes table gets sorted out.

The dates in the createdate column are no longer presenting a problem, so this PR removes that limit.