### PR TITLE
Home page cleanup: Fix broken link, add alt text, avoid duplicate links for screen reader users

### DIFF
--- a/www/components/games.php
+++ b/www/components/games.php
@@ -93,17 +93,17 @@ for ($idx = 0 ; $idx <= 5; $idx++)
         $divclass = "new-game-news";
         $href = "viewgame?id=$gid";
 
-        // show the image: user image if available, otherwise game
+        // show the image: game image if available, otherwise user
         // image, otherwise generic review icon
         if (ENABLE_IMAGES) {
-            if (isset($n["haspic"]) && $n["haspic"]) {
-                echo "<a href=\"showuser?id={$n['userID']}\">"
-                    . "<img border=0 width=50 height=50 src=\"showuser?id={$n['userID']}&pic"
-                    . "&thumbnail=50x50\"></a>";
-            } else if ($n["hasart"]) {
+            if ($n["hasart"]) {
                 echo "<a href=\"viewgame?id={$n['gameid']}\" aria-hidden=\"true\" tabindex=\"-1\">"
                     . coverArtThumbnail($gid, 50, $n['pagevsn'])
                     . "</a>";
+            } else if (isset($n["haspic"]) && $n["haspic"]) {
+                echo "<a href=\"showuser?id={$n['userID']}\">"
+                    . "<img border=0 width=50 height=50 src=\"showuser?id={$n['userID']}&pic"
+                    . "&thumbnail=50x50\"></a>";
             } else {
                 // echo "<a href=\"newslog?newsid=$nid\">"
                 //     . "<img border=0 src=\"news50.gif\"></a>";

--- a/www/components/games.php
+++ b/www/components/games.php
@@ -101,7 +101,7 @@ for ($idx = 0 ; $idx <= 5; $idx++)
                     . "<img border=0 width=50 height=50 src=\"showuser?id={$n['userID']}&pic"
                     . "&thumbnail=50x50\"></a>";
             } else if ($n["hasart"]) {
-                echo "<a href=\"viewgame?id={$n['gameid']}\">"
+                echo "<a href=\"viewgame?id={$n['gameid']}\" aria-hidden=\"true\" tabindex=\"-1\">"
                     . coverArtThumbnail($gid, 50, $n['pagevsn'])
                     . "</a>";
             } else {

--- a/www/components/games.php
+++ b/www/components/games.php
@@ -97,7 +97,7 @@ for ($idx = 0 ; $idx <= 5; $idx++)
         // image, otherwise generic review icon
         if (ENABLE_IMAGES) {
             if ($n["hasart"]) {
-                echo "<a href=\"viewgame?id={$n['gameid']}\" aria-hidden=\"true\" tabindex=\"-1\">"
+                echo "<a href=\"viewgame?id=$gid\" aria-hidden=\"true\" tabindex=\"-1\">"
                     . coverArtThumbnail($gid, 50, $n['pagevsn'])
                     . "</a>";
             } else if (isset($n["haspic"]) && $n["haspic"]) {

--- a/www/components/games.php
+++ b/www/components/games.php
@@ -52,8 +52,8 @@ for ($idx = 0 ; $idx <= 5; $idx++)
         // generic game icon
         if (ENABLE_IMAGES) {
             if ($g["hasart"]) {
-                echo "<a href=\"viewgame?id={$g['id']}\">"
-                    . coverArtThumbnail($g['id'], 50, $g['pagevsn'])
+                echo "<a href=\"viewgame?id={$g['id']}\" aria-hidden=\"true\" tabindex=\"-1\">"
+                    . coverArtThumbnail($g['id'], 50, $g['pagevsn'])       
                     . "</a>";
             } else {
                 // echo "<a href=\"viewgame?id={$g['id']}\">"

--- a/www/components/games.php
+++ b/www/components/games.php
@@ -101,9 +101,9 @@ for ($idx = 0 ; $idx <= 5; $idx++)
                     . coverArtThumbnail($gid, 50, $n['pagevsn'])
                     . "</a>";
             } else if (isset($n["haspic"]) && $n["haspic"]) {
-                echo "<a href=\"showuser?id={$n['userID']}\">"
+                echo "<a href=\"showuser?id={$n['userID']}\">" 
                     . "<img border=0 width=50 height=50 src=\"showuser?id={$n['userID']}&pic"
-                    . "&thumbnail=50x50\"></a>";
+                    . "&thumbnail=50x50\" alt=\"$nuname\"></a>";
             } else {
                 // echo "<a href=\"newslog?newsid=$nid\">"
                 //     . "<img border=0 src=\"news50.gif\"></a>";

--- a/www/components/ifdb-recommends.php
+++ b/www/components/ifdb-recommends.php
@@ -69,7 +69,7 @@ if (count($recs) >= 2) {
         if ($hasart)
             echo "<table border=0 cellspacing=0 cellpadding=0>"
                 . "<tr valign=top><td>"
-                . "<a href=\"viewgame?id=$gameid\" class=\"ifdb-recommends__artLink\" aria-label=\"$title\">"
+                . "<a href=\"viewgame?id=$gameid\" class=\"ifdb-recommends__artLink\" aria-hidden=\"true\" tabindex=\"-1\">"
                 . coverArtThumbnail($gameid, 70, $pagevsn)
                 . "</a></td><td>";
 

--- a/www/components/recommended-lists.php
+++ b/www/components/recommended-lists.php
@@ -43,9 +43,9 @@ for ($idx = 0 ; $idx <= 8; $idx++)
     // generic list icon
     if (ENABLE_IMAGES) {
         if ($l["haspic"]) {
-            echo "<a href=\"showuser?id={$l['userid']}\">"
+            echo "<a href=\"showuser?id={$l['userid']}\" aria-hidden=\"true\" tabindex=\"-1\">"
                 . "<img border=0 width=50 height=50 src=\"showuser?id={$l['userid']}&pic"
-                . "&thumbnail=50x50\"></a>";
+                . "&thumbnail=50x50\" alt=\"\"></a>";
         } else {
             // echo "<a href=\"viewlist?id={$l['id']}\">"
             //     . "<img border=0 src=\"reclist50.gif\"></a>";

--- a/www/components/reviews.php
+++ b/www/components/reviews.php
@@ -35,11 +35,11 @@ for ($idx = 0 ; $idx <= 5 ; $idx++)
     // image, otherwise generic review icon
     if (ENABLE_IMAGES) {
         if ($r["haspic"]) {
-            echo "<a href=\"showuser?id={$r['userid']}\">"
+            echo "<a href=\"showuser?id={$r['userid']}\" aria-hidden=\"true\" tabindex=\"-1\">"
                 . "<img border=0 width=50 height=50 src=\"showuser?id={$r['userid']}&pic"
                 . "&thumbnail=50x50\"></a>";
         } else if ($r["hasart"]) {
-            echo "<a href=\"viewgame?id={$r['gameid']}\">"
+            echo "<a href=\"viewgame?id={$r['gameid']}\" aria-hidden=\"true\" tabindex=\"-1\">"
                 . coverArtThumbnail($r['gameid'], 50, $r['pagevsn'])
                 . "</a>";
         } else {

--- a/www/components/reviews.php
+++ b/www/components/reviews.php
@@ -37,7 +37,7 @@ for ($idx = 0 ; $idx <= 5 ; $idx++)
         if ($r["haspic"]) {
             echo "<a href=\"showuser?id={$r['userid']}\" aria-hidden=\"true\" tabindex=\"-1\">"
                 . "<img border=0 width=50 height=50 src=\"showuser?id={$r['userid']}&pic"
-                . "&thumbnail=50x50\"></a>";
+                . "&thumbnail=50x50\" alt=\"\"></a>";
         } else if ($r["hasart"]) {
             echo "<a href=\"viewgame?id={$r['gameid']}\" aria-hidden=\"true\" tabindex=\"-1\">"
                 . coverArtThumbnail($r['gameid'], 50, $r['pagevsn'])


### PR DESCRIPTION
This PR makes the following changes to the home page.

## For "News on [Game Title]" items in the Games section:
* Fix broken cover art links (they didn't include the TUID before)
* Prefer showing cover art vs. showing the profile image of the user (this just made more sense to me for news announcements about a game, and @salty-horse agreed)
* If the profile image of the user is shown anyway (because no cover art for the game is available), give alt text of the user's name so that screen reader users know what happens if they click on the link. The user's name doesn't otherwise appear in the news announcement, so in this case the link and the alt text are not redundant.

## Everywhere on the home page:
Whenever cover art images or user images are redundant with nearby links, use aria-hidden and tabindex to avoid repeating that link for screen reader users. Use alt="" on the images in these cases where it is not already present (I wasn't sure about this, but since assistive technology has been around longer than ARIA, I guess it makes sense as a fallback in the event that ARIA, and therefore aria-hidden, is not understood? [Old stackoverflow answer](https://stackoverflow.com/questions/33237834/aria-hidden-true-not-hiding-decendents-from-accessiblity-checkers) )

This PR fixes https://github.com/iftechfoundation/ifdb/issues/1380. Also works towards addressing https://github.com/iftechfoundation/ifdb/issues/1377. Tested with NVDA. 
