### PR TITLE
Redesign the small footer of a review and add a "Direct link" section

### DIFF
--- a/www/reviews.php
+++ b/www/reviews.php
@@ -436,7 +436,7 @@ function showReview($db, $gameid, $rec, $specialNames, $optionFlags = 0)
     }
 
     // set up the comment controls, if applicable
-    $commentCtls = $barCommentCtl = "";
+    $commentCtls = $barCommentCtls = "";
     if ($showCommentCtls
         && ($curuser == $userid || ($dfltComments && $showVoteCtls))) {
 
@@ -450,19 +450,30 @@ function showReview($db, $gameid, $rec, $specialNames, $optionFlags = 0)
         }
 
         // set up the <a href> for adding a comment
-        $addCommentLink = "<a href=\"reviewcomment?review=$reviewid\">";
+        $addCommentLink = "<a title=\"Comment on this review\" 
+                             href=\"reviewcomment?review=$reviewid\">";
 
         // generate the controls, depending on the existing comment count
-        if ($commentCount == 0) {
-            $commentCtls = "{$addCommentLink}Add a comment</a>";
-        } else {
-            $commentCtls =
-                "<a href=\"viewgame?id=$gameid&review=$reviewid#comments\">"
-                . "View comments ($commentCount)</a> - "
-                . "{$addCommentLink}Add comment</a>";
+        if ($curuser) {
+            if ($commentCount == 0) {
+                $commentCtls = "{$addCommentLink}Add a comment</a>";
+            } else {
+                $commentCtls = "<a title=\"Direct link to comments\" 
+                    href=\"viewgame?id=$gameid&review=$reviewid#comments\">
+                    View comments ($commentCount)</a>";
+            }
+        }
+        else {
+            if ($commentCount > 0) {
+                $commentCtls = "<a title=\"Direct link to comments\" 
+                    href=\"viewgame?id=$gameid&review=$reviewid#comments\">
+                    View comments ($commentCount)</a>";
+            }
         }
 
-        $barCommentCtls = "| $commentCtls";
+        if ($commentCtls) {
+            $barCommentCtls = "| $commentCtls";
+        }
     }
 
     // add any special notes
@@ -483,15 +494,18 @@ function showReview($db, $gameid, $rec, $specialNames, $optionFlags = 0)
     if ($curuser == $userid) {
 
         echo "<div class=smallfoot><span class=details>
+               <a title=\"Direct link to this review\"
+               href=\"viewgame?id=$gameid&review=$reviewid\">Direct link</a>
+               $barCommentCtls | 
                <i>You wrote this review -
                <a href=\"review?id=$gameid&userid=$userid\">Revise it</a></i>
-               | <a href=\"viewgame?id=$gameid&review=$reviewid\">Direct link</a> $barCommentCtls</span></div>";
+               </span></div>";
 
     } else if ($specialCode == 'external') {
 
         if ($xurl)
-            echo "<span class=details>"
-                . "<a href=\"$xurl\">See the full review</a></span><br>";
+            echo "<span class=details>
+                  <a href=\"$xurl\">See the full review</a></span><br>";
 
     } else if (!$isSpecial && $showVoteCtls) {
 
@@ -506,13 +520,16 @@ function showReview($db, $gameid, $rec, $specialNames, $optionFlags = 0)
         }
         global $nonce;
 
