### PR TITLE
Custom cover art alt text

### DIFF
--- a/sql/incoming-schema-changes.sql
+++ b/sql/incoming-schema-changes.sql
@@ -4,7 +4,7 @@ USE ifdb;
 
 
 ALTER table games
-    Add column cover_art_description VARCHAR(255) AFTER coverart;
+    Add column cover_art_description VARCHAR(2000) AFTER coverart;
 
 
 

--- a/sql/incoming-schema-changes.sql
+++ b/sql/incoming-schema-changes.sql
@@ -3,6 +3,12 @@ USE ifdb;
 -- use this script for pending changes to the production DB schema
 
 
+ALTER table games
+    Add column cover_art_description VARCHAR(255) AFTER coverart;
+
+
+
+
 DROP TABLE IF EXISTS `global_settings`;
 CREATE TABLE `global_settings` ( 
   `setting_id` BIGINT(20) UNSIGNED NOT NULL AUTO_INCREMENT,

--- a/www/editgame
+++ b/www/editgame
@@ -1101,6 +1101,12 @@ for ($i = 0 ; $i < count($fields) ; $i++) {
             "This game has no cover art",
             "coverart", $curval, 90);
 
+    } else if ($colname == "cover_art_description") {
+        // multiline field for cover art description
+        echo "<textarea name=\"$colname\" id=\"$colname\"
+            rows=2 cols=$len>" . htmlspecialcharx($curval)
+            . "</textarea>";
+
     } else if ($colname == "desc") {
         // multiline field for description
         echo "<textarea name=\"$colname\" id=\"$colname\"

--- a/www/editgame-util.php
+++ b/www/editgame-util.php
@@ -70,8 +70,14 @@ $fields = [
           null, TypeString],
     ["Cover Art", "coverart", 0, null, null, TypeImage],
     ["Cover Art Description", "cover_art_description", 60, 
-          "Describe what the cover art looks like. "
-          . "This description will be in the alt text for the image.",
+          'Describe what the cover image looks like, so it can be announced by a screen reader.'
+          . '<details><summary>Guidelines</summary><ul>'
+          . '<li>Avoid saying "image of," "picture of," and the like. Screen readers already announce it as an image. It\'s okay to use more specific words that convey the medium, for instance, "illustration," "cartoon," or "painting."</li>'
+          . '<li>Avoid saying "cover art." IFDB may include that automatically in some places.'
+          . '<li>Avoid including the title, the author, or other text that is readily available on the game page. If the image shows a subtitle that is not found elsewhere, you could include that. For example, you could write, "Text reads: Lost Pig and Place Underground, by Grunk as told to Admiral Jota."</li>'
+          . '<li>End with a period.</li>'
+          . '</ul></details>'
+          . '</details>',
           null, TypeString],
     ["First&nbsp;Publication&nbsp;Date", "published", 15,
           "Format as dd-Mon-yyyy (example: 12-Jul-2005), or

--- a/www/editgame-util.php
+++ b/www/editgame-util.php
@@ -70,7 +70,7 @@ $fields = [
           null, TypeString],
     ["Cover Art", "coverart", 0, null, null, TypeImage],
     ["Cover Art Description", "cover_art_description", 60, 
-          'A description of what the image looks like, to be read aloud by a screen reader - '
+          'A description of what the image looks like, to be included in alt text - '
           . helpWinLink("help-cover-description", "Guidelines for cover art descriptions"),
           null, TypeString],
     ["First&nbsp;Publication&nbsp;Date", "published", 15,

--- a/www/editgame-util.php
+++ b/www/editgame-util.php
@@ -69,6 +69,10 @@ $fields = [
           . helpWinLink("help-ifid", "What's an IFID?"),
           null, TypeString],
     ["Cover Art", "coverart", 0, null, null, TypeImage],
+    ["Cover Art Description", "cover_art_description", 60, 
+          "Describe what the cover art looks like. "
+          . "This description will be in the alt text for the image.",
+          null, TypeString],
     ["First&nbsp;Publication&nbsp;Date", "published", 15,
           "Format as dd-Mon-yyyy (example: 12-Jul-2005), or
           just enter the year if you don't know the exact date",
@@ -169,7 +173,7 @@ function loadGameRecord($db, $id)
             version, license, system, `desc`, genre, language,
             seriesname, seriesnumber, forgiveness,
             bafsid, website, editedby, moddate, pagevsn,
-            coverart, downloadnotes
+            coverart, cover_art_description, downloadnotes
          from games
          where id = ?", [$id]);
     if (mysql_num_rows($result) == 0)

--- a/www/editgame-util.php
+++ b/www/editgame-util.php
@@ -70,14 +70,8 @@ $fields = [
           null, TypeString],
     ["Cover Art", "coverart", 0, null, null, TypeImage],
     ["Cover Art Description", "cover_art_description", 60, 
-          'Describe what the cover image looks like, so it can be announced by a screen reader.'
-          . '<details><summary>Guidelines</summary><ul>'
-          . '<li>Avoid saying "image of," "picture of," and the like. Screen readers already announce it as an image. It\'s okay to use more specific words that convey the medium, for instance, "illustration," "cartoon," or "painting."</li>'
-          . '<li>Avoid saying "cover art." IFDB may include that automatically in some places.'
-          . '<li>Avoid including the title, the author, or other text that is readily available on the game page. If the image shows a subtitle that is not found elsewhere, you could include that. For example, you could write, "Text reads: Lost Pig and Place Underground, by Grunk as told to Admiral Jota."</li>'
-          . '<li>End with a period.</li>'
-          . '</ul></details>'
-          . '</details>',
+          'A description of what the image looks like, to be read aloud by a screen reader - '
+          . helpWinLink("help-cover-description", "Guidelines for cover art descriptions"),
           null, TypeString],
     ["First&nbsp;Publication&nbsp;Date", "published", 15,
           "Format as dd-Mon-yyyy (example: 12-Jul-2005), or

--- a/www/gameinfo.php
+++ b/www/gameinfo.php
@@ -449,6 +449,7 @@ function getDeltaDesc($deltas)
                        "language" => "language",
                        "desc" => "description",
                        "coverart" => "cover art",
+                       "cover_art_description" => "cover art description",
                        "genre" => "genre",
                        "seriesname" => "series name",
                        "seriesnumber" => "episode number",

--- a/www/gameinfo.php
+++ b/www/gameinfo.php
@@ -26,8 +26,8 @@ function getGameInfo($db, $id, $curuser, $requestVersion, &$errMsg, &$errCode)
     $result = mysqli_execute_query($db,
        "select
             title, author, authorExt, published,
-            version, license, `system`, `desc`, length(coverart) hasart, genre,
-            language, seriesname, seriesnumber, forgiveness, bafsid, website,
+            version, license, `system`, `desc`, length(coverart) hasart, cover_art_description, 
+            genre, language, seriesname, seriesnumber, forgiveness, bafsid, website,
             downloadnotes, editedby,
             concat(date_format(moddate, '%e %M %Y at %l:%i'),
                lower(date_format(moddate, '%p'))) as moddate,
@@ -209,6 +209,7 @@ function getGameInfo($db, $id, $curuser, $requestVersion, &$errMsg, &$errCode)
     $language = $rec["language"];
     $system = $rec["system"];
     $hasart = !is_null($rec["hasart"]);
+    $cover_art_description = $rec["cover_art_description"];
     $genre = $rec["genre"];
     $seriesname = $rec["seriesname"];
     $seriesnum = $rec["seriesnumber"];
@@ -416,7 +417,7 @@ function getGameInfo($db, $id, $curuser, $requestVersion, &$errMsg, &$errCode)
     return array($ifids, $title, $author, $authorExt,
                  $pubYear, $pubFull, $license,
                  $system, $desc, $rawDesc,
-                 $hasart, $genre, $seriesname, $seriesnum,
+                 $hasart, $cover_art_description, $genre, $seriesname, $seriesnum,
                  $forgiveness, $bafsid, $version,
                  $language, $languageNameOnly,
                  $website, $links,

--- a/www/help-cover-description
+++ b/www/help-cover-description
@@ -1,0 +1,19 @@
+<?php
+include_once "session-start.php";
+include_once "util.php";
+include_once "pagetpl.php";
+helpPageHeader("Guidelines for Cover Art Descriptions");
+?>
+
+<h1>Guidelines for Cover Art Descriptions</h1>
+
+<ul>
+    <li>Avoid beginning with "Image of," "Picture of," or the like. Screen readers already announce it as an image. It's okay to use more specific words that convey the medium, for instance, "illustration," "cartoon," or "painting."</li>
+    <li>Avoid beginning with "Cover art." IFDB may include that information automatically in some places.
+    <li>Avoid repeating the title, the author, or other text that is readily available on the game page. If the image shows a subtitle that is not found elsewhere, you could include that. For example, you could write, "Text reads: Lost Pig and Place Underground, by Grunk as told to Admiral Jota."</li>
+    <li>End with a period or other ending punctuation so that the screen reader will pause before moving on to other text.</li>
+</ul>
+
+<?php
+helpPageFooter();
+?>

--- a/www/help-cover-description
+++ b/www/help-cover-description
@@ -2,16 +2,39 @@
 include_once "session-start.php";
 include_once "util.php";
 include_once "pagetpl.php";
-helpPageHeader("Guidelines for Cover Art Descriptions");
+helpPageHeader("Cover Art Descriptions");
 ?>
 
-<h1>Guidelines for Cover Art Descriptions</h1>
+<h1>Cover Art Descriptions</h1>
 
-<ul>
-    <li>Avoid beginning with "Image of," "Picture of," or the like. Screen readers already announce it as an image. It's okay to use more specific words that convey the medium, for instance, "illustration," "cartoon," or "painting."</li>
-    <li>Avoid beginning with "Cover art." IFDB may include that information automatically in some places.
-    <li>Avoid repeating the title, the author, or other text that is readily available on the game page. If the image shows a subtitle that is not found elsewhere, you could include that. For example, you could write, "Text reads: Lost Pig and Place Underground, by Grunk as told to Admiral Jota."</li>
-    <li>End with a period or other ending punctuation so that the screen reader will pause before moving on to other text.</li>
+<p>IFDB includes cover art descriptions as part of alt text in a few places. Alt text allows people 
+who are blind or who have low vision to read about an image using a screen reader. Alt text is also 
+displayed instead of a picture when images are turned off in the browser.</p>
+<p>Apart from alt text, IFDB also displays the descriptions directly on pages that show full-sized 
+cover art.</p>
+
+<h2>Guidelines for Cover Art Descriptions</h2>
+
+<ul class=doublespace>
+
+    <li>Descriptions should be concise, usually no longer than a sentence or two.</li>
+
+    <li>Avoid beginning with "image of," "picture of," or the like. Screen readers already 
+    announce it as an image. It's okay to use more specific words that name the medium, for 
+    instance, "illustration," "cartoon," or "painting."</li>
+
+    <li>Avoid beginning with "cover art." IFDB will automatically include "Cover art for 
+    [Game Title]" as part of the alt text or on the page.</li>
+
+    <li>Avoid repeating the game's title, author, or other text that is readily available on the 
+    game page, unless there's a reason to say it again. For example, if the image shows a subtitle 
+    that is not found elsewhere, you can include that. After describing the picture, you can add 
+    something like "Text reads: Lost Pig and Place Underground, by Grunk as told to Admiral Jota."</li>
+
+    <li>If the cover art just shows text on a background, you could write something like "Game title 
+    on a black background."</li>
+
+    <li>Use ending punctuation so that screen readers will pause before moving on to other text.</li>
 </ul>
 
 <?php

--- a/www/util.php
+++ b/www/util.php
@@ -464,15 +464,19 @@ function sendImageLdesc($page_title, $imageID, $cover_art_description, $game_tit
 
           echo "</span>";
       }
-          
+
       if ($cover_art_description) {
-          echo "<p>Image description:<br>$large_cover_alt_text</p>";
-          echo "<p><a href=\"editgame?&id=$gameID\">Edit the cover art description</a></p>";
+          echo "<br><style nonce='$nonce'>";
+          echo "<div class='image_description_box' style='border: 1px solid gray; padding: 0em 1em 0em 1em; height: auto;
+}'>";
+          echo "<p><b>Image description:</b></p><p>$cover_art_description</p>";
+          echo "<p><em>Cover art descriptions are contributed by IFDB members.</em></p></div>";
+         
       } else {
-          echo "<p>No image description is available. To add a cover art description, you can ";
-          echo "<a href=\"editgame?&id=$gameID\">edit the game page</a>.</p>";
+          echo "<p>No image description is available. To help make IFDB more accessible, ";
+          echo "you can <a href=\"editgame?&id=$gameid\">add a cover art description</a>.</p>";
       }
-      echo "<br>";
+  
    ?>
 </div>
 </body>

--- a/www/util.php
+++ b/www/util.php
@@ -2834,7 +2834,7 @@ function check_admin_privileges($db, $userid) {
 
 }
 
-function coverArtThumbnail($id, $size, $version, $params = "") {
+function coverArtThumbnail($id, $size, $version, $params = "", $alt_text = "") {
     $thumbnail = "/coverart?id=$id&thumbnail=";
     $x15 = round($size * 3 / 2);
     $x2 = $size * 2;
@@ -2844,7 +2844,7 @@ function coverArtThumbnail($id, $size, $version, $params = "") {
     }
     global $nonce;
     return "<style nonce='$nonce'>.coverart__img { max-width: 35vw; height: auto; }</style>"
-        ."<img class='coverart__img' loading='lazy' srcset=\"$thumbnail{$size}x$size$params, $thumbnail{$x15}x$x15$params 1.5x, $thumbnail{$x2}x$x2$params 2x, $thumbnail{$x3}x$x3$params 3x\" src=\"$thumbnail{$size}x$size$params\" height=$size width=$size border=0 alt=\"\">";
+        ."<img class='coverart__img' loading='lazy' srcset=\"$thumbnail{$size}x$size$params, $thumbnail{$x15}x$x15$params 1.5x, $thumbnail{$x2}x$x2$params 2x, $thumbnail{$x3}x$x3$params 3x\" src=\"$thumbnail{$size}x$size$params\" height=$size width=$size border=0 alt=\"$alt_text\">";
 }
 
 // ----------------------------------------------------------------------------

--- a/www/util.php
+++ b/www/util.php
@@ -382,7 +382,7 @@ function echoStylesheetLink()
 // --------------------------------------------------------------------------
 // send an image description page - this includes the image and the
 // copyright information
-function sendImageLdesc($page_title, $imageID, $game_title, $cover_art_description)
+function sendImageLdesc($page_title, $imageID, $cover_art_description, $game_title, $gameID)
 {
     global $copyrightStatList;
     checkPersistentLogin();
@@ -462,14 +462,15 @@ function sendImageLdesc($page_title, $imageID, $game_title, $cover_art_descripti
               echo "<br>";
           }
 
-          echo "</span><br>";
+          echo "</span>";
       }
           
       if ($cover_art_description) {
-          echo "<p><details><summary>Image description</summary>$large_cover_alt_text</details></p>";
+          echo "<p>Image description:<br>$large_cover_alt_text</p>";
+          echo "<p><a href=\"editgame?&id=$gameID\">Edit the cover art description</a></p>";
       } else {
-          echo "<p>This image has no description. ";
-          echo "You can add one by editing the game page.</p>";
+          echo "<p>No image description is available. To add a cover art description, you can ";
+          echo "<a href=\"editgame?&id=$gameID\">edit the game page</a>.</p>";
       }
       echo "<br>";
    ?>

--- a/www/util.php
+++ b/www/util.php
@@ -382,7 +382,7 @@ function echoStylesheetLink()
 // --------------------------------------------------------------------------
 // send an image description page - this includes the image and the
 // copyright information
-function sendImageLdesc($title, $imageID)
+function sendImageLdesc($page_title, $imageID, $game_title, $cover_art_description)
 {
     global $copyrightStatList;
     checkPersistentLogin();
@@ -414,16 +414,24 @@ function sendImageLdesc($title, $imageID)
             list($username) = mysql_fetch_row($result);
     }
 
+    // Generate the alt text for the full-sized cover art
+    $large_cover_alt_text = "";
+    if ($cover_art_description) {
+        $large_cover_alt_text = $cover_art_description;
+    } else {
+        $large_cover_alt_text = "Cover art for $game_title.";
+    }
+
     // send the page
 ?>
 <html>
 <head>
    <?php echoStylesheetLink(); ?>
-   <title><?php echo htmlspecialcharx($title) ?></title>
+   <title><?php echo htmlspecialcharx($page_title) ?></title>
 </head>
 <body>
 <div class=main>
-   <img src="showimage?id=<?php echo urlencode($imageID) ?>" alt="Cover art for <?php echo htmlspecialcharx($title) ?>.">
+   <img src="showimage?id=<?php echo urlencode($imageID) ?>" alt="<?php echo htmlspecialcharx($large_cover_alt_text) ?>.">
    <?php
       if ($copymsg || ($copystat && isset($copyrightStatList[$copystat]))
           || $username || $created) {
@@ -456,6 +464,14 @@ function sendImageLdesc($title, $imageID)
 
           echo "</span><br>";
       }
+          
+      if ($cover_art_description) {
+          echo "<p><details><summary>Image description</summary>$large_cover_alt_text</details></p>";
+      } else {
+          echo "<p>This image has no description. ";
+          echo "You can add one by editing the game page.</p>";
+      }
+      echo "<br>";
    ?>
 </div>
 </body>

--- a/www/util.php
+++ b/www/util.php
@@ -423,7 +423,7 @@ function sendImageLdesc($title, $imageID)
 </head>
 <body>
 <div class=main>
-   <img src="showimage?id=<?php echo urlencode($imageID) ?>">
+   <img src="showimage?id=<?php echo urlencode($imageID) ?>" alt="Cover art for <?php echo htmlspecialcharx($title) ?>.">
    <?php
       if ($copymsg || ($copystat && isset($copyrightStatList[$copystat]))
           || $username || $created) {

--- a/www/viewgame
+++ b/www/viewgame
@@ -929,13 +929,14 @@ echo helpWinLink("help-ifid", "IFID");
                <?php
 if ($hasart) {
     $arthref = "{$_SERVER['PHP_SELF']}?coverart&id=$id";
+    $cover_alt_text = "Cover art for $title. Click for full-sized image and copyright information.";
     if (isset($_REQUEST['version']))
         $arthref .= "&version=" . $_REQUEST['version'];
                ?>
            <div class=coverart>
 
               <a href="<?php echo $arthref ?>&ldesc">
-                 <?php echo coverArtThumbnail($id, 175, isset($_REQUEST['version']) ? $_REQUEST['version'] : $pagevsn); ?>
+                 <?php echo coverArtThumbnail($id, 175, isset($_REQUEST['version']) ? $_REQUEST['version'] : $pagevsn, "", $cover_alt_text); ?>
               </a>
            </div>
                <?php

--- a/www/viewgame
+++ b/www/viewgame
@@ -930,11 +930,13 @@ echo helpWinLink("help-ifid", "IFID");
                <?php
 if ($hasart) {
     $arthref = "{$_SERVER['PHP_SELF']}?coverart&id=$id";
-    $cover_alt_text = "Cover art for $title. Click for full-sized image";
+    // If there's a custom description for this cover art, include it as part of the alt text.
+    $cover_alt_text = "Cover art for $title. ";
     if ($cover_art_description) {
-        $cover_alt_text .= ", description,";
+        $cover_alt_text .= "$cover_art_description ";
     }
-    $cover_alt_text .= " and copyright information.";
+    $cover_alt_text .= "Click for full-sized image and copyright information.";
+    
     if (isset($_REQUEST['version']))
         $arthref .= "&version=" . $_REQUEST['version'];
                ?>

--- a/www/viewgame
+++ b/www/viewgame
@@ -941,8 +941,18 @@ if ($hasart) {
            <div class=coverart>
 
               <a href="<?php echo $arthref ?>&ldesc">
-                 <?php echo coverArtThumbnail($id, 175, isset($_REQUEST['version']) ? $_REQUEST['version'] : $pagevsn, "", $cover_alt_text); ?>
-              </a>
+                <?php echo coverArtThumbnail($id, 175, isset($_REQUEST['version']) ? $_REQUEST['version'] : $pagevsn, "", $cover_alt_text);
+                echo "</a>";
+                // If we're logged in and this game doesn't have a cover art description, 
+                // show a link to add one. 
+                if ($curuser && !$cover_art_description) {
+                    global $nonce;
+                    echo "<style nonce='$nonce'>.link_below_cover_viewgame { max-width: 35vw; height: auto; font-size: .7em; text-align: center;}</style>";
+                    echo "<div class='link_below_cover_viewgame'>";
+                    echo "<a href=\"editgame?&id=$id\" "
+                    . "title=\"To help make IFDB more accessible, click to edit the page and add a cover art description.\">Add an image description</a></div>";
+                } ?>
+
            </div>
                <?php
 } // if ($hasart)

--- a/www/viewgame
+++ b/www/viewgame
@@ -207,7 +207,7 @@ function sendCoverArt()
     if (isset($_REQUEST['ldesc']))
         sendImageLdesc("Cover Art for $title"
                        . ($targVsn ? " (version $targVsn)" : ""),
-                       $imgname);
+                       $imgname, $title, $cover_art_description);
 
     // retrieve the image data
     list($imgdata, $fmt) = fetch_image($imgname, true);
@@ -375,7 +375,8 @@ if (!$errMsg) {
     list($ifids, $title, $author, $authorExt,
          $pubYear, $pubFull, $license,
          $system, $desc, $rawDesc,
-         $hasart, $genre, $seriesname, $seriesnum,
+         $hasart, $cover_art_description,
+         $genre, $seriesname, $seriesnum,
          $forgiveness, $bafsid, $version,
          $language, $languageNameOnly,
          $website, $links,
@@ -929,7 +930,11 @@ echo helpWinLink("help-ifid", "IFID");
                <?php
 if ($hasart) {
     $arthref = "{$_SERVER['PHP_SELF']}?coverart&id=$id";
-    $cover_alt_text = "Cover art for $title. Click for full-sized image and copyright information.";
+    $cover_alt_text = "Cover art for $title. Click for full-sized image";
+    if ($cover_art_description) {
+        $cover_alt_text .= ", description,";
+    }
+    $cover_alt_text .= " and copyright information.";
     if (isset($_REQUEST['version']))
         $arthref .= "&version=" . $_REQUEST['version'];
                ?>

--- a/www/viewgame
+++ b/www/viewgame
@@ -207,7 +207,7 @@ function sendCoverArt()
     if (isset($_REQUEST['ldesc']))
         sendImageLdesc("Cover Art for $title"
                        . ($targVsn ? " (version $targVsn)" : ""),
-                       $imgname, $title, $cover_art_description);
+                       $imgname, $cover_art_description, $title, $id);
 
     // retrieve the image data
     list($imgdata, $fmt) = fetch_image($imgname, true);


### PR DESCRIPTION
After discussion elsewhere, this PR does the following:

1. Add a new column to the games table to store custom cover art descriptions.

2. Add a new field to the edit game form to add a cover art description.

3. Add a new help window, linked from the edit game form, with guidelines for cover art descriptions.

4. Add $alt_text parameter to coverArtThumbnail function so that alt text can be included in cover art thumbnails.

5. On the viewgame page, add alt text to the small cover, saying: "Cover art for [Game Title]. [Custom description, if there is one.] Click for full-sized image and copyright information." 

6. On the full-sized cover art (visible when you click the small cover art on the viewgame page), add alt text saying the custom description if there is one. If there isn't a custom description, say "Cover art for [Game Title]" instead. _Note: I have not been able to directly test any changes on this page, because the dev environment seems to redirect me to the live IFDB site instead._

7. Also on the full-sized cover art page, display the custom description as part of the main text (visible to everyone, not only screen reader users) in a box under the copyright information, and say that these descriptions are contributed by IFDB members (to try to make it clearer that descriptions are not necessarily written by whoever made the art or uploaded it). If there is no custom description, show a link to add one.

8. On the viewgame page, if there is no custom description and if the user is logged in, print a small link under the small cover art saying "add an image description." The link goes to the edit game form.


Fixes https://github.com/iftechfoundation/ifdb/issues/1378. Related to https://github.com/iftechfoundation/ifdb/issues/738.