### PR TITLE
Increase character limit for languages

### DIFF
--- a/sql/incoming-schema-changes.sql
+++ b/sql/incoming-schema-changes.sql
@@ -3,6 +3,9 @@ USE ifdb;
 -- use this script for pending changes to the production DB schema
 
 
+ALTER TABLE `games` MODIFY COLUMN `language` VARCHAR (128);
+
+
 DROP TABLE IF EXISTS `global_settings`;
 CREATE TABLE `global_settings` ( 
   `setting_id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,

--- a/www/editgame-util.php
+++ b/www/editgame-util.php
@@ -404,7 +404,7 @@ function saveUpdates($db, $adminPriv, $apiMode,
         $dblen = (isset($dbLens[$key]) ? $dbLens[$key] : 0);
         if ($dblen && gettype($val) != "array" && strlen($val) > $dblen) {
             $errDetail[$key][] = "This value is too long (the maximum "
-                                 . "length is $dblen character).";
+                                 . "length is $dblen characters).";
         }
 
         // validate certain entries


### PR DESCRIPTION
The language column only allows 16 characters, which is not enough for some games that have been translated into many languages.

This PR increases the character limit to 128, and also changes the error message to say a maximum number of "characters" (plural).

Fixes https://github.com/iftechfoundation/ifdb/issues/1292