### PR TITLE
Very minor cleanup of comments on viewgame page

### DIFF
--- a/www/viewgame
+++ b/www/viewgame
@@ -1879,7 +1879,7 @@ if ($embargoCnt > 0)
 
     // ---------------- end Game Details section ------------
 
-    } // if ($detailView)
+    } // if ($detailView || $historyView)
 
 
 //------------------------ CROSS-RECOMMENDATIONS --------------------------


### PR DESCRIPTION
* One of the PHP functions in the section for displaying median time got moved to another file, so remove extra space and plural "functions" in the comment.
* Avoid implying that time notes and links to voter profiles are only for new time votes. I think that comment is left over from when we were in the middle of switching to publicly attributed time votes.
* A comment that looks like it's supposed to be repeating the condition in the "if" line, did not match, so I assumed this was an error and changed it to match.