-        echo "<div class=smallfoot><span class=details>";
+        echo "<div class=smallfoot><span class=details>
+            <a href=\"viewgame?id=$gameid&review=$reviewid\" 
+            title=\"Direct link to this review\">Direct link</a> 
+            $barCommentCtls | ";
 
         if (!$curuser) {
-            echo "You can <a href=\"login?dest=viewgame%3Fid%3D$gameid%26review%3D$reviewid\">log in</a> "
-               . "to rate this review, mute this user, or add a comment.";
+            echo "<a href=\"login?dest=viewgame%3Fid%3D$gameid%26review%3D$reviewid\">Log in</a> "
+               . "to comment, rate this review, or mute this user.";
         } else {
-            echo "Was this review helpful to you? &nbsp; "
+            echo "Was this review helpful? &nbsp; "
                 . "<a href=\"needjs\">"
                 . addEventListener('click', "sendReviewVote('$reviewid', 'Y'); return false;")
                 . "Yes</a> &nbsp; "
@@ -561,9 +578,6 @@ function showReview($db, $gameid, $rec, $specialNames, $optionFlags = 0)
                 . "title=\"Notify moderators that this review violates "
                 . "the community guidelines\"><nobr>Flag as inappropriate</nobr></a>"
                 . "</td></tr>"
-                . "<tr><td><a href=\"viewgame?id=$gameid&review=$reviewid\" "
-                . "title=\"Direct link to this review\"><nobr>Direct link</nobr></a>"
-                . "</td></tr>"
                 . "<tr class='reviews__separator'><td></td></tr>"
                 . "<tr><td><a href=\"userfilter?list\">"
                 . "<nobr>View my user filters</nobr></a>"
@@ -575,7 +589,6 @@ function showReview($db, $gameid, $rec, $specialNames, $optionFlags = 0)
                 . "</div>"
                 . "</div>"
 
-                . "&nbsp;$barCommentCtls"
                 . "&nbsp;<span id=\"voteMsg_$reviewid\" class=\"xmlstatmsg\">"
                 . "</span><span id=\"voteStat_$reviewid\"></span>"
                 . "<script type=\"text/javascript\" nonce=\"$nonce\">\r\n<!--\r\n"
@@ -586,8 +599,11 @@ function showReview($db, $gameid, $rec, $specialNames, $optionFlags = 0)
         echo "</span></div>";
 
     } else if ($specialCode == 'author' || $specialCode == 'ifdb') {
-        echo "<div class=smallfoot><span class=details>$commentCtls"
-            . "</span></div>";
+        echo "<div class=smallfoot><span class=details>
+            <a title=\"Direct link to this review\"
+            href=\"viewgame?id=$gameid&review=$reviewid\">Direct link</a>
+            $barCommentCtls
+            </span></div>";
     }
 
 


