### PR TITLE
Adding sandbox to reviews from the author

### DIFF
--- a/www/viewgame
+++ b/www/viewgame
@@ -1571,7 +1571,17 @@ if ($embargoCnt > 0)
     // -------------------------- DETAIL VIEW ------------------------------
     //
     if ($detailView) {
-
+        // Include only reviews from our sandbox or sandbox 0 (all users)
+        $sandbox = "(0)";
+        if ($curuser)
+        {
+            // get my sandbox
+            $mysandbox = 0;
+            $result = mysql_query("select sandbox from users where id='$curuser'", $db);
+            list($mysandbox) = mysql_fetch_row($result);
+            if ($mysandbox != 0)
+                $sandbox = "(0,$mysandbox)";
+        }
         // show other (non-editorial) special reviews
         $result = mysql_query(
             "select reviews.id as reviewid,
@@ -1586,6 +1596,7 @@ if ($embargoCnt > 0)
                and users.id = reviews.userid
                and editorial = 0
                and ifnull(now() >= reviews.embargodate, 1)
+               and ifnull(users.sandbox, 0) in $sandbox
              order by displayrank", $db);
 
         if (mysql_num_rows($result) != 0) {


### PR DESCRIPTION
This copies the sandbox code from the regular reviews page into the special reviews section. It checks the user's sandbox and outputs either (0) or (0,1), then checks the review writer's sandbox and only reveals it if it's in that list.