### PR TITLE
Combine checkmark link and "vote for this game" link into one

### DIFF
--- a/www/ifdb.css
+++ b/www/ifdb.css
@@ -1960,6 +1960,7 @@ img.vote-checkmark {
     height: 20px;
     border: none;
     vertical-align: middle;
+    margin-right: 5px;
 }
 
 /*

--- a/www/poll
+++ b/www/poll
@@ -1318,14 +1318,14 @@ function expandVote(id)
                             $aVote = "<a href=\"poll?id=$id&submitVote"
                                  . "&gameID=$prvGameID&quickQuote=&voteDesc=\">";
                             echo " $aVote<img class=\"vote-checkmark\" "
-                                . "border=0 src=\"img/blank.gif\"></a> "
-                                . "{$aVote}Vote for this game anonymously</a>";
+                                . "border=0 src=\"img/blank.gif\" alt=\"\">"
+                                . "Vote for this game anonymously</a>";
                         } else {
                             $aVote = "<a href=\"poll?id=$id&addVote"
-                                 . "&game=$prvGameID\">";
+                                . "&game=$prvGameID\">";
                             echo " $aVote<img class=\"vote-checkmark\" "
-                                . "border=0 src=\"img/blank.gif\"></a> "
-                                . "{$aVote}Vote for this game</a>";
+                                . "border=0 src=\"img/blank.gif\" alt=\"\">"
+                                . "Vote for this game</a>";
                         }
                     }
                     echo "</span>";


### PR DESCRIPTION
Reduce audio clutter for screen reader users by combining redundant adjacent links--the checkmark link and the "Vote for this game" text link--into a single link.

There had been a space between the graphic and the text, and that space got underlined when I combined the two links. To avoid the underlined space, I deleted the space from the text, and then added an equivalent amount of space back in using margin-right on the checkmark graphic.

I tested with NVDA.

An example of https://github.com/iftechfoundation/ifdb/issues/1374
