### PR TITLE
Add a "lockdown mode" where all new IFDB accounts require moderator approval 

### DIFF
--- a/sql/incoming-schema-changes.sql
+++ b/sql/incoming-schema-changes.sql
@@ -2,6 +2,23 @@ USE ifdb;
 
 -- use this script for pending changes to the production DB schema
 
+
+DROP TABLE IF EXISTS `global_settings`;
+CREATE TABLE `global_settings` ( 
+  `setting_id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,
+  `setting_name` VARCHAR(255) NOT NULL,
+  `current_value` VARCHAR(255) NOT NULL,
+  PRIMARY KEY (setting_id),
+  UNIQUE KEY `setting_name` (`setting_name`)
+);
+
+insert into global_settings (setting_name, current_value)
+values
+  ('account approval', 'normal');
+
+
+
+
 DROP TABLE IF EXISTS `suspicious_domains`;
 CREATE TABLE `suspicious_domains` ( 
   `suspicious_domain_id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,

--- a/www/adminops
+++ b/www/adminops
@@ -651,7 +651,7 @@ if (isset($_REQUEST['domains'])) {
 
 //------------------ end of manage suspicious domains ---------------------
 
-//----------------- BEGIN LOCKDOWN OPTIONS -----------
+//----------------- BEGIN LOCKDOWN CONTROLS -----------
 
 if (isset($_REQUEST['lockdown'])) {
     $switch_to_lockdown = $_POST["lockdown_button"] ?? null;
@@ -687,8 +687,8 @@ if (isset($_REQUEST['lockdown'])) {
         }     
 
     // Show what mode we're in and explain the modes
-    pageHeader("Lockdown Options");
-    echo "<h1>Lockdown Options</h1>";
+    pageHeader("Lockdown Controls");
+    echo "<h1>Lockdown Controls</h1>";
     echo "<p>Account creation is currently in ";
     if ($current_account_approval_mode == "normal") {
         echo "<b>Normal Mode</b>.";
@@ -715,7 +715,7 @@ if (isset($_REQUEST['lockdown'])) {
     
 } // if (isset($_REQUEST['lockdown']))
 
-//------------------ end of lockdown options ---------------------
+//------------------ end of lockdown controls ---------------------
 
 
 if (isset($_REQUEST['bulkaddtag'])) {
@@ -3486,7 +3486,7 @@ function cleanutf8($str)
     <li><a href="adminops?adminemail">Send admin email</a></li>
     <li><a href="adminops?addnews">Add a Site News item</a></li>
     <li><a href="adminops?domains">Manage suspicious domains</a></li>
-    <li><a href="adminops?lockdown">Lockdown options</a></li>
+    <li><a href="adminops?lockdown">Lockdown controls</a></li>
     <li><a href="adminops?burygame">Bury game</a></li>
     <li><a href="adminops?duplicateDetector">Duplicate game detector</a></li>
 </ul>

--- a/www/adminops
+++ b/www/adminops
@@ -651,6 +651,73 @@ if (isset($_REQUEST['domains'])) {
 
 //------------------ end of manage suspicious domains ---------------------
 
+//----------------- BEGIN LOCKDOWN OPTIONS -----------
+
+if (isset($_REQUEST['lockdown'])) {
+    $switch_to_lockdown = $_POST["lockdown_button"] ?? null;
+    $switch_to_normal = $_POST["normal_button"] ?? null;
+
+    if ($switch_to_lockdown OR $switch_to_normal) {
+        // The user pressed a button to switch modes.
+        // Figure out which mode.
+        $new_account_approval_mode = "";
+        if ($switch_to_lockdown) {
+            $new_account_approval_mode = "lockdown";
+        } else if ($switch_to_normal){
+            $new_account_approval_mode = "normal";
+        }   
+        // Update the account creation mode in the database.
+        mysqli_execute_query($db,
+            "UPDATE global_settings
+            SET current_value = ?
+            WHERE setting_name = 'account approval'", 
+            [$new_account_approval_mode]);
+    }
+
+    // Find which account approval mode we're in
+    $result = mysqli_execute_query($db,
+        "SELECT current_value
+        FROM global_settings
+        WHERE setting_name = 'account approval'");
+    if (!$result) throw new Exception("Error: " . mysqli_error($db));
+        $matching_settings_rows = mysqli_fetch_all($result, MYSQLI_ASSOC);
+        $current_account_approval_mode = "";
+        foreach ($matching_settings_rows as $row) {
+            $current_account_approval_mode = htmlspecialchars($row['current_value']);
+        }     
+
+    // Show what mode we're in and explain the modes
+    pageHeader("Lockdown Options");
+    echo "<h1>Lockdown Options</h1>";
+    echo "<p>Account creation is currently in ";
+    if ($current_account_approval_mode == "normal") {
+        echo "<b>Normal Mode</b>.";
+    } else if ($current_account_approval_mode == "lockdown"){
+        echo "<b>Lockdown Mode</b>.";
+    }
+    echo "<p>In normal mode, low-risk new accounts can be "; 
+    echo "activated without moderator approval.</p>";
+    echo "<p>In lockdown mode, no new accounts can be ";
+    echo "activated until a moderator manually approves them.</p>";
+
+    // Display the button to switch modes
+    echo '<form action="/adminops?lockdown" method="post">';
+        if ($current_account_approval_mode == "normal") { 
+        echo "<input type='submit' name='lockdown_button' id='lockdown_button' value='Switch to Lockdown Mode'>";
+    } else if ($current_account_approval_mode == "lockdown"){ 
+        echo "<input type='submit' name='normal_button' id='normal_button' value='Switch to Normal Mode'>";
+    }
+    echo '</form></p>';
+    echo '<hr>';
+    echo '<p><a href="/adminops">Return to the Administrator Operations panel</a></p>';
+    pageFooter();
+    exit();
+    
+} // if (isset($_REQUEST['lockdown']))
+
+//------------------ end of lockdown options ---------------------
+
+
 if (isset($_REQUEST['bulkaddtag'])) {
     $tag = $_POST['tag'] ?? null;
     $tag2 = $_POST['tag2'] ?? null;
@@ -3419,6 +3486,7 @@ function cleanutf8($str)
     <li><a href="adminops?adminemail">Send admin email</a></li>
     <li><a href="adminops?addnews">Add a Site News item</a></li>
     <li><a href="adminops?domains">Manage suspicious domains</a></li>
+    <li><a href="adminops?lockdown">Lockdown options</a></li>
     <li><a href="adminops?burygame">Bury game</a></li>
     <li><a href="adminops?duplicateDetector">Duplicate game detector</a></li>
 </ul>

--- a/www/newuser
+++ b/www/newuser
@@ -510,6 +510,10 @@ function handlePost()
         values ('$userid', '$ip', now())", $db);
 
     // send notification to the ifdb administrator
+    $lockdown_message = "";
+    if ($lockdown) {
+        $lockdown_message = "<br>IFDB account creation is currently in lockdown mode.";
+    }
     $msg = "IFDB new user registration\r\n"
 
            . "<p>New user email: " . htmlspecialcharx($email)
@@ -525,7 +529,8 @@ function handlePost()
            . "<br>StopForumSpam.com: " . $sfsIsSpam
            . "<br>Suspicious email domain: "
            .     ($email_domain_suspicion_level ? "<b>Yes (".$email_domain_suspicion_level.")</b>" : "No")
-
+           . $lockdown_message
+           
            . "<br><br><a href=\"http://www.google.com/search?q=%22"
            .    urlencode($email) . "%22\">Search for email</a>"
            . "<br><a href=\"http://www.google.com/search?q=%22"

--- a/www/newuser
+++ b/www/newuser
@@ -438,11 +438,27 @@ function handlePost()
         return true;
     }
 
+    // Check to see if IFDB account approval is currently in lockdown mode
+    $lockdown = false;
+    $result = mysqli_execute_query($db,
+        "SELECT current_value
+        FROM global_settings
+        WHERE setting_name = 'account approval'");
+    if (!$result) throw new Exception("Error: " . mysqli_error($db));
+    $matching_settings_rows = mysqli_fetch_all($result, MYSQLI_ASSOC);
+    $current_account_approval_mode = "";
+    foreach ($matching_settings_rows as $row) {
+        $current_account_approval_mode = htmlspecialchars($row['current_value']);
+    }
+    if ($current_account_approval_mode == "lockdown") {
+        $lockdown = true;
+    }
+
     // If the stopforumspam check turned up an obvious spammer, or the
     // email domain is one that we know from our own experience to be
-    // mostly used by spammers, don't even allow the user to activate
-    // the account until we can review it.
-    if ($sfsBanned || $domainBanned)
+    // mostly used by spammers, or if we're in lockdown mode, don't even 
+    // allow the user to activate the account until we can review it.
+    if ($sfsBanned || $domainBanned || $lockdown)
     {
         // use account statue 'R' - review needed
         $acctStatus = "R";


### PR DESCRIPTION
Add a "lockdown controls" link on the admin panel.
Add a "lockdown controls" section to adminops with a button to switch between normal mode and lockdown mode.
On the newuser page, check to see if we're in lockdown mode and, if so, don't automatically activate the new account.
Fixes #1368.