### PR TITLE
Include series/seriesnumber in viewgame API

### DIFF
--- a/www/viewgame-components/viewgame-api.php
+++ b/www/viewgame-components/viewgame-api.php
@@ -140,6 +140,13 @@ if (isset($_REQUEST['ifiction']) || $json)
     if ($desc)
         $bibliographic['description'] = $desc;
 
+    if (!isEmpty($seriesname)) {
+        $bibliographic['series'] = $seriesname;
+        if (!isEmpty($seriesnum)) {
+            $bibliographic['seriesnumber'] = $seriesnum;
+        }
+    }
+
     if ($website)
         $contacts['url'] = $website;
 


### PR DESCRIPTION
An odd oversight. The `putific` API handles series/seriesnumber as inputs, but the `viewgame` API doesn't display them in the output.