### PR TITLE
Add alt text to the small cover art on the viewgame page and full-sized cover art.

### DIFF
--- a/www/util.php
+++ b/www/util.php
@@ -2834,7 +2834,7 @@ function check_admin_privileges($db, $userid) {
 
 }
 
-function coverArtThumbnail($id, $size, $version, $params = "") {
+function coverArtThumbnail($id, $size, $version, $params = "", $alt_text = "") {
     $thumbnail = "/coverart?id=$id&thumbnail=";
     $x15 = round($size * 3 / 2);
     $x2 = $size * 2;
@@ -2844,7 +2844,7 @@ function coverArtThumbnail($id, $size, $version, $params = "") {
     }
     global $nonce;
     return "<style nonce='$nonce'>.coverart__img { max-width: 35vw; height: auto; }</style>"
-        ."<img class='coverart__img' loading='lazy' srcset=\"$thumbnail{$size}x$size$params, $thumbnail{$x15}x$x15$params 1.5x, $thumbnail{$x2}x$x2$params 2x, $thumbnail{$x3}x$x3$params 3x\" src=\"$thumbnail{$size}x$size$params\" height=$size width=$size border=0 alt=\"\">";
+        ."<img class='coverart__img' loading='lazy' srcset=\"$thumbnail{$size}x$size$params, $thumbnail{$x15}x$x15$params 1.5x, $thumbnail{$x2}x$x2$params 2x, $thumbnail{$x3}x$x3$params 3x\" src=\"$thumbnail{$size}x$size$params\" height=$size width=$size border=0 alt=\"$alt_text\">";
 }
 
 // ----------------------------------------------------------------------------

--- a/www/util.php
+++ b/www/util.php
@@ -423,7 +423,7 @@ function sendImageLdesc($title, $imageID)
 </head>
 <body>
 <div class=main>
-   <img src="showimage?id=<?php echo urlencode($imageID) ?>">
+   <img src="showimage?id=<?php echo urlencode($imageID) ?>" alt="Cover art for <?php echo htmlspecialcharx($title) ?>.">
    <?php
       if ($copymsg || ($copystat && isset($copyrightStatList[$copystat]))
           || $username || $created) {

--- a/www/viewgame
+++ b/www/viewgame
@@ -929,13 +929,14 @@ echo helpWinLink("help-ifid", "IFID");
                <?php
 if ($hasart) {
     $arthref = "{$_SERVER['PHP_SELF']}?coverart&id=$id";
+    $cover_alt_text = "Cover art for $title. Click for full-sized image and copyright information.";
     if (isset($_REQUEST['version']))
         $arthref .= "&version=" . $_REQUEST['version'];
                ?>
            <div class=coverart>
 
               <a href="<?php echo $arthref ?>&ldesc">
-                 <?php echo coverArtThumbnail($id, 175, isset($_REQUEST['version']) ? $_REQUEST['version'] : $pagevsn); ?>
+                 <?php echo coverArtThumbnail($id, 175, isset($_REQUEST['version']) ? $_REQUEST['version'] : $pagevsn, "", $cover_alt_text); ?>
               </a>
            </div>
                <?php


### PR DESCRIPTION
Based on discussion elsewhere, this PR does the following:

* On the viewgame page, add alt text to the cover art image saying "Cover art for Game Title. Click for full-sized image and copyright information."
* Add an alt text parameter to the coverArtThumbnail function in util.php
* On the large version of the cover art (visible when you click the small cover art on the viewgame page), add the alt text "Cover art for Game Title." (I have not been able to test this, because the dev environment seems to redirect me to the live IFDB site when I try to look at this page.) 

This PR does not add any custom text that describes what the cover looks like, partly because I'm not sure that's actually possible in this dev environment, but hopefully that could be added in the future to one or both of these spots.

Fixes https://github.com/iftechfoundation/ifdb/issues/1378.