### PR TITLE
Add "Tips" link to header and footer

### DIFF
--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -1350,6 +1350,10 @@ span.headlineRss {
         display: none;
     }
 
+    #topbar-tips {
+        display: none;
+    }
+
     #main-nav-wrapper{
         padding: 0;
     }

--- a/www/pagetpl.php
+++ b/www/pagetpl.php
@@ -102,6 +102,7 @@ function pageHeader($title, $focusCtl = false, $extraOnLoad = false,
         <nav id="main-nav" class="main-nav">
             <div class="nav-left">
                 <a id="topbar-home" href="/">Home</a>
+                <a id="topbar-tips" href="/tips">Tips</a>
                 <a id="topbar-browse" href="/search?browse">Browse</a>
                 <form class= "searchbar-wrapper" method="get" action="/search" name="search" role="search">
                         <input id="topbar-searchbar" type="search" name="searchbar" placeholder="Search for games...">
@@ -182,6 +183,7 @@ function pageFooter()
 
 <div class="footer prerender-moderate">
 <a class="nav" id="footer-home" href="/">IFDB Home</a> |
+<a class="nav" id="" href="/tips">Tips</a> |
 <a class="nav" id="footer-contact" href="/contact">Contact Us</a> |
 <a class="nav" id="footer-coc" href="/code-of-conduct">Code of Conduct</a> |
 <a class="nav" id="footer-tos" href="/tos">Terms of Service</a> |

--- a/www/pagetpl.php
+++ b/www/pagetpl.php
@@ -183,7 +183,7 @@ function pageFooter()
 
 <div class="footer prerender-moderate">
 <a class="nav" id="footer-home" href="/">IFDB Home</a> |
-<a class="nav" id="" href="/tips">Tips</a> |
+<a class="nav" id="footer-tips" href="/tips">Tips</a> |
 <a class="nav" id="footer-contact" href="/contact">Contact Us</a> |
 <a class="nav" id="footer-coc" href="/code-of-conduct">Code of Conduct</a> |
 <a class="nav" id="footer-tos" href="/tos">Terms of Service</a> |


### PR DESCRIPTION
Fixes [Tips link is not visible enough (home page) ](https://github.com/iftechfoundation/ifdb/issues/763):

Added a "Tips" link going to the /tips page in both the header and the small list of links in the footer.

Header:
<img width="900" height="138" alt="image1" src="https://github.com/user-attachments/assets/5f78c118-eebd-41db-9389-b1cd837395d9" />

Footer:
<img width="629" height="137" alt="image2" src="https://github.com/user-attachments/assets/a66e31be-2d37-4ca4-af15-4aec0f1bb014" />

The Tips link in the header disappears at low screen widths, just like the header's Home link. I did this to save space. Saving space is also why the link is called "Tips" and not "Tips & More" or "Tips & Info". A longer link name clogs up the top navbar when the user is logged in and has just enough screen width to get the full version of the top navbar and not the mobile version.

Iniquit addressed the issue first in [this pull request](https://github.com/iftechfoundation/ifdb/pull/83), but it never made its way into the main code.