### PR DESCRIPTION
Fixes [Some Review toolbar features should be visible for logged-out users](https://github.com/iftechfoundation/ifdb/issues/1353)

This problem has bothered me for a while. It's not obvious that logged-out users can still access a review's main page and see the comments.

I reorganized the review footer and added a "Direct link" section to the footer to fix this. I considered making the title of the review, instead of the date, link to the review, but I decided not to change that. The dark mode color scheme of a visited link looked ugly on the title of a review. At any rate, since the "Direct link" section would be added to the footer, people can use that instead.

I removed some words from certain messages in the footer to save space and compensate for the extra space taken up by the "Direct link" section. I also changed the logic of when `Add a comment` and `View comments (x)` show up, described in the last section here.

Summary of changes:
- Add "Direct link" to the small footer
- Change order of links in the small footer
- Change wording of small footer messages slightly, to save space
- Change when "View comments (x)" and "Add a comment" show up
- Add "title" attribute to some links in the small footer, for ease of use

[Edit: I missed author-created reviews the first time around. This has now been fixed. I've force-pushed my changes, and added new screenshots below.]

### Screenshots before

**Not logged in, viewing any review:**
<img width="589" height="53" alt="You can log in to rate this review, mute this user, or add a comment." src="https://github.com/user-attachments/assets/07d01f1e-1b3a-4d34-b63f-c6710a6b653c" />

**Logged in as admin, viewing a review you've voted helpful with no comments:**
<img width="618" height="57" alt="Was this review helpful to you?   Yes   No   Edit  More Options
 | Add a comment" src="https://github.com/user-attachments/assets/722cdbd4-da90-47f0-9684-4dc0ff58cd91" />

**Logged in as admin, viewing a review you've voted helpful with 4 comments:**
<img width="740" height="59" alt="Was this review helpful to you?   Yes   No   Remove vote   Edit  More Options
 | View comments (4) - Add comment" src="https://github.com/user-attachments/assets/b5fda143-fd7a-4060-9d6d-ec72afce8d24" />

**Logged in and viewing your own review with no comments:**
<img width="534" height="50" alt=" You wrote this review - Revise it | Direct link | Add a comment" src="https://github.com/user-attachments/assets/19c54e4e-1b66-4d01-8959-a6703f573f6c" />

**Logged in and viewing your own review with 1 comment:**
<img width="534" height="50" alt=" You wrote this review - Revise it | Direct link | View comments (1) - Add comment" src="https://github.com/user-attachments/assets/f2521cda-3193-4aae-bffd-f1bf5b587a64" />

**Not logged in, or logged in as admin, or logged in as a regular user, viewing a review by the game's author with no comments:**
<img width="362" height="34" alt="Add comment" src="https://github.com/user-attachments/assets/70da0567-e6ce-4f1f-a672-42c23767631c" />

**Not logged in, or logged in as admin, or logged in as a regular user, viewing a review by the game's author with 1 comment:**
<img width="362" height="34" alt="View comments (1) - Add comment" src="https://github.com/user-attachments/assets/79da4541-0756-4079-a9d2-4a091ba63acb" />

### Screenshots after

**Not logged in, viewing a review with no comments:**
<img width="546" height="44" alt="Direct link | Log in to comment, rate this review, or mute this user." src="https://github.com/user-attachments/assets/36ce3287-1681-48cb-9987-0b70bd78eb25" />

**Not logged in, viewing a review with 4 comments:**
<img width="546" height="44" alt="Direct link | View comments (4) | Log in to comment, rate this review, or mute this user." src="https://github.com/user-attachments/assets/7185693d-1704-4010-b7fd-b3a82e35be7c" />

**Logged in as admin, viewing a review you've voted helpful with no comments:**
<img width="649" height="55" alt="Direct link | Was this review helpful?   Yes   No   More Options" src="https://github.com/user-attachments/assets/df8f5e7a-3213-4d32-87fd-b58c84b88566" />

**Logged in as admin, viewing a review you've voted helpful with 4 comments:**
<img width="660" height="50" alt="Direct link | View comments (4) | Was this review helpful?   Yes   No   More Options" src="https://github.com/user-attachments/assets/8048bdc2-6852-4983-873a-845f2db16ee6" />

**Logged in and viewing your own review with no comments:**
<img width="589" height="53" alt="Direct link | Add a comment | You wrote this review - Revise it" src="https://github.com/user-attachments/assets/2e171354-5292-469f-8aa5-4f2c9c34ddb8" />

**Logged in and viewing your own review with 1 comment:**
<img width="589" height="53" alt="Direct link | View comments (1) | You wrote this review - Revise it" src="https://github.com/user-attachments/assets/52f5bfb0-2c1c-4cfe-9212-a8cb69ea1fda" />

**Not logged in, viewing a review by the game's author with no comments:**
<img width="362" height="34" alt="Direct link" src="https://github.com/user-attachments/assets/d0b4bedd-b365-4f7b-9726-3c1985b0052c" />

**Logged in, viewing a review by the game's author with no comments:**
<img width="362" height="34" alt="Direct link | Add a comment" src="https://github.com/user-attachments/assets/fed372cd-2388-4fa9-abf7-ee47f6858715" />

**Not logged in, or logged in as admin, or logged in as a regular user, viewing a review by the game's author with 1 comment:**
<img width="362" height="34" alt="Direct link | View comments (1)" src="https://github.com/user-attachments/assets/ffc85ab9-9bf6-45fd-829e-b3a513ff48a2" />

## Note about `Add comment` and `View comments (x)`

Niche, but potentially useful to know:

With the current code, when you're looking at a review from the direct link, the `View comments (x)` link disappears from the review footer.

I kept this feature in my modified code. I didn't screenshot every variation of the review footer below, however, because that would take a very long time. All the screenshots above were taken *not* from the review's direct link, but from the game's main page.

With the old code: `Add comment` always appears in the review footer. `View comments (x)` appears only if you're logged in, and the review has comments, and you're NOT looking at the review's direct link. If you're looking at the review's direct link, `View comments (x)` never appears.

With the new code: `Add comment` only exists in the review footer if you're logged in, AND (the review has no comments OR (the review has comments and you're looking at the review's direct link)). `View comments (x)` appears only if the review has comments, and you're NOT looking at the review's direct link. If you're looking at the review's direct link, `View comments (x)` never appears.

Also:

With the new code, `View comments (x)` appears regardless of whether you're logged in. This may seem redundant given that the new `Direct link` section of the footer already links to the direct link of the review, and `View comments (x)` also links to the direct link of the review. However, `Direct link` links to the *top* of the review, while `View comments (x)` links to the comments section. This is useful for long reviews where someone would have to scroll down very far to see the comments section.

With the new code, you have to be at the review's direct link before you can click `Add a comment`. With the old code, the `Add a comment` link always existed and you didn't have to be at the review's direct link to click it. I think this is an acceptable loss to save space in the review footer, and making people see the existing comments before they can add a comment of their own may be worth it. The `Add a comment` feature is rarely used, at any rate.