### PR TITLE
coverart: Use latest version if requested version is greater

### DIFF
--- a/www/coverart
+++ b/www/coverart
@@ -105,8 +105,17 @@ if ($targVsn) {
         if (isset($deltas['title']))
             $title = $deltas['title'];
 
+        $pagevsn = (int)$rec['pagevsn'];
+
+        // Hack to assist local development, which uses production as an image source.
+        // If the target version is above what the server knows about, return the latest version.
+        if ($i == 0 && $pagevsn < $targVsn) {
+            $foundvsn = true;
+            break;
+        }
+
         // stop if this is the version we're looking for
-        if ((int)$rec['pagevsn'] == $targVsn)
+        if ($pagevsn == $targVsn)
         {
             $foundvsn = true;
             break;


### PR DESCRIPTION
Fixes #1384.

This is to assist local development, which uses ifdb.org as an image source, and might advance the version during testing.

I tested this just with debug prints, to make sure the correct version is set at the end of the loop.