### PR TITLE
Avoid repeating duplicate links for screen readers on search page, recommended lists pages, poll pages, etc.

### DIFF
--- a/www/lists.php
+++ b/www/lists.php
@@ -23,7 +23,7 @@ function listMatchItem($match, $num, $showArt, $rating, $hrefTarget)
 
 
     if ($art)
-        echo "<a href=\"viewgame?id=$id\"$hrefTarget class=\"lists__art\">"
+        echo "<a href=\"viewgame?id=$id\"$hrefTarget class=\"lists__art\" aria-hidden=\"true\" tabindex=\"-1\">"
             . coverArtThumbnail($id, 100, $pagevsn)
             . "</a>";
 

--- a/www/newitems.php
+++ b/www/newitems.php
@@ -429,11 +429,11 @@ function showNewItemList($db, $first, $last, $items, $options)
             // image, otherwise generic review icon
             if ($enableImages) {
                 if ($r["haspic"]) {
-                    echo "<a href=\"showuser?id={$r['userid']}\">"
+                    echo "<a href=\"showuser?id={$r['userid']}\" aria-hidden=\"true\" tabindex=\"-1\">"
                         . "<img border=0 width=50 height=50 src=\"showuser?id={$r['userid']}&pic"
-                        . "&thumbnail=50x50\"></a>";
+                        . "&thumbnail=50x50\" alt=\"\"></a>";
                 } else if ($r["hasart"]) {
-                    echo "<a href=\"viewgame?id={$r['gameid']}\">"
+                    echo "<a href=\"viewgame?id={$r['gameid']}\" aria-hidden=\"true\" tabindex=\"-1\">"
                         . coverArtThumbnail($r['gameid'], 50, $r['pagevsn'])
                         . "</a>";
                 } else {

--- a/www/poll
+++ b/www/poll
@@ -1351,7 +1351,7 @@ function expandVote(id)
                 // show the cover art if available
                 if ($coverArt) {
                     echo "<td class='poll__artCell'>"
-                        . "<a href=\"viewgame?id=$gameID\">"
+                        . "<a href=\"viewgame?id=$gameID\" aria-hidden=\"true\" tabindex=\"-1\">"
                         . coverArtThumbnail($gameID, 80, $pagevsn)
                         . "</a></td>";
                 } else {

--- a/www/search
+++ b/www/search
@@ -1527,9 +1527,9 @@ else if ($term || $browse)
                 if ($pic) {
                     echo "<table class=grid border=0 cellspacing=0 cellpadding=0>"
                         . "<tr><td>"
-                        . "<a class='$eagerness' href=\"showuser?id=$id\">"
+                        . "<a class='$eagerness' href=\"showuser?id=$id\" aria-hidden=\"true\" tabindex=\-1\">"
                         . "<img src=\"showuser?id=$id&pic&thumbnail=80x80\" "
-                        . "border=0></td><td>"
+                        . "border=0 alt=\"\"></td><td>"
                         . "<h3 class=result><a href=\"showuser?id=$id\">"
                         . "<b>$name</b></a></h3>$badge<br>"
                         . "<span class=details>"

--- a/www/search
+++ b/www/search
@@ -1400,7 +1400,7 @@ else if ($term || $browse)
                 echo "<p>";
                 echo "<article class=grid><div>";
                 if ($art) {
-                    echo "<a class='$eagerness' href=\"viewgame?id=$id\">"
+                    echo "<a class='$eagerness' href=\"viewgame?id=$id\" aria-hidden='true' tabindex='-1'>"
                         . coverArtThumbnail($id, 80, $pagevsn) . "</a>";
                 }
                 echo "</div><div><h3 class=result><a href=\"viewgame?id=$id\">"

--- a/www/viewgame-components/cross-recommendations.php
+++ b/www/viewgame-components/cross-recommendations.php
@@ -73,7 +73,7 @@
                     if ($crart)
                         echo "<table class=grid cellspacing=0 cellpadding=0 "
                             . "border=0><tr><td>"
-                            . "<a href=\"viewgame?id=$crid\">"
+                            . "<a href=\"viewgame?id=$crid\" aria-hidden=\"true\" tabindex=\"-1\">"
                             . coverArtThumbnail($crid, 80, $crversion)
                             . "</a></td><td>";
 


### PR DESCRIPTION
IFDB has lists of games with a cover art link beside a game title link, and with both links leading to the same destination. This kind of thing can cause redundancy for screen readers:

> Otherwise what happens is when you’re browsing you hear “Cover of foo, graphic link” and then “foo” when you move to the next item which is the plain text link. Ideally you only want to hear one of those, the other is extraneous. 

([Discussed here](https://intfiction.org/t/poll-alt-text-for-cover-art-on-ifdb/80337/7))

Right now, it looks like the alt text is set to "" for the thumbnails, but according to [Webaim.org](https://webaim.org/techniques/alttext/#functional) :

> When an image is the only content inside a link or button, alt text is all that a screen reader has to go on. If it’s empty or missing, screen readers might read the image filename or the URL of the linked page in hopes that this may be helpful to the user, but this is not always the case.

As suggested by an IFDB user and [this page](https://accessibleweb.com/question-answer/what-should-i-do-if-i-have-multiple-links-that-go-to-the-same-page/), one way of addressing this is to use  `aria-hidden="true" tabindex="-1` on the anchor element of the image link.

This PR make this change for:
* the search page
* recommended lists
* the poll page
* the allnew?reviews page
* browsing members on the browse page
* cross-recommended games on the viewgame page

This PR partly addresses https://github.com/iftechfoundation/ifdb/issues/1377.